### PR TITLE
Fix Null Values in Sort

### DIFF
--- a/atd-vze/src/Components/GridTable.js
+++ b/atd-vze/src/Components/GridTable.js
@@ -154,9 +154,13 @@ const GridTable = ({ title, query, filters }) => {
    * @returns {*}
    */
   const responseValue = (obj, keys) => {
-    for (let k = 1; k < keys.length; k++)
-      obj = obj ? obj[keys[k]] || null : null;
-
+    for (let k = 1; k < keys.length; k++) {
+      try {
+        obj = obj[keys[k]];
+      } catch {
+        obj = null;
+      }
+    }
     return obj;
   };
 

--- a/atd-vze/src/queries/gqlAbstract.js
+++ b/atd-vze/src/queries/gqlAbstract.js
@@ -253,7 +253,7 @@ gqlAbstractTableAggregateName (
    * @returns {string}
    */
   getDefault(columnName) {
-    return `${this.config["columns"][columnName]["default"] || "-"}`;
+    return this.config["columns"][columnName]["default"];
   }
 
   /**
@@ -265,7 +265,7 @@ gqlAbstractTableAggregateName (
     const type = this.getType(columnName);
     const defaultValue = this.getDefault(columnName);
 
-    if (!value) return defaultValue;
+    if (value === null) return "-";
 
     switch (type) {
       case "string": {

--- a/atd-vze/src/views/Locations/Locations.js
+++ b/atd-vze/src/views/Locations/Locations.js
@@ -30,7 +30,7 @@ let queryConf = {
       sortable: true,
       label_search: null,
       label_table: "Total Crashes",
-      default: "-",
+      default: 0,
       type: "Integer",
     },
     "crashes_count_cost_summary { total_deaths }": {
@@ -38,7 +38,7 @@ let queryConf = {
       sortable: true,
       label_search: null,
       label_table: "Total Deaths",
-      default: "-",
+      default: 0,
       type: "Integer",
     },
     "crashes_count_cost_summary { total_serious_injuries }": {
@@ -46,7 +46,7 @@ let queryConf = {
       sortable: true,
       label_search: null,
       label_table: "Total Serious Injry.",
-      default: "-",
+      default: 0,
       type: "Integer",
     },
     "crashes_count_cost_summary { est_comp_cost }": {
@@ -54,7 +54,7 @@ let queryConf = {
       sortable: true,
       label_search: null,
       label_table: "Comp. Cost",
-      default: "-",
+      default: 0,
       type: "Currency",
     },
   },


### PR DESCRIPTION
Closes #276 

I noticed grid table would show null values and 0's  both as null or empty. This can be confusing when sorting, since null values will go first, and zeroes go last, but both seem the same. So we needed to implement a way to differentiate nulls from zeroes.