### PR TITLE
Create relationship in Hasura for crash geocoder method

### DIFF
--- a/atd-vze/src/queries/crashes.js
+++ b/atd-vze/src/queries/crashes.js
@@ -26,6 +26,9 @@ export const GET_CRASH = gql`
       est_comp_cost
       est_econ_cost
       fhe_collsn_id
+      geocode_method {
+        name
+      }
       geocode_date
       geocode_provider
       geocode_status

--- a/atd-vze/src/queries/lookups.js
+++ b/atd-vze/src/queries/lookups.js
@@ -56,12 +56,3 @@ export const GET_LOOKUPS = gql`
     }
   }
 `;
-
-export const GET_GEOCODERS = gql`
-  {
-    atd_txdot_geocoders {
-      name
-      geocoder_id
-    }
-  }
-`;

--- a/atd-vze/src/views/Crashes/Crash.js
+++ b/atd-vze/src/views/Crashes/Crash.js
@@ -208,7 +208,10 @@ function Crash(props) {
                       "unassigned"}
                     )
                     <br />
-                    Source: {geocodeMethod.name}
+                    Source:{" "}
+                    {latitude && longitude
+                      ? geocodeMethod.name
+                      : "No Primary Coordinates"}
                   </Col>
                   <Col>
                     {!isEditingCoords && (

--- a/atd-vze/src/views/Crashes/Crash.js
+++ b/atd-vze/src/views/Crashes/Crash.js
@@ -25,7 +25,6 @@ import { crashDataMap } from "./crashDataMap";
 import "./crash.scss";
 
 import { GET_CRASH, UPDATE_CRASH } from "../../queries/crashes";
-import { GET_GEOCODERS } from "../../queries/lookups";
 
 const calculateYearsLifeLost = people => {
   // Assume 75 year life expectancy,
@@ -49,8 +48,6 @@ function Crash(props) {
   const { loading, error, data, refetch } = useQuery(GET_CRASH, {
     variables: { crashId },
   });
-
-  const { data: geocoderOptions } = useQuery(GET_GEOCODERS);
 
   const [editField, setEditField] = useState("");
   const [formData, setFormData] = useState({});

--- a/atd-vze/src/views/Crashes/Crash.js
+++ b/atd-vze/src/views/Crashes/Crash.js
@@ -133,7 +133,7 @@ function Crash(props) {
     address_confirmed_primary: primaryAddress,
     address_confirmed_secondary: secondaryAddress,
     cr3_stored_flag: cr3StoredFlag,
-    geocode_provider: geocodeProvider,
+    geocode_method: geocodeMethod,
   } = data.atd_txdot_crashes[0];
 
   const mapGeocoderAddress = createGeocoderAddressString(data);
@@ -208,7 +208,7 @@ function Crash(props) {
                       "unassigned"}
                     )
                     <br />
-                    Source: {data.atd_txdot_crashes[0].geocode_method.name}
+                    Source: {geocodeMethod.name}
                   </Col>
                   <Col>
                     {!isEditingCoords && (

--- a/atd-vze/src/views/Crashes/Crash.js
+++ b/atd-vze/src/views/Crashes/Crash.js
@@ -74,20 +74,6 @@ function Crash(props) {
     return geocoderAddressString;
   };
 
-  const convertGeocoderToName = geocoderID => {
-    const geocoders = geocoderOptions.atd_txdot_geocoders || [];
-    const primaryLat = data.atd_txdot_crashes[0]["latitude_primary"];
-    const primaryLong = data.atd_txdot_crashes[0]["longitude_primary"];
-
-    const geocoderOption = geocoders.find(
-      option => option.geocoder_id === geocoderID
-    );
-
-    return primaryLat && primaryLong
-      ? geocoderOption && geocoderOption.name
-      : "No Primary Coordinates";
-  };
-
   const handleInputChange = e => {
     const newFormState = Object.assign(formData, {
       [editField]: e.target.value,
@@ -222,7 +208,7 @@ function Crash(props) {
                       "unassigned"}
                     )
                     <br />
-                    Source: {convertGeocoderToName(geocodeProvider)}
+                    Source: {data.atd_txdot_crashes[0].geocode_method.name}
                   </Col>
                   <Col>
                     {!isEditingCoords && (

--- a/atd-vze/src/views/Crashes/crashDataMap.js
+++ b/atd-vze/src/views/Crashes/crashDataMap.js
@@ -359,6 +359,8 @@ export const crashDataMap = [
       geocode_provider: {
         label: "Geocode Provider",
         editable: false,
+        dataTableName: "atd_txdot_crashes",
+        dataPath: ["geocode_method", "name"],
       },
       geocode_status: {
         label: "Geocode Status",


### PR DESCRIPTION
This PR refactors the code merged in PR #465 

An object relationship was created between crash `geocoder_id` and `geocode_provider` to expose the geocoder name of a crash location through a crash query. The Geocode Provider field in the Geocoding data table is now updated to show the geocoder name as well.

### Geocoding data table
![Screen Shot 2019-11-26 at 10 43 44 AM](https://user-images.githubusercontent.com/37249039/69654440-6d880600-103a-11ea-90ad-5f6f71b9885d.png)
