### PR TITLE
Update nonCR3 collision to location association script

### DIFF
--- a/atd-vzd/triggers/find_noncr3_collisions_for_location.sql
+++ b/atd-vzd/triggers/find_noncr3_collisions_for_location.sql
@@ -1,0 +1,18 @@
+CREATE OR REPLACE FUNCTION public.find_noncr3_collisions_for_location
+(id integer)
+ RETURNS SETOF atd_apd_blueform
+ LANGUAGE sql
+ STABLE
+AS $function$
+SELECT
+  *
+FROM
+  atd_apd_blueform AS blueform
+WHERE
+	ST_Contains((
+		SELECT
+  atd_loc.shape
+FROM atd_txdot_locations AS atd_loc
+WHERE
+			atd_loc.unique_id::INTEGER=id), ST_MakePoint (blueform.longitude, blueform.latitude))
+$function$


### PR DESCRIPTION
This script is a more performant method for doing bulk locations associations for non-CR3 collisions.

This SQL function has now been added to both staging & production DBs and added here for version control.

And this script has been executed on both staging and production DBs. 5,072 row effected in production.

Closes #483 