### PR TITLE
Add speed_mgmt & econ_cost to Crash details page

### DIFF
--- a/atd-vze/src/queries/crashes.js
+++ b/atd-vze/src/queries/crashes.js
@@ -24,6 +24,7 @@ export const GET_CRASH = gql`
       day_of_week
       death_cnt
       est_comp_cost
+      est_econ_cost
       fhe_collsn_id
       geocode_date
       geocode_provider
@@ -77,6 +78,7 @@ export const GET_CRASH = gql`
       rpt_street_desc
       rr_relat_fl
       schl_bus_fl
+      speed_mgmt_points
       street_name
       street_name_2
       street_nbr

--- a/atd-vze/src/views/Crashes/crashDataMap.js
+++ b/atd-vze/src/views/Crashes/crashDataMap.js
@@ -32,6 +32,16 @@ export const crashDataMap = [
         editable: false,
         format: "dollars",
       },
+      est_econ_cost: {
+        label: "Est. Economic Cost",
+        editable: false,
+        format: "dollars",
+      },
+      speed_mgmt_points: {
+        label: "Speed Management Points",
+        editable: false,
+        format: "text",
+      },
       fhe_collsn_id: {
         label: "Manner of Collision ID",
         editable: false,


### PR DESCRIPTION
_Closes #379_

This simple PR wraps up the backend work to update cost values and implementing the speed management points table.