### PR TITLE
Incorrect values in VZE Dashboard

### DIFF
--- a/atd-vze/src/queries/dashboard.js
+++ b/atd-vze/src/queries/dashboard.js
@@ -16,7 +16,7 @@ export const GET_CRASHES_YTD = gql`
         }
       }
     }
-    atd_txdot_crashes_aggregate(
+    seriousInjuriesAndTotal: atd_txdot_crashes_aggregate(
       where: {
         city_id: { _eq: 22 }
         crash_date: { _gte: $yearStart, _lte: $yearEnd }

--- a/atd-vze/src/queries/dashboard.js
+++ b/atd-vze/src/queries/dashboard.js
@@ -2,7 +2,7 @@ import { gql } from "apollo-boost";
 
 export const GET_CRASHES_YTD = gql`
   query GetCrashesYTD($yearStart: date, $yearEnd: date) {
-    atd_txdot_crashes_aggregate(
+    fatalities: atd_txdot_crashes_aggregate(
       where: {
         city_id: { _eq: 22 }
         crash_date: { _gte: $yearStart, _lte: $yearEnd }
@@ -11,9 +11,21 @@ export const GET_CRASHES_YTD = gql`
       }
     ) {
       aggregate {
-        count
         sum {
           apd_confirmed_death_count
+        }
+      }
+    }
+    atd_txdot_crashes_aggregate(
+      where: {
+        city_id: { _eq: 22 }
+        crash_date: { _gte: $yearStart, _lte: $yearEnd }
+        private_dr_fl: { _neq: "Y" }
+      }
+    ) {
+      aggregate {
+        count
+        sum {
           sus_serious_injry_cnt
         }
       }

--- a/atd-vze/src/views/VZDashboard/VZDashboard.js
+++ b/atd-vze/src/views/VZDashboard/VZDashboard.js
@@ -24,9 +24,12 @@ function VZDashboard() {
     years_of_life_lost: yearsOfLifeLostPerson,
   } = data.atd_txdot_person_aggregate.aggregate.sum;
   const {
-    apd_confirmed_death_count: deathCount,
     sus_serious_injry_cnt: seriousInjuryCount,
   } = data.atd_txdot_crashes_aggregate.aggregate.sum;
+  const {
+    apd_confirmed_death_count: deathCount,
+  } = data.fatalities.aggregate.sum;
+
   const { count: crashesCount } = data.atd_txdot_crashes_aggregate.aggregate;
 
   const yearsOfLifeLostYTD =

--- a/atd-vze/src/views/VZDashboard/VZDashboard.js
+++ b/atd-vze/src/views/VZDashboard/VZDashboard.js
@@ -25,12 +25,12 @@ function VZDashboard() {
   } = data.atd_txdot_person_aggregate.aggregate.sum;
   const {
     sus_serious_injry_cnt: seriousInjuryCount,
-  } = data.atd_txdot_crashes_aggregate.aggregate.sum;
+  } = data.seriousInjuriesAndTotal.aggregate.sum;
   const {
     apd_confirmed_death_count: deathCount,
   } = data.fatalities.aggregate.sum;
 
-  const { count: crashesCount } = data.atd_txdot_crashes_aggregate.aggregate;
+  const { count: crashesCount } = data.seriousInjuriesAndTotal.aggregate;
 
   const yearsOfLifeLostYTD =
     yearsOfLifeLostPrimaryPerson + yearsOfLifeLostPerson;


### PR DESCRIPTION
Closes #499 

This PR adds an additional table query to the dashboard query aliased as `fatalities`. The issue arose when a filter, `apd_confirmed_fatality: { _neq: "N" }`, was added to the GraphQL query that populated the Fatalities, Serious Injuries, and Total Crashes widgets. This provided an accurate total for fatalities but it underrepresented serious injuries and total crashes. These widgets are now populated by separate queries with the appropriate filters.

### Updated dashboard
![Screen Shot 2019-12-05 at 2 16 08 PM](https://user-images.githubusercontent.com/37249039/70270755-ae82c780-176a-11ea-8f1c-1bd489d5446a.png)

 