### PR TITLE
Refactor unique_id

### DIFF
--- a/atd-vze/src/queries/Locations.js
+++ b/atd-vze/src/queries/Locations.js
@@ -2,8 +2,8 @@ import { gql } from "apollo-boost";
 
 export const GET_LOCATION = gql`
   query GetLocation($id: String) {
-    atd_txdot_locations(where: { unique_id: { _eq: $id } }) {
-      unique_id
+    atd_txdot_locations(where: { location_id: { _eq: $id } }) {
+      location_id
       address
       description
       geometry
@@ -55,7 +55,7 @@ export const GET_LOCATION = gql`
         count
       }
     }
-    atd_txdot_locations(where: { unique_id: { _eq: $id } }) {
+    atd_txdot_locations(where: { location_id: { _eq: $id } }) {
       crashes_by_veh_body_style {
         veh_body_styl_desc
         count

--- a/atd-vze/src/queries/Locations.js
+++ b/atd-vze/src/queries/Locations.js
@@ -6,7 +6,6 @@ export const GET_LOCATION = gql`
       location_id
       address
       description
-      geometry
       metadata
       last_update
       is_retired

--- a/atd-vze/src/queries/crashes.js
+++ b/atd-vze/src/queries/crashes.js
@@ -133,7 +133,7 @@ export const GET_CRASH = gql`
       where: { record_type: { _eq: "crashes" }, record_id: { _eq: $crashId } }
       order_by: { record_type: asc }
     ) {
-      id
+      change_log_id
       record_id
       record_crash_id
       record_json

--- a/atd-vze/src/views/Locations/Locations.js
+++ b/atd-vze/src/views/Locations/Locations.js
@@ -10,7 +10,7 @@ let queryConf = {
   table: "atd_txdot_locations",
   single_item: "locations",
   columns: {
-    unique_id: {
+    location_id: {
       primary_key: true,
       searchable: true,
       sortable: true,
@@ -27,7 +27,7 @@ let queryConf = {
     },
   },
   order_by: {
-    unique_id: "desc", // Unique ID desc by default
+    location_id: "desc", // Unique ID desc by default
   },
   where: {},
   limit: 25,

--- a/atd-vze/src/views/Locations/locationDataMap.js
+++ b/atd-vze/src/views/Locations/locationDataMap.js
@@ -2,7 +2,7 @@ const locationDataMap = [
   {
     title: "Details",
     fields: {
-      unique_id: "Location ID",
+      location_id: "Location ID",
       address: "Address",
       description: "Crash ID",
       geometry: "Geometry",

--- a/atd-vze/src/views/Locations/locationDataMap.js
+++ b/atd-vze/src/views/Locations/locationDataMap.js
@@ -5,7 +5,6 @@ const locationDataMap = [
       location_id: "Location ID",
       address: "Address",
       description: "Crash ID",
-      geometry: "Geometry",
       metadata: "Metadata",
       last_update: "Last Update",
     },


### PR DESCRIPTION
This PR refactors the code in compliance with issue #217, and the purpose of this PR is to find all instances of unique_id in the code base that need refactoring (luckily there are only four files that needed editing)

NOTE:
- The changes were actually made to the database for the primary key, it was renamed from unique_id to location_id; however, a the column was cloned and named unique_id so that the old code would not crash.

Once this PR is merged to master, we should be able to remove the helper column unique_id for good.