### PR TITLE
collision type

### DIFF
--- a/atd-vze/src/queries/Locations.js
+++ b/atd-vze/src/queries/Locations.js
@@ -12,6 +12,10 @@ export const GET_LOCATION = gql`
       metadata
       last_update
       is_retired
+      crashes_by_manner_collision(order_by: {count: desc}, limit: 5) {
+        collsn_desc
+        count
+      }
     }
     atd_txdot_crashes_aggregate(
       where: { city_id: { _eq: 22 }, location: { location_id: { _eq: $id } } }

--- a/atd-vze/src/views/Locations/Location.js
+++ b/atd-vze/src/views/Locations/Location.js
@@ -116,12 +116,6 @@ function Location(props) {
     ],
   };
 
-  const test = data.atd_txdot_locations[0].crashes_by_manner_collision.map(
-    a => a.collsn_desc
-  );
-  const testB = test.map(a => formatLabel(a));
-  console.log(test, testB);
-
   const horizontalBar = {
     labels: data.atd_txdot_locations[0].crashes_by_manner_collision
       .map((a, index) => `${index + 1}. ${a.collsn_desc}`)

--- a/atd-vze/src/views/Locations/Location.js
+++ b/atd-vze/src/views/Locations/Location.js
@@ -67,7 +67,7 @@ function Location(props) {
           sections.push(temp);
           temp = "";
         } else {
-          if (index == words.length - 1) {
+          if (index === words.length - 1) {
             sections.push(concat);
             return;
           } else {
@@ -77,7 +77,7 @@ function Location(props) {
         }
       }
 
-      if (index == words.length - 1) {
+      if (index === words.length - 1) {
         sections.push(item);
         return;
       }


### PR DESCRIPTION
Fixes #248 

Had an issue with the labels being way too long and disappearing off the side of the widget, so I used a workaround to split the labels at about half their length onto more than one line by converting them to arrays. Not very elegant, and looks weird at certain sizes, but at least you can read them. There may be a better workaround. I added numbers to each label to make them easier to read and will also will likely reformat them to be in sentence case.

<img width="512" alt="Screen Shot 2019-10-07 at 8 46 59 PM" src="https://user-images.githubusercontent.com/35410637/66361277-dc52b800-e943-11e9-8917-194ac57c7f8b.png">

https://giphy.com/gifs/jTwLaLNAXok0yzYrL8