### PR TITLE
Fatality flag future edits did not appear to be saved

### DIFF
--- a/atd-vze/src/views/Crashes/crashDataMap.js
+++ b/atd-vze/src/views/Crashes/crashDataMap.js
@@ -92,17 +92,17 @@ export const crashDataMap = [
   {
     title: "Fatalities/Injuries",
     fields: {
-      apd_confirmed_fatality: {
-        label: "Fatality Flag",
-        editable: true,
-        uiType: "select",
-        lookupOptions: "atd_txdot__y_n_lkp",
-        lookupPrefix: "y_n",
-      },
       apd_confirmed_death_count: {
         label: "Death Count",
         editable: true,
         uiType: "text",
+      },
+      apd_confirmed_fatality: {
+        label: "Fatality Flag",
+        editable: false,
+        uiType: "select",
+        lookupOptions: "atd_txdot__y_n_lkp",
+        lookupPrefix: "y_n",
       },
       crash_sev_id: {
         label: "Crash Severity",

--- a/atd-vze/src/views/Crashes/crashDataMap.js
+++ b/atd-vze/src/views/Crashes/crashDataMap.js
@@ -100,6 +100,8 @@ export const crashDataMap = [
       apd_confirmed_fatality: {
         label: "Fatality Flag",
         editable: false,
+        lookupOptions: "atd_txdot__y_n_lkp",
+        lookupPrefix: "y_n",
       },
       crash_sev_id: {
         label: "Crash Severity",

--- a/atd-vze/src/views/Crashes/crashDataMap.js
+++ b/atd-vze/src/views/Crashes/crashDataMap.js
@@ -100,9 +100,6 @@ export const crashDataMap = [
       apd_confirmed_fatality: {
         label: "Fatality Flag",
         editable: false,
-        uiType: "select",
-        lookupOptions: "atd_txdot__y_n_lkp",
-        lookupPrefix: "y_n",
       },
       crash_sev_id: {
         label: "Crash Severity",


### PR DESCRIPTION
Closes #313 

This PR makes fatality flag non-editable since its value will change on the DB level as the value of death count changes ( if death count > 0 then fatality flag is "Y" and if death count = 0 then fatality flag is "N"). It also changes the order of the death count and fatality flag in the UI.

### Death count is 0
![Screen Shot 2019-10-31 at 1 38 33 PM](https://user-images.githubusercontent.com/37249039/67976379-fbabd080-fbe3-11e9-8c2a-9a66f1a24f04.png)

### Death count is greater than 0
![Screen Shot 2019-10-31 at 1 38 47 PM](https://user-images.githubusercontent.com/37249039/67976433-0e260a00-fbe4-11e9-9bb0-b4462097704b.png)
