### PR TITLE
VZD ETL: Update socrata demographics data with mode

### DIFF
--- a/atd-etl/app/process/helpers_socrata.py
+++ b/atd-etl/app/process/helpers_socrata.py
@@ -84,8 +84,12 @@ def flatten_hasura_response(records):
             # If dict is found, iterate to bring key values to top-level
             elif type(first_level_value) == dict:
                 for dict_key, dict_value in first_level_value.items():
-                    formatted_record[dict_key] = dict_value
-                    del formatted_record[first_level_key]
+                    if(type(dict_value) == dict):
+                        for second_level_key, second_level_value in dict_value.items():
+                            formatted_record[second_level_key] = second_level_value
+                    else:
+                        formatted_record[dict_key] = dict_value
+                del formatted_record[first_level_key]
         formatted_records.append(formatted_record)
     return formatted_records
 
@@ -194,10 +198,10 @@ def format_person_data(data, formatter_config):
 
     # Join records and format
     people_records = person_records + primary_person_records
-    formatted_records = rename_record_columns(
-        people_records, formatter_config["columns_to_rename"])
     formatted_records = flatten_hasura_response(
-        formatted_records)
+        people_records)
+    formatted_records = rename_record_columns(
+        formatted_records, formatter_config["columns_to_rename"])
     formatted_records = create_mode_flags(
         formatted_records, formatter_config["flags_list"])
 

--- a/atd-etl/app/process/helpers_socrata.py
+++ b/atd-etl/app/process/helpers_socrata.py
@@ -90,9 +90,9 @@ def flatten_hasura_response(records):
     return formatted_records
 
 
-def create_crash_mode_flags(records, unit_modes):
+def create_mode_flags(records, unit_modes):
     """
-    Creates crash mode flag columns in data along with "Y" or "N" value
+    Creates mode flag columns in data along with "Y" or "N" value
     :param records: list - List of record dicts
     :param unit_modes: list - List of mode strings to create flag columns
     """
@@ -170,7 +170,7 @@ def format_crash_data(data, formatter_config):
     formatted_records = flatten_hasura_response(records)
     formatted_records = rename_record_columns(
         formatted_records, formatter_config["columns_to_rename"])
-    formatted_records = create_crash_mode_flags(
+    formatted_records = create_mode_flags(
         formatted_records, formatter_config["flags_list"])
     formatted_records = create_point_datatype(formatted_records)
 
@@ -198,5 +198,7 @@ def format_person_data(data, formatter_config):
         people_records, formatter_config["columns_to_rename"])
     formatted_records = flatten_hasura_response(
         formatted_records)
+    formatted_records = create_mode_flags(
+        formatted_records, formatter_config["flags_list"])
 
     return formatted_records

--- a/atd-etl/app/process/helpers_socrata.py
+++ b/atd-etl/app/process/helpers_socrata.py
@@ -84,12 +84,14 @@ def flatten_hasura_response(records):
             # If dict is found, iterate to bring key values to top-level
             elif type(first_level_value) == dict:
                 for dict_key, dict_value in first_level_value.items():
+                    # If dict contains nested dicts
                     if(type(dict_value) == dict):
                         for second_level_key, second_level_value in dict_value.items():
                             formatted_record[second_level_key] = second_level_value
                     else:
                         formatted_record[dict_key] = dict_value
                 del formatted_record[first_level_key]
+        print(formatted_record)
         formatted_records.append(formatted_record)
     return formatted_records
 

