### PR TITLE
Fix previous year query to req entire year's data

### DIFF
--- a/atd-vzv/src/views/dashboard/seriousInjuryAndFatalCrashesByMonth.js
+++ b/atd-vzv/src/views/dashboard/seriousInjuryAndFatalCrashesByMonth.js
@@ -7,14 +7,13 @@ import { Container } from "reactstrap";
 
 const SeriousInjuryAndFatalCrashesByMonth = () => {
   const today = moment().format("YYYY-MM-DD");
-  const todayMonthYear = moment().format("-MM-DD");
   const thisYear = moment().format("YYYY");
   const lastYear = moment()
     .subtract(1, "year")
     .format("YYYY");
 
   const yearToDateUrl = `https://data.austintexas.gov/resource/y2wy-tgr5.json?$where=(sus_serious_injry_cnt > 0 OR death_cnt > 0) AND crash_date between '${thisYear}-01-01T00:00:00' and '${today}T23:59:59'`;
-  const previousYearUrl = `https://data.austintexas.gov/resource/y2wy-tgr5.json?$where=(sus_serious_injry_cnt > 0 OR death_cnt > 0) AND crash_date between '${lastYear}-01-01T00:00:00' and '${lastYear}${todayMonthYear}T23:59:59'`;
+  const previousYearUrl = `https://data.austintexas.gov/resource/y2wy-tgr5.json?$where=(sus_serious_injry_cnt > 0 OR death_cnt > 0) AND crash_date between '${lastYear}-01-01T00:00:00' and '${lastYear}-12-31T23:59:59'`;
 
   const [yearToDateInjuryDeathArray, setYearToDateInjuryDeathArray] = useState(
     []


### PR DESCRIPTION
Closes #356 

This PR fixes an issue with the API request for the previous year's crash data. The query was requesting year-to-date of last year (as needed for other visualizations), but this graph displays the full data set from the previous year and available data for the current year. The graph now shows accurate totals for all months of the previous year.

![Screen Shot 2019-10-28 at 3 43 43 PM](https://user-images.githubusercontent.com/37249039/67716608-299dd480-f99a-11e9-909a-90fcb2ab9788.png)
