### PR TITLE
RunETL: Fixed ZSH

### DIFF
--- a/atd-etl/app/process_test_run.py
+++ b/atd-etl/app/process_test_run.py
@@ -6,12 +6,16 @@ Author: Austin Transportation Department, Data and Technology Services
 Description: The purpose of this script is to help troubleshooting
 running python commands within the splinter docker container.
 """
-
+import sys
 from process.config import ATD_ETL_CONFIG
 
 print("Running a test within the ETL container. Checking access to environment variables.\n")
 
 print("1. CRIS Website:     '%s'" % ATD_ETL_CONFIG["ATD_CRIS_WEBSITE"])
 print("2. Hasura Endpoint:  '%s'" % ATD_ETL_CONFIG["HASURA_ENDPOINT"])
+
+print("\nTotal Arguments: %s" % len(sys.argv))
+for x in range(len(sys.argv)):
+    print("[%s] %s" % (x, sys.argv[x]))
 
 print("\nThe test has finished, check if you see the two environment variables above.\n")

--- a/atd-etl/runetl.sh
+++ b/atd-etl/runetl.sh
@@ -61,22 +61,24 @@ function runetl {
     echo -e "ATD_DOCKER_IMAGE: \t${ATD_DOCKER_IMAGE}";
     echo -e "--------------------\n";
 
+    echo "--------------------------------------------------------------------";
+    echo "--- Running web-pdb debugger at http://localhost:${WEB_PDB_PORT} ---";
+    echo "--------------------------------------------------------------------";
 
-    # If the command is not bash, prepend the forward slash...
-    if [[ "$2" == "bash" ]]; then
-        FINAL_COMMAND=$RUN_COMMAND;
-    else
-        FINAL_COMMAND="/${RUN_COMMAND}";
+    # Prepend the forward slash if missing in the run command...
+    if [[ "${RUN_COMMAND}" =~ ^app/ ]]; then
+        RUN_COMMAND="/${RUN_COMMAND}";
     fi;
 
-    echo "--------------------------------------------------------------------"
-    echo "--- Running web-pdb debugger at http://localhost:${WEB_PDB_PORT} ---"
-    echo "--------------------------------------------------------------------"
+    FINAL_COMMAND="docker run -it --rm -p $WEB_PDB_PORT:5555/tcp \
+        -v $(pwd)/app:/app -v $(pwd)/data:/data -v $(pwd)/tmp:/app/tmp \
+        --env-file $ATD_CRIS_CONFIG $ATD_DOCKER_IMAGE $RUN_COMMAND;"
+
+    echo $FINAL_COMMAND;
+    echo "--------------------------------------------------------------------";
 
     # Run Docker
-    docker run -it --rm -p $WEB_PDB_PORT:5555/tcp \
-        -v $(pwd)/app:/app -v $(pwd)/data:/data -v $(pwd)/tmp:/app/tmp \
-        --env-file $ATD_CRIS_CONFIG $ATD_DOCKER_IMAGE $FINAL_COMMAND;
+    eval ${FINAL_COMMAND};
 
     # Reload Run Script into memory
     source $(pwd)/runetl.sh;


### PR DESCRIPTION
Closes #517 

It fixes the ZSH compatibility issue when running commands like these: `app/process_hasura_import.py charges`. The purpose is to run app/process_hasura_import.py and pass to that python script the `charges` argument as a string.


To Test:

```
runetl ~/.ssh/atd-etl/etl.staging.env "app/process_test_run.py charges" 
```