### PR TITLE
Bumped serialize-javascript version

### DIFF
--- a/atd-vze/package.json
+++ b/atd-vze/package.json
@@ -51,7 +51,8 @@
     "react-test-renderer": "^16.8.6",
     "reactstrap": "^8.0.0",
     "simple-line-icons": "^2.4.1",
-    "styled-components": "^4.3.2"
+    "styled-components": "^4.3.2",
+    "serialize-javascript": ">=2.1.1"
   },
   "devDependencies": {
     "eslint-config-prettier": "^6.0.0",

--- a/atd-vzv/package.json
+++ b/atd-vzv/package.json
@@ -23,7 +23,8 @@
     "react-dom": "^16.10.2",
     "react-scripts": "3.2.0",
     "reactstrap": "^8.1.1",
-    "styled-components": "^4.4.0"
+    "styled-components": "^4.4.0",
+    "serialize-javascript": ">=2.1.1"
   },
   "scripts": {
     "start": "react-scripts start",


### PR DESCRIPTION
Moderate severity (XSS vulnerability) for VZE and VZV, security-patched as recommended here: 
https://github.com/cityofaustin/atd-vz-data/network/alert/atd-vze/package-lock.json/serialize-javascript/open