### PR TITLE
Fix lookup value mismatch bug

### DIFF
--- a/atd-vze/src/Components/DataTable.js
+++ b/atd-vze/src/Components/DataTable.js
@@ -99,22 +99,33 @@ const DataTable = ({
 
                       // If there is no lookup options, we can assume the field value can be displayed as is.
                       // If there is a lookup option, then the value is an ID to be referenced in a lookup table.
-                      const fieldValueDisplay =
-                        // make sure the value isn't null blank
-                        fieldValue &&
-                        // make sure there is a lookup object in the config
-                        !!fieldConfigObject.lookupOptions &&
-                        // make sure the config lookup object matches with lookup queries
-                        lookupSelectOptions[fieldConfigObject.lookupOptions]
-                          ? lookupSelectOptions[
-                              fieldConfigObject.lookupOptions
-                            ].find(
-                              item => item[`${lookupPrefix}_id`] === fieldValue
-                            )[`${lookupPrefix}_desc`]
-                          : fieldValue;
-
                       const selectOptions =
                         lookupSelectOptions[fieldConfigObject.lookupOptions];
+
+                      const renderLookupDescString = () => {
+                        // make sure the value isn't null blank
+                        if (!fieldValue) return "";
+
+                        // make sure there is a lookup object in the config
+                        if (!selectOptions || !fieldConfigObject.lookupOptions)
+                          return fieldValue;
+
+                        // make sure the config lookup object matches with lookup queries
+                        const matchingLookupObject = selectOptions.find(
+                          item => item[`${lookupPrefix}_id`] === fieldValue
+                        );
+
+                        if (!matchingLookupObject) {
+                          console.warn(
+                            `${field} has a value of ${fieldValue} which has no match in the related lookup table. You should check to make sure the lookup table isn't missing any rows of data.`
+                          );
+                          return `ID: ${fieldValue}`;
+                        } else {
+                          return matchingLookupObject[`${lookupPrefix}_desc`];
+                        }
+                      };
+
+                      const fieldValueDisplay = renderLookupDescString();
 
                       return (
                         <tr key={i}>


### PR DESCRIPTION
_Closes #503_

The immediate fix to this bug is updating the `atd_txdot__obj_struck_lkp` table with a row for "HIT MAILBOX" which somehow got skipped on import. This is the SQL code that has now been applied to both production and staging.

```sql
INSERT INTO "public"."atd_txdot__obj_struck_lkp" ("obj_struck_id", "obj_struck_desc", "eff_beg_date", "eff_end_date") VALUES ('31', 'HIT MAILBOX', '2010-Jan-01', '9999-12-31');
```

The code in this PR tries to make the logic more readable and provide more console help if we see a missing lookup/field value error in the future. Before I added the missing column to the DB, this is what a user would see when the lookup value is missing:

![Screen Shot 2019-12-12 at 3 07 19 PM](https://user-images.githubusercontent.com/5697474/70749888-e5208b00-1cf2-11ea-9be6-a35fe0709275.png)
