### PR TITLE
Crash Page Fix

### DIFF
--- a/atd-vze/src/views/Crashes/Crash.js
+++ b/atd-vze/src/views/Crashes/Crash.js
@@ -107,7 +107,12 @@ function Crash(props) {
                             <td>{`${section.fields[field]}:`}</td>
                             <td>
                               <strong>
-                                {data.atd_txdot_crashes[0][field]}
+                                {typeof data.atd_txdot_crashes[0][field] ===
+                                "object"
+                                  ? JSON.stringify(
+                                      data.atd_txdot_crashes[0][field]
+                                    )
+                                  : data.atd_txdot_crashes[0][field]}
                               </strong>
                             </td>
                           </tr>


### PR DESCRIPTION
It appears the Crash page is not able to handle objects, in this particular case it is polygon data that tries to be converted into a string. This is a temporary fix that checks whether the current field is an object, if so it tries to print via JSON.stringify