### PR TITLE
Crash count widgets + description lookups for units and injury severity

### DIFF
--- a/atd-vze/src/App.js
+++ b/atd-vze/src/App.js
@@ -86,7 +86,7 @@ class App extends Component {
           uri: "https://vzd.austintexas.io/v1/graphql",
           headers: {
             Authorization: `Bearer ${this.state.token}`,
-            "x-hasura-allowed-roles": this.state.role,
+            "x-hasura-role": this.state.role,
           },
         });
         console.log("Client Initialized");

--- a/atd-vze/src/queries/crashes.js
+++ b/atd-vze/src/queries/crashes.js
@@ -1,0 +1,126 @@
+import { gql } from "apollo-boost";
+
+export const GET_CRASH = gql`
+  query FindCrash($crashId: Int) {
+    atd_txdot_crashes(where: { crash_id: { _eq: $crashId } }) {
+      active_school_zone_fl
+      approval_date
+      approved_by
+      at_intrsct_fl
+      case_id
+      crash_date
+      crash_fatal_fl
+      crash_id
+      crash_sev_id
+      crash_speed_limit
+      crash_time
+      day_of_week
+      death_cnt
+      fhe_collsn_id
+      geocode_date
+      geocode_provider
+      geocode_status
+      geocoded
+      hwy_nbr
+      hwy_sfx
+      hwy_sys
+      intrsct_relat_id
+      investigator_narrative
+      is_retired
+      last_update
+      latitude
+      latitude_confirmed
+      latitude_geocoded
+      light_cond_id
+      longitude
+      longitude_confirmed
+      longitude_geocoded
+      non_injry_cnt
+      nonincap_injry_cnt
+      obj_struck_id
+      onsys_fl
+      position
+      poss_injry_cnt
+      private_dr_fl
+      qa_status
+      road_constr_zone_fl
+      road_type_id
+      rpt_block_num
+      rpt_city_id
+      rpt_hwy_num
+      rpt_hwy_sfx
+      rpt_latitude
+      rpt_longitude
+      rpt_outside_city_limit_fl
+      rpt_rdwy_sys_id
+      rpt_road_part_id
+      rpt_sec_block_num
+      rpt_sec_hwy_num
+      rpt_sec_hwy_sfx
+      rpt_sec_rdwy_sys_id
+      rpt_sec_road_part_id
+      rpt_sec_street_desc
+      rpt_sec_street_name
+      rpt_sec_street_pfx
+      rpt_sec_street_sfx
+      rpt_street_name
+      rpt_street_pfx
+      rpt_street_sfx
+      rr_relat_fl
+      schl_bus_fl
+      street_name
+      street_name_2
+      street_nbr
+      street_nbr_2
+      sus_serious_injry_cnt
+      toll_road_fl
+      tot_injry_cnt
+      traffic_cntl_id
+      unkn_injry_cnt
+      wthr_cond_id
+    }
+    atd_txdot_primaryperson(where: { crash_id: { _eq: $crashId } }) {
+      prsn_age
+      prsn_injry_sev_id
+      drvr_zip
+      drvr_city_name
+      injury_severity {
+        injry_sev_desc
+      }
+      unit_nbr
+    }
+    atd_txdot_person(where: { crash_id: { _eq: $crashId } }) {
+      prsn_age
+      prsn_injry_sev_id
+      injury_severity {
+        injry_sev_desc
+      }
+      unit_nbr
+    }
+    atd_txdot_units(where: { crash_id: { _eq: $crashId } }) {
+      unit_desc_id
+      unit_nbr
+      contrib_factr_1_id
+      veh_make_id
+      veh_mod_id
+      veh_mod_year
+      unit_description {
+        veh_unit_desc_desc
+      }
+      make {
+        veh_make_desc
+      }
+      model {
+        veh_mod_desc
+      }
+      body_style {
+        veh_body_styl_desc
+      }
+    }
+    atd_txdot_charges(where: { crash_id: { _eq: $crashId } }) {
+      citation_nbr
+      charge_cat_id
+      charge
+    }
+  }
+`;

