### PR TITLE
622 update month based on current month

### DIFF
--- a/atd-vzv/src/constants/time.js
+++ b/atd-vzv/src/constants/time.js
@@ -6,6 +6,7 @@ export const oneYearAgo = moment()
   .subtract(1, "year")
   .format("YYYY-MM-DD");
 export const todayMonthYear = moment().format("-MM-DD");
+export const thisMonth = moment().format("MM");
 export const thisYear = moment().format("YYYY");
 export const lastYear = moment()
   .subtract(1, "year")

--- a/atd-vzv/src/views/summary/FatalitiesMultiYear.js
+++ b/atd-vzv/src/views/summary/FatalitiesMultiYear.js
@@ -66,23 +66,22 @@ const FatalitiesMultiYear = () => {
   };
 
   const renderHeader = () => {
+    let deathArray;
+    let year;
     if (thisMonth > "01") {
-      return (
-        <h6 style={{ color: colors.blue, textAlign: "center" }}>
-          As of {lastMonthString}, there have been{" "}
-          <strong>{calculateYearlyTotals(thisYearDeathArray)}</strong> traffic
-          fatalities in {thisYear}.
-        </h6>
-      );
+      deathArray = thisYearDeathArray;
+      year = thisYear;
     } else {
-      return (
-        <h6 style={{ color: colors.blue, textAlign: "center" }}>
-          As of {lastMonthString}, there have been{" "}
-          <strong>{calculateYearlyTotals(lastYearDeathArray)}</strong> traffic
-          fatalities in {lastYear}.
-        </h6>
-      );
+      deathArray = lastYearDeathArray;
+      year = lastYear;
     }
+    return (
+      <h6 style={{ color: colors.blue, textAlign: "center" }}>
+        As of {lastMonthString}, there have been{" "}
+        <strong>{calculateYearlyTotals(deathArray)}</strong> traffic fatalities
+        in {year}.
+      </h6>
+    );
   };
 
   useEffect(() => {

--- a/atd-vzv/src/views/summary/FatalitiesMultiYear.js
+++ b/atd-vzv/src/views/summary/FatalitiesMultiYear.js
@@ -100,16 +100,12 @@ const FatalitiesMultiYear = () => {
       let yearsAgoDate = moment()
         .subtract(yearsAgo, "year")
         .format("YYYY");
-      console.log(
-        `${crashEndpointUrl}?$where=death_cnt > 0 AND crash_date between '${yearsAgoDate}-01-01T00:00:00' and '${yearsAgoDate}-12-31T23:59:59'`
-      );
       return `${crashEndpointUrl}?$where=death_cnt > 0 AND crash_date between '${yearsAgoDate}-01-01T00:00:00' and '${yearsAgoDate}-12-31T23:59:59'`;
     };
 
     // If there is a full month of data available for the current year (i.e., we are past January),
     // fetch records for this year through last month
     if (thisMonth > "01") {
-      console.log(thisYearUrl);
       axios.get(thisYearUrl).then(res => {
         setThisYearDeathArray(
           calculateMonthlyTotals(res, lastMonthLastDayDate)

--- a/atd-vzv/src/views/summary/FatalitiesMultiYear.js
+++ b/atd-vzv/src/views/summary/FatalitiesMultiYear.js
@@ -5,7 +5,7 @@ import moment from "moment";
 import { Line } from "react-chartjs-2";
 import { Container, Row, Col } from "reactstrap";
 import { crashEndpointUrl } from "./queries/socrataQueries";
-import { thisYear } from "../../constants/time";
+import { thisMonth, thisYear, lastYear } from "../../constants/time";
 import { colors } from "../../constants/colors";
 
 const FatalitiesMultiYear = () => {
@@ -31,6 +31,7 @@ const FatalitiesMultiYear = () => {
   };
 
   const calculateMonthlyTotals = (data, dateString) => {
+    console.log(dateString);
     // Limit returned data to months of data available and prevent line from zeroing out
     // If dataString is passed in, convert to month string and use to truncate monthIntegerArray
     const monthLimit = dateString ? moment(dateString).format("MM") : "12";
@@ -73,9 +74,22 @@ const FatalitiesMultiYear = () => {
       `${thisYear}-${lastMonthNumber}`,
       "YYYY-MM"
     ).daysInMonth();
-    const lastMonthLastDayDate = `${thisYear}-${lastMonthNumber}-${lastMonthLastDayNumber}`;
 
-    const thisYearUrl = `${crashEndpointUrl}?$where=death_cnt > 0 AND crash_date between '${thisYear}-01-01T00:00:00' and '${lastMonthLastDayDate}T23:59:59'`;
+    let lastMonthLastDayDate;
+    let thisYearUrl;
+
+    if (thisMonth === "01") {
+      console.log("It's January");
+      const thisYear = "2019";
+      lastMonthLastDayDate = `${lastYear}-${lastMonthNumber}-${lastMonthLastDayNumber}`;
+      thisYearUrl = `${crashEndpointUrl}?$where=death_cnt > 0 AND crash_date between '${lastYear}-01-01T00:00:00' and '${lastMonthLastDayDate}T23:59:59'`;
+    } else {
+      console.log("It's not January");
+      lastMonthLastDayDate = `${thisYear}-${lastMonthNumber}-${lastMonthLastDayNumber}`;
+      thisYearUrl = `${crashEndpointUrl}?$where=death_cnt > 0 AND crash_date between '${thisYear}-01-01T00:00:00' and '${lastMonthLastDayDate}T23:59:59'`;
+    };
+
+    console.log(thisYearUrl)
 
     const getFatalitiesByYearsAgoUrl = yearsAgo => {
       let yearsAgoDate = moment()


### PR DESCRIPTION
Fixes #622 

Fixes issue by only querying and rendering data for current year if it is past January. If this looks good, I can implement this fix on the other two VZV components.

<img width="713" alt="Screen Shot 2020-01-22 at 5 40 18 PM" src="https://user-images.githubusercontent.com/35410637/72944372-544fbd00-3d3e-11ea-9a31-2fde192af5b6.png">