--- a/atd-etl/app/process/socrata_queries.py
+++ b/atd-etl/app/process/socrata_queries.py
@@ -70,6 +70,11 @@ people_query_template = Template(
             crash {
                 crash_date
             }
+            unit {
+                unit_description {
+                veh_unit_desc_desc
+            }
+    }
         }
         atd_txdot_primaryperson(limit: $limit, offset: $offset, order_by: {primaryperson_id: asc}, where: {_or: [{prsn_injry_sev_id: {_eq: 1}}, {prsn_injry_sev_id: {_eq: 4}}], _and: {crash: {city_id: {_eq: 22}}}}) {
             primaryperson_id
@@ -80,6 +85,11 @@ people_query_template = Template(
             crash {
                 crash_date
             }
+            unit {
+                unit_description {
+                    veh_unit_desc_desc
+                }
+            }   
         }
     }
 """

--- a/atd-etl/app/process/socrata_queries.py
+++ b/atd-etl/app/process/socrata_queries.py
@@ -71,10 +71,13 @@ people_query_template = Template(
                 crash_date
             }
             unit {
+                body_style {
+                    veh_body_styl_desc
+                }
                 unit_description {
-                veh_unit_desc_desc
+                    veh_unit_desc_desc
+                }
             }
-    }
         }
         atd_txdot_primaryperson(limit: $limit, offset: $offset, order_by: {primaryperson_id: asc}, where: {_or: [{prsn_injry_sev_id: {_eq: 1}}, {prsn_injry_sev_id: {_eq: 4}}], _and: {crash: {city_id: {_eq: 22}}}}) {
             primaryperson_id
@@ -86,6 +89,9 @@ people_query_template = Template(
                 crash_date
             }
             unit {
+                body_style {
+                    veh_body_styl_desc
+                }
                 unit_description {
                     veh_unit_desc_desc
                 }

--- a/atd-etl/app/process/socrata_queries.py
+++ b/atd-etl/app/process/socrata_queries.py
@@ -16,7 +16,7 @@ crashes_query_template = Template(
     query getCrashesSocrata {
         atd_txdot_crashes (limit: $limit, offset: $offset, order_by: {crash_id: asc}, where: {city_id: {_eq: 22}}) {
             crash_id
-    		crash_fatal_fl
+            crash_fatal_fl
             crash_date
             crash_time
             case_id
@@ -67,15 +67,17 @@ people_query_template = Template(
             prsn_injry_sev_id
             prsn_age
             prsn_gndr_id
+            unit_nbr
             crash {
                 crash_date
-            }
-            unit {
-                body_style {
-                    veh_body_styl_desc
-                }
-                unit_description {
-                    veh_unit_desc_desc
+                units {
+                    unit_nbr
+                    unit_description {
+                        veh_unit_desc_desc
+                    }
+                    body_style {
+                        veh_body_styl_desc
+                    }
                 }
             }
         }
@@ -84,18 +86,19 @@ people_query_template = Template(
             prsn_injry_sev_id
             prsn_age
             prsn_gndr_id
-            drvr_zip
+            unit_nbr
             crash {
                 crash_date
+                units {
+                    unit_nbr
+                    unit_description {
+                        veh_unit_desc_desc
+                    }
+                    body_style {
+                        veh_body_styl_desc
+                    }
+                }
             }
-            unit {
-                body_style {
-                    veh_body_styl_desc
-                }
-                unit_description {
-                    veh_unit_desc_desc
-                }
-            }   
         }
     }
 """