--- a/atd-vze/src/views/Crashes/Crash.js
+++ b/atd-vze/src/views/Crashes/Crash.js
@@ -14,15 +14,15 @@ const calculateYearsLifeLost = people => {
   // Find the differance between person.prsn_age & 75
   // Sum over the list of ppl with .reduce
   return people.reduce((accumulator, person) => {
-    let yearsLifeLost = 0;
+    let years = 0;
     if (person.injury_severity.injry_sev_desc === "KILLED") {
       let yearsLifeLost = 75 - Number(person.prsn_age);
       // What if the person is older than 75?
       // For now, so we don't have negative numbers,
       // Assume years of life lost is 0
-      yearsLifeLost = yearsLifeLost < 0 ? 0 : yearsLifeLost;
+      years = yearsLifeLost < 0 ? 0 : yearsLifeLost;
     }
-    return accumulator + yearsLifeLost;
+    return accumulator + years;
   }, 0); // start with a count at 0 years
 };
 

--- a/atd-vze/src/views/Crashes/Crash.js
+++ b/atd-vze/src/views/Crashes/Crash.js
@@ -2,113 +2,11 @@ import React from "react";
 import { Card, CardBody, CardHeader, Col, Row, Table } from "reactstrap";
 import { withApollo } from "react-apollo";
 import { useQuery } from "@apollo/react-hooks";
-import { gql } from "apollo-boost";
 import crashDataMap from "./crashDataMap";
 import CrashCollapses from "./CrashCollapses";
 import CrashMap from "./CrashMap";
 
-const GET_CRASH = gql`
-  query FindCrash($crashId: Int) {
-    atd_txdot_crashes(where: { crash_id: { _eq: $crashId } }) {
-      active_school_zone_fl
-      approval_date
-      approved_by
-      at_intrsct_fl
-      case_id
-      crash_date
-      crash_fatal_fl
-      crash_id
-      crash_sev_id
-      crash_speed_limit
-      crash_time
-      day_of_week
-      death_cnt
-      fhe_collsn_id
-      geocode_date
-      geocode_provider
-      geocode_status
-      geocoded
-      hwy_nbr
-      hwy_sfx
-      hwy_sys
-      intrsct_relat_id
-      investigator_narrative
-      is_retired
-      last_update
-      latitude
-      latitude_confirmed
-      latitude_geocoded
-      light_cond_id
-      longitude
-      longitude_confirmed
-      longitude_geocoded
-      non_injry_cnt
-      nonincap_injry_cnt
-      obj_struck_id
-      onsys_fl
-      position
-      poss_injry_cnt
-      private_dr_fl
-      qa_status
-      road_constr_zone_fl
-      road_type_id
-      rpt_block_num
-      rpt_city_id
-      rpt_hwy_num
-      rpt_hwy_sfx
-      rpt_latitude
-      rpt_longitude
-      rpt_outside_city_limit_fl
-      rpt_rdwy_sys_id
-      rpt_road_part_id
-      rpt_sec_block_num
-      rpt_sec_hwy_num
-      rpt_sec_hwy_sfx
-      rpt_sec_rdwy_sys_id
-      rpt_sec_road_part_id
-      rpt_sec_street_desc
-      rpt_sec_street_name
-      rpt_sec_street_pfx
-      rpt_sec_street_sfx
-      rpt_street_name
-      rpt_street_pfx
-      rpt_street_sfx
-      rr_relat_fl
-      schl_bus_fl
-      street_name
-      street_name_2
-      street_nbr
-      street_nbr_2
-      sus_serious_injry_cnt
-      toll_road_fl
-      tot_injry_cnt
-      traffic_cntl_id
-      unkn_injry_cnt
-      wthr_cond_id
-    }
-    atd_txdot_primaryperson(where: { crash_id: { _eq: $crashId } }) {
-      prsn_age
-      prsn_injry_sev_id
-      drvr_zip
-      drvr_city_name
-    }
-    atd_txdot_person(where: { crash_id: { _eq: $crashId } }) {
-      prsn_age
-      prsn_injry_sev_id
-    }
-    atd_txdot_units(where: { crash_id: { _eq: $crashId } }) {
-      unit_desc_id
-      unit_nbr
-      contrib_factr_1_id
-      veh_make_id
-      veh_mod_id
-      veh_mod_year
-    }
-    atd_txdot_charges(where: { crash_id: { _eq: $crashId } }) {
-      citation_nbr
-      charge_cat_id
-      charge
-      id
+import { GET_CRASH } from "../../queries/crashes";
     }
   }
 `;

