### PR TITLE
Crash QA Table Clear button not working

### DIFF
--- a/atd-vze/src/Components/GridTable.js
+++ b/atd-vze/src/Components/GridTable.js
@@ -26,7 +26,6 @@ import GridTableSearch from "./GridTableSearch";
 import GridFilters from "./GridFilters";
 import GridDateRange from "./GridDateRange";
 
-
 const GridTable = ({ title, query, filters }) => {
   /**
    * State management:
@@ -52,7 +51,7 @@ const GridTable = ({ title, query, filters }) => {
     startDate: query.config.initStartDate || null,
     endDate: query.config.initEndDate || null,
   });
-
+  console.log("Query Config", query.config);
   /**
    * Shows or hides advanced filters
    */
@@ -122,6 +121,7 @@ const GridTable = ({ title, query, filters }) => {
    * Clears all filters
    */
   const clearFilters = () => {
+    query.deleteWhere(searchParameters.column);
     setSearchParameters({});
     setFilterOptions({});
   };

--- a/atd-vze/src/Components/GridTable.js
+++ b/atd-vze/src/Components/GridTable.js
@@ -51,7 +51,7 @@ const GridTable = ({ title, query, filters }) => {
     startDate: query.config.initStartDate || null,
     endDate: query.config.initEndDate || null,
   });
-  console.log("Query Config", query.config);
+
   /**
    * Shows or hides advanced filters
    */


### PR DESCRIPTION
Closes #242 

This PR clears the search filter stored in the `query` instance used by the GraphQL query abstract. The clear button was not working because the search filter was set in the query instance config and in the state of `<GridTable />` but then only removed from state. I added `query.deleteWhere(column)` to delete the search filter from the instance before deleting it from state when clear is clicked. The table query then populates the table with the pre-filtered results.