### PR TITLE
Removed CircleCI Docker Cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,6 @@ jobs:
       # We need docker enabled
       - setup_remote_docker:
           version: 18.09.3
-          docker_layer_caching: true
 
       # We are simply going to source our docker helper script and run our build process.
       - run:


### PR DESCRIPTION
Closes #331 

This is a non-consequential PR, mostly for the convenience of removing circleci error messages. 

CircleCI builds our ETL container that runs Capybara, at the moment the container is non-operational, so it is no problem if it isn't currently building successfully.