### PR TITLE
Add updated_by to mutation and payload

### DIFF
--- a/atd-vze/src/queries/crashes.js
+++ b/atd-vze/src/queries/crashes.js
@@ -167,6 +167,7 @@ export const UPDATE_COORDS = gql`
     $geocodeProvider: Int
     $latitude: float8
     $longitude: float8
+    $updatedBy: String
   ) {
     update_atd_txdot_crashes(
       where: { crash_id: { _eq: $crashId } }
@@ -175,6 +176,7 @@ export const UPDATE_COORDS = gql`
         geocode_provider: $geocodeProvider
         latitude_primary: $latitude
         longitude_primary: $longitude
+        updated_by: $updatedBy
       }
     ) {
       returning {

--- a/atd-vze/src/views/Crashes/Maps/CrashEditCoordsMap.js
+++ b/atd-vze/src/views/Crashes/Maps/CrashEditCoordsMap.js
@@ -107,7 +107,9 @@ class CrashEditCoordsMap extends Component {
       crashId: this.props.crashId,
       latitude: this.state.markerLatitude,
       longitude: this.state.markerLongitude,
+      updatedBy: localStorage.getItem("hasura_user_email"),
     };
+
     this.props.client
       .mutate({
         mutation: UPDATE_COORDS,


### PR DESCRIPTION
Closes #491 

This PR adds the `updated_by` column to the GraphQL mutation tied to the map coordinates edit map. The payload was also updated to provide the user's email with the mutation. The change log now shows the email of the user who made an edit.

I also created issue #536 to address the details of the change log for a map edit.

### Change log after coordinates edit
![Screen Shot 2019-12-19 at 4 00 37 PM](https://user-images.githubusercontent.com/37249039/71213320-cd0fb500-2278-11ea-877c-e8d0f5d5d625.png)

### Log Details after coordinates edit
![Screen Shot 2019-12-19 at 3 45 10 PM](https://user-images.githubusercontent.com/37249039/71213101-5d012f00-2278-11ea-9cff-fca4e8505168.png)