--- a/atd-etl/app/process_socrata_export.py
+++ b/atd-etl/app/process_socrata_export.py
@@ -25,29 +25,29 @@ client = Socrata("data.austintexas.gov", ATD_ETL_CONFIG["SOCRATA_APP_TOKEN"],
 
 # Define tables to query from Hasura and publish to Socrata
 query_configs = [
-    {
-        "table": "crash",
-        "template": crashes_query_template,
-        "formatter": format_crash_data,
-        "formatter_config": {
-            "tables": ["atd_txdot_crashes"],
-            "columns_to_rename": {
-                "veh_body_styl_desc": "unit_desc",
-                "veh_unit_desc_desc": "unit_mode",
-                "latitude_primary": "latitude",
-                "longitude_primary": "longitude"
-            },
-            "flags_list": ["MOTOR VEHICLE",
-                           "TRAIN",
-                           "PEDALCYCLIST",
-                           "PEDESTRIAN",
-                           "MOTORIZED CONVEYANCE",
-                           "TOWED/PUSHED/TRAILER",
-                           "NON-CONTACT",
-                           "OTHER"]
-        },
-        "dataset_uid": "y2wy-tgr5"
-    },
+    # {
+    #     "table": "crash",
+    #     "template": crashes_query_template,
+    #     "formatter": format_crash_data,
+    #     "formatter_config": {
+    #         "tables": ["atd_txdot_crashes"],
+    #         "columns_to_rename": {
+    #             "veh_body_styl_desc": "unit_desc",
+    #             "veh_unit_desc_desc": "unit_mode",
+    #             "latitude_primary": "latitude",
+    #             "longitude_primary": "longitude"
+    #         },
+    #         "flags_list": ["MOTOR VEHICLE",
+    #                        "TRAIN",
+    #                        "PEDALCYCLIST",
+    #                        "PEDESTRIAN",
+    #                        "MOTORIZED CONVEYANCE",
+    #                        "TOWED/PUSHED/TRAILER",
+    #                        "NON-CONTACT",
+    #                        "OTHER"]
+    #     },
+    #     "dataset_uid": "y2wy-tgr5"
+    # },
     {
         "table": "person",
         "template": people_query_template,
@@ -100,7 +100,7 @@ for config in query_configs:
 
         # Upsert records to Socrata
         # client.upsert(config["dataset_uid"], records)
-        print(records[1])
+        # print(records[1])
         total_records += len(records)
 
         if len(records) == 0:

--- a/atd-etl/app/process_socrata_export.py
+++ b/atd-etl/app/process_socrata_export.py
@@ -55,12 +55,22 @@ query_configs = [
         "formatter_config": {
             "tables": ["atd_txdot_person", "atd_txdot_primaryperson"],
             "columns_to_rename": {
+                "veh_body_styl_desc": "unit_desc",
+                "veh_unit_desc_desc": "unit_mode",
                 "primaryperson_id": "person_id"
             },
             "prefixes": {
                 "person_id": "P",
                 "primaryperson_id": "PP",
-            }
+            },
+            "flags_list": ["MOTOR VEHICLE",
+                           "TRAIN",
+                           "PEDALCYCLIST",
+                           "PEDESTRIAN",
+                           "MOTORIZED CONVEYANCE",
+                           "TOWED/PUSHED/TRAILER",
+                           "NON-CONTACT",
+                           "OTHER"]
         },
         "dataset_uid": "xecs-rpy9"
     }

--- a/atd-etl/app/process_socrata_export.py
+++ b/atd-etl/app/process_socrata_export.py
@@ -55,8 +55,6 @@ query_configs = [
         "formatter_config": {
             "tables": ["atd_txdot_person", "atd_txdot_primaryperson"],
             "columns_to_rename": {
-                "veh_body_styl_desc": "unit_desc",
-                "veh_unit_desc_desc": "unit_mode",
                 "primaryperson_id": "person_id"
             },
             "prefixes": {

--- a/atd-etl/app/process_socrata_export.py
+++ b/atd-etl/app/process_socrata_export.py
@@ -99,7 +99,8 @@ for config in query_configs:
         records = config["formatter"](data, config["formatter_config"])
 
         # Upsert records to Socrata
-        client.upsert(config["dataset_uid"], records)
+        # client.upsert(config["dataset_uid"], records)
+        print(records[1])
         total_records += len(records)
 
         if len(records) == 0:

--- a/atd-etl/app/process_socrata_export.py
+++ b/atd-etl/app/process_socrata_export.py
@@ -25,29 +25,29 @@ client = Socrata("data.austintexas.gov", ATD_ETL_CONFIG["SOCRATA_APP_TOKEN"],
 
 # Define tables to query from Hasura and publish to Socrata
 query_configs = [
-    # {
-    #     "table": "crash",
-    #     "template": crashes_query_template,
-    #     "formatter": format_crash_data,
-    #     "formatter_config": {
-    #         "tables": ["atd_txdot_crashes"],
-    #         "columns_to_rename": {
-    #             "veh_body_styl_desc": "unit_desc",
-    #             "veh_unit_desc_desc": "unit_mode",
-    #             "latitude_primary": "latitude",
-    #             "longitude_primary": "longitude"
-    #         },
-    #         "flags_list": ["MOTOR VEHICLE",
-    #                        "TRAIN",
-    #                        "PEDALCYCLIST",
-    #                        "PEDESTRIAN",
-    #                        "MOTORIZED CONVEYANCE",
-    #                        "TOWED/PUSHED/TRAILER",
-    #                        "NON-CONTACT",
-    #                        "OTHER"]
-    #     },
-    #     "dataset_uid": "y2wy-tgr5"
-    # },
+    {
+        "table": "crash",
+        "template": crashes_query_template,
+        "formatter": format_crash_data,
+        "formatter_config": {
+            "tables": ["atd_txdot_crashes"],
+            "columns_to_rename": {
+                "veh_body_styl_desc": "unit_desc",
+                "veh_unit_desc_desc": "unit_mode",
+                "latitude_primary": "latitude",
+                "longitude_primary": "longitude"
+            },
+            "flags_list": ["MOTOR VEHICLE",
+                           "TRAIN",
+                           "PEDALCYCLIST",
+                           "PEDESTRIAN",
+                           "MOTORIZED CONVEYANCE",
+                           "TOWED/PUSHED/TRAILER",
+                           "NON-CONTACT",
+                           "OTHER"]
+        },
+        "dataset_uid": "y2wy-tgr5"
+    },
     {
         "table": "person",
         "template": people_query_template,
@@ -99,8 +99,7 @@ for config in query_configs:
         records = config["formatter"](data, config["formatter_config"])
 
         # Upsert records to Socrata
-        # client.upsert(config["dataset_uid"], records)
-        print(records[1])
+        client.upsert(config["dataset_uid"], records)
         total_records += len(records)
 
         if len(records) == 0:

--- a/atd-etl/app/process_socrata_export.py
+++ b/atd-etl/app/process_socrata_export.py
@@ -100,7 +100,7 @@ for config in query_configs:
 
         # Upsert records to Socrata
         # client.upsert(config["dataset_uid"], records)
-        # print(records[1])
+        print(records[1])
         total_records += len(records)
 
         if len(records) == 0:


### PR DESCRIPTION
This PR changes the Socrata publishing ETL script to add data about the mode of transportation for each person in the demographics dataset. Crash units data was added to the query to match the person's `unit_nbr` to a unit in the crash. The [dataset](https://data.austintexas.gov/Transportation-and-Mobility/-UNDER-CONSTRUCTION-Vision-Zero-Demographic-Statis/xecs-rpy9/data) now has `unit_mode`, `unit_desc`, and all of the mode flags in the crashes open dataset as well.