### PR TITLE
Simplify Dockerfile

### DIFF
--- a/atd-cris-capybara/Dockerfile
+++ b/atd-cris-capybara/Dockerfile
@@ -1,18 +1,29 @@
-FROM ruby:stretch
+FROM ruby:2.6.5-buster
+LABEL MAINTAINER="Sergio Garcia <sergio.garcia@austintexas.gov>"
+LABEL MAINTAINER="Rémy Greinhofer <remy.greinhofer@gmail.com>"
 
-RUN mkdir /app && mkdir /app/tmp
+WORKDIR /usr/src/app
 
-WORKDIR /app
+RUN apt-get update -y \
+  && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+  awscli \
+  g++ \
+  gstreamer1.0-plugins-base \
+  gstreamer1.0-tools \
+  gstreamer1.0-x \
+  libqt5webkit5-dev \
+  p7zip-full \
+  python3 \
+  python3-pip \
+  python3-psycopg2 \
+  python3-requests \
+  qt5-default \
+  ruby-capybara \
+  ruby-selenium-webdriver \
+  xvfb \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
+  && gem install capybara-webkit mail --no-document \
+  && pip3 install --no-cache-dir knackpy
 
-RUN echo "deb http://ftp.de.debian.org/debian testing main" >> /etc/apt/sources.list && \
-    echo 'APT::Default-Release "stretch";' | tee -a /etc/apt/apt.conf.d/00local
-
-RUN apt-get update -y && apt-get -t stretch install -y g++ xvfb qt5-default libqt5webkit5-dev \
-    gstreamer1.0-plugins-base gstreamer1.0-tools gstreamer1.0-x qt-sdk p7zip-full
-
-RUN apt-get -t testing install -y python3.7 python3-pip
-
-RUN gem install capybara capybara-webkit selenium-webdriver  mail --no-document
-RUN pip3 install awscli knackpy psycopg2 requests
-
-COPY app /app
+COPY app /usr/src/app

--- a/atd-cris-capybara/Dockerfile
+++ b/atd-cris-capybara/Dockerfile
@@ -18,6 +18,7 @@ RUN apt-get update -y \
   qt5-default \
   ruby-capybara \
   ruby-selenium-webdriver \
+  xauth \
   xvfb \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \

--- a/atd-cris-capybara/Dockerfile
+++ b/atd-cris-capybara/Dockerfile
@@ -14,8 +14,6 @@ RUN apt-get update -y \
   libqt5webkit5-dev \
   p7zip-full \
   python3 \
-  python3-pip \
-  python3-psycopg2 \
   python3-requests \
   qt5-default \
   ruby-capybara \
@@ -23,7 +21,6 @@ RUN apt-get update -y \
   xvfb \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
-  && gem install capybara-webkit mail --no-document \
-  && pip3 install --no-cache-dir knackpy
+  && gem install capybara-webkit mail --no-document
 
 COPY app /usr/src/app


### PR DESCRIPTION
Simplifies the Dockerfile and reduces its size by using as much upstream
resources as possible instead of building them and cleaning up the
caches at the end of the process.