### PR TITLE
Update Socrata ETL to enable GeoJSON fetch from Socrata

### DIFF
--- a/atd-etl/app/process/helpers_socrata.py
+++ b/atd-etl/app/process/helpers_socrata.py
@@ -52,7 +52,7 @@ def run_hasura_query(query):
 def flatten_hasura_response(records):
     """
     Flattens data response from Hasura
-    :param records: list - List of record dicts 
+    :param records: list - List of record dicts
     """
     formatted_records = []
     for record in records:
@@ -119,6 +119,10 @@ def create_crash_mode_flags(records, unit_modes):
 
 
 def create_point_datatype(records):
+    """
+    Creates point datatype to enable fetching GeoJSON from Socrata
+    :param records: list - List of record dicts
+    """
     for record in records:
         latitude = record['latitude']
         longitude = record['longitude']

--- a/atd-etl/app/process/helpers_socrata.py
+++ b/atd-etl/app/process/helpers_socrata.py
@@ -118,6 +118,12 @@ def create_crash_mode_flags(records, unit_modes):
     return records
 
 
+def create_point_datatype(records):
+    for record in records:
+        record["point"] = f"POINT ({record["longitude"]} {record["longitude"])"
+    return records
+
+
 def rename_record_columns(records, columns_to_rename):
     """
     Renames columns for better desc and to match Socrata column names
@@ -158,6 +164,7 @@ def format_crash_data(data, formatter_config):
         formatted_records, formatter_config["columns_to_rename"])
     formatted_records = create_crash_mode_flags(
         formatted_records, formatter_config["flags_list"])
+    formatted_records = create_point_datatype(formatted_records)
 
     return formatted_records
 

--- a/atd-etl/app/process/helpers_socrata.py
+++ b/atd-etl/app/process/helpers_socrata.py
@@ -126,6 +126,7 @@ def create_point_datatype(records):
     for record in records:
         latitude = record['latitude']
         longitude = record['longitude']
+        # Socrata rejects point upserts with no lat/lon
         if latitude != None and longitude != None:
             record["point"] = f"POINT ({longitude} {latitude})"
     return records

--- a/atd-etl/app/process/helpers_socrata.py
+++ b/atd-etl/app/process/helpers_socrata.py
@@ -120,7 +120,10 @@ def create_crash_mode_flags(records, unit_modes):
 
 def create_point_datatype(records):
     for record in records:
-        record["point"] = f"POINT ({record["longitude"]} {record["longitude"])"
+        latitude = record['latitude']
+        longitude = record['longitude']
+        if latitude != None and longitude != None:
+            record["point"] = f"POINT ({longitude} {latitude})"
     return records
 
 

--- a/atd-etl/app/process/socrata_queries.py
+++ b/atd-etl/app/process/socrata_queries.py
@@ -28,8 +28,8 @@ crashes_query_template = Template(
             rpt_street_sfx
             crash_speed_limit
             road_constr_zone_fl
-            latitude
-            longitude
+            latitude_primary
+            longitude_primary
             street_name
             street_nbr
             street_name_2

--- a/atd-etl/app/process_socrata_export.py
+++ b/atd-etl/app/process_socrata_export.py
@@ -89,8 +89,7 @@ for config in query_configs:
         records = config["formatter"](data, config["formatter_config"])
 
         # Upsert records to Socrata
-        print(records[0])
-        # client.upsert(config["dataset_uid"], records)
+        client.upsert(config["dataset_uid"], records)
         total_records += len(records)
 
         if len(records) == 0:

--- a/atd-etl/app/process_socrata_export.py
+++ b/atd-etl/app/process_socrata_export.py
@@ -34,6 +34,8 @@ query_configs = [
             "columns_to_rename": {
                 "veh_body_styl_desc": "unit_desc",
                 "veh_unit_desc_desc": "unit_mode",
+                "latitude_primary": "latitude",
+                "longitude_primary": "longitude"
             },
             "flags_list": ["MOTOR VEHICLE",
                            "TRAIN",
@@ -87,7 +89,8 @@ for config in query_configs:
         records = config["formatter"](data, config["formatter_config"])
 
         # Upsert records to Socrata
-        client.upsert(config["dataset_uid"], records)
+        print(records[0])
+        # client.upsert(config["dataset_uid"], records)
         total_records += len(records)
 
         if len(records) == 0:


### PR DESCRIPTION
This is a small update to the ETL script to create a Socrata `POINT` datatype using the primary latitude and longitude. This allows GeoJSON requested from Socrata to populate coordinates correctly. I also changed the source of the latitude and latitude columns to `latitude_primary` and `longitude_primary` (Rémy helped catch this when he was looking through the dataset).

https://dev.socrata.com/docs/datatypes/point.html