### PR TITLE
Fix display of 1st "Updated by" entry

### DIFF
--- a/atd-vze/src/queries/crashes.js
+++ b/atd-vze/src/queries/crashes.js
@@ -144,6 +144,7 @@ export const GET_CRASH = gql`
       record_crash_id
       record_json
       update_timestamp
+      updated_by
     }
     atd_txdot_crash_locations(where: { crash_id: { _eq: $crashId } }) {
       location_id

--- a/atd-vze/src/views/Crashes/CrashChangeLog.js
+++ b/atd-vze/src/views/Crashes/CrashChangeLog.js
@@ -133,7 +133,7 @@ class CrashChangeLog extends Component {
       <section>
         <h6>Crash ID: {record.record_crash_id}</h6>
         <h6>Edited Date: {record.update_timestamp}</h6>
-        <h6>Created by: {record.record_json.updated_by || "Unavailable"}</h6>
+        <h6>Updated by: {record.updated_by || "Unavailable"}</h6>
         &nbsp;
         <Table responsive>
           <thead>
@@ -195,7 +195,9 @@ class CrashChangeLog extends Component {
                     </Badge>
                   </td>
                   <td>
-                    <Badge color="danger">{String(record['record_json'].updated_by || "Unavailable")} </Badge>
+                    <Badge color="danger">
+                      {String(record.updated_by || "Unavailable")}{" "}
+                    </Badge>
                   </td>
                   <td>
                     <Button

--- a/atd-vze/src/views/Crashes/CrashChangeLog.js
+++ b/atd-vze/src/views/Crashes/CrashChangeLog.js
@@ -196,7 +196,7 @@ class CrashChangeLog extends Component {
                   </td>
                   <td>
                     <Badge color="danger">
-                      {String(record.updated_by || "Unavailable")}{" "}
+                      {String(record.updated_by || "Unavailable")}
                     </Badge>
                   </td>
                   <td>


### PR DESCRIPTION
Closes #234 

This PR fixes an issue where the first entry in the change log shows the Updated By: entry as "Unavailable". This is due to the way the data was structured...

A change log record includes a column called `record_json` which stores a json representation of the previous state of the record before the change was made. We were using the "updated_by" value in within that json record. And since that original record was imported by the system, the "updated_by" field was null.

Now, we've updated the staging and production database `atd_txdot_change_log` table to have a new `updated_by` column. And we've also updated the trigger that populates the change_log table when a record changes. So now we pull that `updated_by` value from the change_log entry's column, instead of the change_log record's nested previous state.

### `atd_txdot_change_log` table structure
![Screen Shot 2019-10-31 at 2 49 12 PM](https://user-images.githubusercontent.com/5697474/67981280-47fc0e00-fbee-11e9-8602-b90eebed3168.png)

### Before
![Screen Shot 2019-10-31 at 2 26 11 PM](https://user-images.githubusercontent.com/5697474/67980433-6a8d2780-fbec-11e9-91fd-f51480d18f3e.png)

### After
![Screen Shot 2019-10-31 at 2 23 43 PM](https://user-images.githubusercontent.com/5697474/67981358-737ef880-fbee-11e9-8bb9-2a42935adaa8.png)

### Changed section of the crash audit log tigger

```
    ------------------------------------------------------------------------------------------
    -- CHANGE-LOG OPERATIONS
    ------------------------------------------------------------------------------------------
    -- Stores a copy of the current record into the change log
    IF  (TG_OP = 'UPDATE') then
        INSERT INTO atd_txdot_change_log (record_id, record_crash_id, record_type, record_json, updated_by)
        VALUES (old.crash_id, old.crash_id, 'crashes', row_to_json(old), NEW.updated_by);
    END IF;
```