### PR TITLE
Location ID in Crash Details

### DIFF
--- a/atd-vze/src/queries/crashes.js
+++ b/atd-vze/src/queries/crashes.js
@@ -139,6 +139,9 @@ export const GET_CRASH = gql`
       record_crash_id
       record_json
       update_timestamp
+    },
+    atd_txdot_crash_locations(where: {crash_id: {_eq: $crashId}}) {
+      location_id
     }
   }
 `;

--- a/atd-vze/src/views/Crashes/Crash.js
+++ b/atd-vze/src/views/Crashes/Crash.js
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { Link } from "react-router-dom";
 import {
   Card,
   CardBody,
@@ -251,7 +252,23 @@ function Crash(props) {
         <Col lg={6}>
           <div className="mb-4">
             <Card>
-              <CardHeader>Crash Location</CardHeader>
+              <CardHeader>
+                Crash Location{" "}
+                {(data && data.atd_txdot_crash_locations.length > 0 && (
+                  <>
+                    (ID:&nbsp;
+                    <Link
+                      to={`/locations/${
+                        data.atd_txdot_crash_locations[0]["location_id"]
+                      }`}
+                    >
+                      {data.atd_txdot_crash_locations[0]["location_id"]}
+                    </Link>
+                    )
+                  </>
+                )) ||
+                  "(Unassigned)"}
+              </CardHeader>
               <CardBody>
                 {latitude && longitude ? (
                   <>


### PR DESCRIPTION
Closes #237 

You should be able to see the location id of a crash (where available):
https://localhost:3000/#/crashes/17038893
![Screen Shot 2019-10-09 at 1 47 41 PM](https://user-images.githubusercontent.com/5282430/66510836-72e5bd00-ea9b-11e9-9168-57a87a5596c5.png)

and when not available:
![Screen Shot 2019-10-09 at 1 48 30 PM](https://user-images.githubusercontent.com/5282430/66510867-8002ac00-ea9b-11e9-803a-be7a673d72bd.png)
