### PR TITLE
VZE: LocationCrashes table export data for Unit Description does not match table data

### DIFF
--- a/atd-vze/src/Components/GridExportData.js
+++ b/atd-vze/src/Components/GridExportData.js
@@ -66,38 +66,38 @@ const GridExportData = ({ query, columnsToExport, totalRecords }) => {
     // Handles:
     // 1. Nested objects
     // 2. Nested arrays of objects
-    const newData = data.map(row => {
-      // Look through each row for nested objects or arrays and move all to top level
-      Object.entries(row).forEach(([key, value]) => {
+    const flattenRow = (row, flattenedRow) => {
+      debugger;
+      Object.entries(row).forEach(([columnName, columnValue]) => {
         // Remove __typename from export (contains table name which is already in filename)
-        if (key === "__typename") {
-          delete row["__typename"];
-        } else if (Array.isArray(value)) {
+        if (columnName === "__typename") {
+          return;
+        } else if (typeof columnValue === "string") {
+          if (flattenedRow[columnName]) {
+            flattenedRow[
+              columnName
+            ] = `${flattenedRow[columnName]}, ${columnValue}`;
+          } else {
+            flattenedRow[columnName] = columnValue;
+          }
+        } else if (Array.isArray(columnValue)) {
           // If value is array, recursive call and handle objects in array
-          value = formatExportData(value);
-          value.forEach(object => {
-            Object.entries(object).forEach(([key, value]) => {
-              if (row[key]) {
-                // If top level already has this key, concat
-                row[key] = `${row[key]}, ${value}`;
-              } else {
-                // Else use spread to add to top level
-                row = { ...row, ...object };
-              }
-            });
-            // Delete nested data after added to top level
-            delete row[key];
-          });
-        } else if (typeof value === "object" && value !== null) {
-          // If value is object, remove __typename and move to top level, then delete
-          "__typename" in value && delete value["__typename"];
-          row = { ...row, ...value };
-          delete row[key];
+          flattenRow(columnValue, flattenedRow);
+        } else if (typeof columnValue === "object" && columnValue !== null) {
+          flattenRow(columnValue, flattenedRow);
         }
       });
-      return row;
+      return flattenedRow;
+    };
+
+    const flattenedData = data.map(row => {
+      // Look through each row for nested objects or arrays and move all to top level
+      let flattenedRow = {};
+      flattenedRow = flattenRow(row, flattenedRow);
+      debugger;
     });
-    return newData;
+
+    return flattenedData;
   };
 
   return (

--- a/atd-vze/src/Components/GridExportData.js
+++ b/atd-vze/src/Components/GridExportData.js
@@ -37,7 +37,7 @@ const GridExportData = ({ query, columnsToExport, totalRecords }) => {
   // Use .queryCSV to insert columnsToExport prop into query
   let [getExport, { loading, data }] = useLazyQuery(
     query.queryCSV(columnsToExport),
-    { fetchPolicy: "no-cache" }
+    { fetchPolicy: "no-cache" } // Temporary fix for https://github.com/apollographql/react-apollo/issues/3361
   );
 
   const toggleModal = () => setIsModalOpen(!isModalOpen);

--- a/atd-vze/src/Components/GridExportData.js
+++ b/atd-vze/src/Components/GridExportData.js
@@ -21,7 +21,7 @@ import {
 } from "reactstrap";
 import { AppSwitch } from "@coreui/react";
 
-const defaultRowsPerExport = 4000;
+const exportWarningLimit = 4000;
 
 const StyledSaveLink = styled.i`
   color: ${colors.info};
@@ -61,11 +61,11 @@ const GridExportData = ({ query, columnsToExport, totalRecords }) => {
 
   /**
    * Returns an array of objects (each object is a row and each key of that object is a column in the export file)
-   * @param {Array} Data returned from DB with nested data structures
+   * @param {array} data - Data returned from DB with nested data structures
    * @returns {array}
    */
   const formatExportData = data => {
-    // Moves nested keys to top level object (CSVLink uses each top level key as a column header)
+    // Move nested keys to top level object (CSVLink uses each top level key as a column header)
     const flattenRow = (row, flattenedRow) => {
       Object.entries(row).forEach(([columnName, columnValue]) => {
         // Ignore __typename (contains table name which is already in filename)
@@ -146,7 +146,7 @@ const GridExportData = ({ query, columnsToExport, totalRecords }) => {
               </Col>
             </Row>
           </FormGroup>
-          {query.limit > defaultRowsPerExport && (
+          {query.limit > exportWarningLimit && (
             <Alert color="danger">
               For larger downloads, please expect a delay while the CSV file is
               generated. This may take multiple minutes.

--- a/atd-vze/src/Components/GridExportData.js
+++ b/atd-vze/src/Components/GridExportData.js
@@ -21,6 +21,8 @@ import {
 } from "reactstrap";
 import { AppSwitch } from "@coreui/react";
 
+const defaultRowsPerExport = 4000;
+
 const StyledSaveLink = styled.i`
   color: ${colors.info};
   cursor: pointer;
@@ -63,9 +65,6 @@ const GridExportData = ({ query, columnsToExport, totalRecords }) => {
    */
   const formatExportData = data => {
     // Moves nested data to top level object (CSVLink uses each top level key as a column header)
-    // Handles:
-    // 1. Nested objects
-    // 2. Nested arrays of objects
     const flattenRow = (row, flattenedRow) => {
       Object.entries(row).forEach(([columnName, columnValue]) => {
         // Remove __typename from export (contains table name which is already in filename)
@@ -77,7 +76,7 @@ const GridExportData = ({ query, columnsToExport, totalRecords }) => {
         } else if (typeof columnValue === "object" && columnValue !== null) {
           // If value is array, recursive call and handle k/v pairs in object
           flattenRow(columnValue, flattenedRow);
-        } else if (!!columnValue) {
+        } else {
           // Do not return null values
           if (flattenedRow[columnName]) {
             flattenedRow[
@@ -91,12 +90,13 @@ const GridExportData = ({ query, columnsToExport, totalRecords }) => {
       return flattenedRow;
     };
 
+    // Flatten each row and return array of objects for CSVLink data
     const flattenedData = data.map(row => {
-      // Look through each row for nested objects or arrays and move all to top level
       let flattenedRow = {};
       flattenedRow = flattenRow(row, flattenedRow);
       return flattenedRow;
     });
+
     return flattenedData;
   };
 
@@ -145,7 +145,7 @@ const GridExportData = ({ query, columnsToExport, totalRecords }) => {
               </Col>
             </Row>
           </FormGroup>
-          {query.limit > 4000 && (
+          {query.limit > defaultRowsPerExport && (
             <Alert color="danger">
               For larger downloads, please expect a delay while the CSV file is
               generated. This may take multiple minutes.

--- a/atd-vze/src/Components/GridExportData.js
+++ b/atd-vze/src/Components/GridExportData.js
@@ -36,7 +36,8 @@ const GridExportData = ({ query, columnsToExport, totalRecords }) => {
 
   // Use .queryCSV to insert columnsToExport prop into query
   let [getExport, { loading, data }] = useLazyQuery(
-    query.queryCSV(columnsToExport)
+    query.queryCSV(columnsToExport),
+    { fetchPolicy: "no-cache" }
   );
 
   const toggleModal = () => setIsModalOpen(!isModalOpen);
@@ -64,20 +65,20 @@ const GridExportData = ({ query, columnsToExport, totalRecords }) => {
    * @returns {array}
    */
   const formatExportData = data => {
-    // Moves nested data to top level object (CSVLink uses each top level key as a column header)
+    // Moves nested keys to top level object (CSVLink uses each top level key as a column header)
     const flattenRow = (row, flattenedRow) => {
       Object.entries(row).forEach(([columnName, columnValue]) => {
-        // Remove __typename from export (contains table name which is already in filename)
+        // Ignore __typename (contains table name which is already in filename)
         if (columnName === "__typename") {
           return;
         } else if (Array.isArray(columnValue)) {
           // If value is array, recursive call and handle objects in array
           flattenRow(columnValue, flattenedRow);
         } else if (typeof columnValue === "object" && columnValue !== null) {
-          // If value is array, recursive call and handle k/v pairs in object
+          // If value is object, recursive call and handle k/v pairs in object
           flattenRow(columnValue, flattenedRow);
         } else {
-          // Do not return null values
+          // Handle key/value pairs, concat if column already exists
           if (flattenedRow[columnName]) {
             flattenedRow[
               columnName

--- a/atd-vze/src/Components/GridExportData.js
+++ b/atd-vze/src/Components/GridExportData.js
@@ -67,12 +67,18 @@ const GridExportData = ({ query, columnsToExport, totalRecords }) => {
     // 1. Nested objects
     // 2. Nested arrays of objects
     const flattenRow = (row, flattenedRow) => {
-      debugger;
       Object.entries(row).forEach(([columnName, columnValue]) => {
         // Remove __typename from export (contains table name which is already in filename)
         if (columnName === "__typename") {
           return;
-        } else if (typeof columnValue === "string") {
+        } else if (Array.isArray(columnValue)) {
+          // If value is array, recursive call and handle objects in array
+          flattenRow(columnValue, flattenedRow);
+        } else if (typeof columnValue === "object" && columnValue !== null) {
+          // If value is array, recursive call and handle k/v pairs in object
+          flattenRow(columnValue, flattenedRow);
+        } else if (!!columnValue) {
+          // Do not return null values
           if (flattenedRow[columnName]) {
             flattenedRow[
               columnName
@@ -80,11 +86,6 @@ const GridExportData = ({ query, columnsToExport, totalRecords }) => {
           } else {
             flattenedRow[columnName] = columnValue;
           }
-        } else if (Array.isArray(columnValue)) {
-          // If value is array, recursive call and handle objects in array
-          flattenRow(columnValue, flattenedRow);
-        } else if (typeof columnValue === "object" && columnValue !== null) {
-          flattenRow(columnValue, flattenedRow);
         }
       });
       return flattenedRow;
@@ -94,9 +95,8 @@ const GridExportData = ({ query, columnsToExport, totalRecords }) => {
       // Look through each row for nested objects or arrays and move all to top level
       let flattenedRow = {};
       flattenedRow = flattenRow(row, flattenedRow);
-      debugger;
+      return flattenedRow;
     });
-
     return flattenedData;
   };
 

--- a/atd-vze/src/Components/GridTable.js
+++ b/atd-vze/src/Components/GridTable.js
@@ -292,13 +292,13 @@ const GridTable = ({
     for (let item of section) {
       let val = responseValue(item, keys);
 
-      if (val !== null && map.has(val) === false) {
+      if (val !== null) {
         map.set(val, true);
         result.push(val);
       }
     }
     // Merge all into a string
-    return result.join(",");
+    return result.join(", ");
   };
 
   /**

--- a/atd-vze/src/queries/crashes.js
+++ b/atd-vze/src/queries/crashes.js
@@ -280,16 +280,16 @@ export const UPDATE_CRASH = gql`
 `;
 
 export const crashQueryExportFields = `
+crash_id
+case_id
 active_school_zone_fl
 apd_confirmed_death_count
 approval_date
 approved_by
 at_intrsct_fl
-case_id
 city_id
 crash_date
 crash_fatal_fl
-crash_id
 crash_sev_id
 crash_speed_limit
 crash_time


### PR DESCRIPTION
Closes #557 

This PR unifies the presentation of Crash Unit Description between `GridTable` and the .csv export from `GridExportData`.

The code to expose nested data in the GraphQL response was refactored to focus on each row and then handle each data type case for columns in the row (ignore, non-nested, nested array, and nested object). `GridTable` was then modified to display each unit description instead of the types of unit descriptions in a crash (`MOTOR VEHICLE, PEDESTRIAN, PEDESTRIAN` instead of `MOTOR VEHICLE, PEDESTRIAN`).

### Crashes Table compared to export for Crash ID: 14104007
![14104007](https://user-images.githubusercontent.com/37249039/71633652-29f55e80-2bdb-11ea-9787-47d25f23f0d5.png)

### Crash view for Crash ID: 14104007 (Units accordion)
![14104007 crash view](https://user-images.githubusercontent.com/37249039/71633655-2e217c00-2bdb-11ea-9e4a-ccb602c23e24.png)