--- a/atd-vze/src/views/Crashes/CrashCollapses.js
+++ b/atd-vze/src/views/Crashes/CrashCollapses.js
@@ -138,7 +138,14 @@ class CrashCollapses extends Component {
                         aria-controls="collapseOne"
                       >
                         <h5 className="m-0 p-0">
-                          <i className="fa fa-group" /> People
+                          <i className="fa fa-group" /> People{" "}
+                          <Badge color="secondary float-right">
+                            {
+                              this.props.data.atd_txdot_primaryperson.concat(
+                                this.props.data.atd_txdot_person
+                              ).length
+                            }
+                          </Badge>
                         </h5>
                       </Button>
                     </CardHeader>
@@ -236,6 +243,9 @@ class CrashCollapses extends Component {
                       >
                         <h5 className="m-0 p-0">
                           <i className="fa fa-car" /> Units
+                          <Badge color="secondary float-right">
+                            {this.props.data.atd_txdot_units.length}
+                          </Badge>
                         </h5>
                       </Button>
                     </CardHeader>
@@ -289,6 +299,13 @@ class CrashCollapses extends Component {
                       >
                         <h5 className="m-0 p-0">
                           <i className="fa fa-legal" /> Charges
+                          <Badge color="secondary float-right">
+                            {
+                              this.props.data.atd_txdot_charges.filter(
+                                charge => charge.charge_cat_id !== 0
+                              ).length
+                            }
+                          </Badge>
                         </h5>
                       </Button>
                     </CardHeader>

--- a/atd-vze/src/views/Crashes/CrashCollapses.js
+++ b/atd-vze/src/views/Crashes/CrashCollapses.js
@@ -74,6 +74,48 @@ class CrashCollapses extends Component {
     this.setState({ fadeIn: !this.state.fadeIn });
   }
 
+  getInjurySeverityColor(desc) {
+    switch (desc) {
+      case "UNKNOWN":
+        return "muted";
+      case "NOT INJURED":
+        return "primary";
+      case "INCAPACITATING INJURY":
+        return "warning";
+      case "NON-INCAPACITATING INJURY":
+        return "warning";
+      case "POSSIBLE INJURY":
+        return "warning";
+      case "KILLED":
+        return "danger";
+      default:
+        break;
+    }
+  }
+
+  getUnitType(type) {
+    switch (type) {
+      case "MOTOR VEHICLE":
+        return <i className="fa fa-car" />;
+      case "TRAIN":
+        return <i className="fa fa-train" />;
+      case "PEDALCYCLIST":
+        return <i className="fa fa-bicycle" />;
+      case "PEDESTRIAN":
+        return <i className="fa fa-child" />;
+      case "MOTORIZED CONVEYANCE":
+        return "MOTORIZED CONVEYANCE";
+      case "TOWED/PUSHED/TRAILER":
+        return "TOWED/PUSHED/TRAILER";
+      case "NON-CONTACT":
+        return "NON-CONTACT";
+      case "OTHER (EXPLAIN IN NARRATIVE)":
+        return "Other";
+      default:
+        break;
+    }
+  }
+
   render() {
     return (
       <div className="animated fadeIn">
@@ -112,6 +154,7 @@ class CrashCollapses extends Component {
                         <Table responsive>
                           <thead>
                             <tr>
+                              <th>Unit</th>
                               <th>City</th>
                               <th>ZIP</th>
                               <th>Age</th>
@@ -122,12 +165,17 @@ class CrashCollapses extends Component {
                             {this.props.data.atd_txdot_primaryperson.map(
                               (person, i) => (
                                 <tr key={`person-${i}`}>
+                                  <td>{person.unit_nbr}</td>
                                   <td>{person.drvr_city_name}</td>
                                   <td>{person.drvr_zip}</td>
                                   <td>{person.prsn_age}</td>
                                   <td>
-                                    <Badge color="success">
-                                      {person.prsn_injry_sev_id}
+                                    <Badge
+                                      color={this.getInjurySeverityColor(
+                                        person.injury_severity.injry_sev_desc
+                                      )}
+                                    >
+                                      {person.injury_severity.injry_sev_desc}
                                     </Badge>
                                   </td>
                                 </tr>
@@ -137,36 +185,42 @@ class CrashCollapses extends Component {
                         </Table>
 
                         {this.props.data.atd_txdot_person.length > 0 && (
-                          <h5>Other People</h5>
+                          <>
+                            <h5>Other People</h5>
+                            <Table responsive>
+                              <thead>
+                                <tr>
+                                  <th>Unit</th>
+                                  <th>Age</th>
+                                  <th>Injury Severity</th>
+                                </tr>
+                              </thead>
+                              <tbody>
+                                {this.props.data.atd_txdot_person.map(
+                                  person => (
+                                    <tr>
+                                      <td>{person.unit_nbr}</td>
+                                      <td>{person.prsn_age}</td>
+                                      <td>
+                                        <Badge
+                                          color={this.getInjurySeverityColor(
+                                            person.injury_severity
+                                              .injry_sev_desc
+                                          )}
+                                        >
+                                          {
+                                            person.injury_severity
+                                              .injry_sev_desc
+                                          }
+                                        </Badge>
+                                      </td>
+                                    </tr>
+                                  )
+                                )}
+                              </tbody>
+                            </Table>
+                          </>
                         )}
-                        {this.props.data.atd_txdot_person.map(person => (
-                          <Table responsive>
-                            <thead>
-                              <tr>
-                                <th>City</th>
-                                <th>ZIP</th>
-                                <th>Age</th>
-                                <th>Injury Severity</th>
-                              </tr>
-                            </thead>
-                            <tbody>
-                              {this.props.data.atd_txdot_primaryperson.map(
-                                person => (
-                                  <tr>
-                                    <td>{person.drvr_city_name}</td>
-                                    <td>{person.drvr_zip}</td>
-                                    <td>{person.prsn_age}</td>
-                                    <td>
-                                      <Badge color="success">
-                                        {person.prsn_injry_sev_id}
-                                      </Badge>
-                                    </td>
-                                  </tr>
-                                )
-                              )}
-                            </tbody>
-                          </Table>
-                        ))}
                       </CardBody>
                     </Collapse>
                   </Card>
@@ -194,7 +248,9 @@ class CrashCollapses extends Component {
                         <Table responsive>
                           <thead>
                             <tr>
-                              <th>Unit Type</th>
+                              <th>Unit</th>
+                              <th>Type</th>
+                              <th>Body Style</th>
                               <th>Factor 1</th>
                               <th>Make/Model</th>
                             </tr>
@@ -202,11 +258,17 @@ class CrashCollapses extends Component {
                           <tbody>
                             {this.props.data.atd_txdot_units.map((unit, i) => (
                               <tr key={`person-${i}`}>
-                                <td>{unit.unit_desc_id}</td>
+                                <td>{unit.unit_nbr}</td>
+                                <td>
+                                  {this.getUnitType(
+                                    unit.unit_description.veh_unit_desc_desc
+                                  )}
+                                </td>
+                                <td>{unit.body_style.veh_body_styl_desc}</td>
                                 <td>{unit.contrib_factr_1_id}</td>
                                 <td>
-                                  {unit.veh_mod_year} {unit.veh_make_id}{" "}
-                                  {unit.veh_mod_id}
+                                  {unit.veh_mod_year} {unit.make.veh_make_desc}{" "}
+                                  {unit.model.veh_mod_desc}
                                 </td>
                               </tr>
                             ))}


### PR DESCRIPTION
_Closes #113_
_Closes #114_

### Adds fatality/injury widgets to the top row

<img width="1552" alt="Screen Shot 2019-08-17 at 2 49 14 PM" src="https://user-images.githubusercontent.com/5697474/63216667-48f8c580-c0fe-11e9-8b5e-1fc6d78c6c32.png">

### Add counts to related records tables

<img width="582" alt="Screen Shot 2019-08-17 at 3 18 12 PM" src="https://user-images.githubusercontent.com/5697474/63216898-56b04a00-c102-11e9-82c9-e87a1451c8eb.png">

### Adds injury severity description (instead of lookup IDs) to People table

<img width="545" alt="Screen Shot 2019-08-17 at 3 18 17 PM" src="https://user-images.githubusercontent.com/5697474/63216897-5617b380-c102-11e9-950e-6519f6a2e515.png">

### Adds unit type, body style, make and model descriptions (instead of lookup IDs) to Units table

<img width="540" alt="Screen Shot 2019-08-17 at 3 18 23 PM" src="https://user-images.githubusercontent.com/5697474/63216899-56b04a00-c102-11e9-9574-5543528360fa.png">



