### PR TITLE
VZV | Map | ASMP Street Level Overlay

### DIFF
--- a/atd-vzv/src/constants/colors.js
+++ b/atd-vzv/src/constants/colors.js
@@ -18,5 +18,10 @@ export const colors = {
   redGradient2Of5: "#fcae91",
   redGradient3Of5: "#fb6a4a",
   redGradient4Of5: "#de2d26",
-  redGradient5Of5: "#a50f15"
+  redGradient5Of5: "#a50f15",
+  mapAsmp1: "#F9AE91",
+  mapAsmp2: "#F66A4A",
+  mapAsmp3: "#E60000",
+  mapAsmp4: "#A50F15",
+  mapAsmp5: "#1B519D"
 };

--- a/atd-vzv/src/utils/store.js
+++ b/atd-vzv/src/utils/store.js
@@ -10,11 +10,13 @@ export default ({ children }) => {
     start: mapStartDate,
     end: mapEndDate
   });
+  const [mapOverlay, setMapOverlay] = useState("");
 
   const store = {
     mapFilters: [mapFilters, setMapFilters],
     mapDateRange: [mapDateRange, setMapDateRange],
-    sidebarToggle: [isOpen, setIsOpen]
+    sidebarToggle: [isOpen, setIsOpen],
+    mapOverlay: [mapOverlay, setMapOverlay]
   };
 
   return (

--- a/atd-vzv/src/utils/store.js
+++ b/atd-vzv/src/utils/store.js
@@ -10,7 +10,10 @@ export default ({ children }) => {
     start: mapStartDate,
     end: mapEndDate
   });
-  const [mapOverlay, setMapOverlay] = useState("");
+  const [mapOverlay, setMapOverlay] = useState({
+    name: "",
+    options: []
+  });
 
   const store = {
     mapFilters: [mapFilters, setMapFilters],

--- a/atd-vzv/src/views/map/Map.js
+++ b/atd-vzv/src/views/map/Map.js
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from "react";
 import { StoreContext } from "../../utils/store";
 import ReactMapGL, { Source, Layer } from "react-map-gl";
 import { createMapDataUrl } from "./helpers";
-import { dataLayer } from "./map-style";
+import { crashDataLayer, asmpDataLayer } from "./map-style";
 import axios from "axios";
 
 import { Card, CardBody, CardText } from "reactstrap";
@@ -40,10 +40,12 @@ const Map = () => {
   } = React.useContext(StoreContext);
 
   useEffect(() => {
-    const overlayUrl = `https://services.arcgis.com/0L95CJ0VTaxqcmED/ArcGIS/rest/services/TRANSPORTATION_asmp_street_network/FeatureServer/0/query?where=1=1&f=geojson`;
-    // TODO: Need to get street level metadata from ArcGIS in order to style the layer based on level
-    // Street Level 2
-    // https://services.arcgis.com/0L95CJ0VTaxqcmED/ArcGIS/rest/services/TRANSPORTATION_asmp_street_network/FeatureServer/0/query?where=STREET_LEVEL=2&f=geojson
+    const overlayUrl = `https://services.arcgis.com/0L95CJ0VTaxqcmED/ArcGIS/rest/services/TRANSPORTATION_asmp_street_network/FeatureServer/0/query?where=STREET_LEVEL%20%3E=%200&orderByFields=OBJECTID%20ASC&resultRecordCount=1000&resultOffset=0&outFields=*&f=geojson`;
+    // TODO: Use viewport as parameter to query ArcGIS? Don't need to query all records for entire map at once
+    // Url needs &outFields=* in query to get all metadata
+    // Street Level >= 0 & orderByFields=OBJECTID ASC & 1000 results with 0 offset
+    // https://services.arcgis.com/0L95CJ0VTaxqcmED/ArcGIS/rest/services/TRANSPORTATION_asmp_street_network/FeatureServer/0/query?where=STREET_LEVEL%20%3E=%200&orderByFields=OBJECTID%20ASC&resultRecordCount=1000&resultOffset=0&outFields=*&f=geojson
+    // Paging through data https://github.com/koopjs/FeatureServer/issues/141
     axios.get(overlayUrl).then(res => {
       setOverlay(res.data);
     });
@@ -105,14 +107,14 @@ const Map = () => {
       getCursor={_getCursor}
       onHover={_onHover}
     >
-      {!!mapData && (
+      {/* {!!mapData && (
         <Source type="geojson" data={mapData}>
-          <Layer {...dataLayer} />
+          <Layer {...crashDataLayer} />
         </Source>
-      )}
+      )} */}
       {!!overlay && (
         <Source type="geojson" data={overlay}>
-          <Layer {...dataLayer} />
+          <Layer {...asmpDataLayer} />
         </Source>
       )}
       {hoveredFeature && _renderTooltip()}

--- a/atd-vzv/src/views/map/Map.js
+++ b/atd-vzv/src/views/map/Map.js
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from "react";
 import { StoreContext } from "../../utils/store";
 import ReactMapGL, { Source, Layer } from "react-map-gl";
 import { createMapDataUrl } from "./helpers";
-import { crashDataLayer, asmpDataLayer } from "./map-style";
+import { crashDataLayer, buildAsmpLayers, asmpConfig } from "./map-style";
 import axios from "axios";
 
 import { Card, CardBody, CardText } from "reactstrap";
@@ -85,116 +85,6 @@ const Map = () => {
     );
   };
 
-  const asmp5Layer = {
-    id: "asmp_street_network/5",
-    type: "line",
-    source: {
-      type: "vector",
-      tiles: [
-        "https://tiles.arcgis.com/tiles/0L95CJ0VTaxqcmED/arcgis/rest/services/ASMP_Streets_VectorTile/VectorTileServer/tile/{z}/{y}/{x}.pbf"
-      ]
-    },
-    "source-layer": "asmp_street_network",
-    filter: ["==", "_symbol", 4],
-    layout: {
-      "line-cap": "round",
-      "line-join": "round",
-      visibility: `${overlay === "asmp" ? "visible" : "none"}`
-    },
-    paint: {
-      "line-color": "#1B519D",
-      "line-width": 2
-    }
-  };
-
-  const asmp4Layer = {
-    id: "asmp_street_network/4",
-    type: "line",
-    source: {
-      type: "vector",
-      tiles: [
-        "https://tiles.arcgis.com/tiles/0L95CJ0VTaxqcmED/arcgis/rest/services/ASMP_Streets_VectorTile/VectorTileServer/tile/{z}/{y}/{x}.pbf"
-      ]
-    },
-    "source-layer": "asmp_street_network",
-    filter: ["==", "_symbol", 3],
-    layout: {
-      "line-cap": "round",
-      "line-join": "round",
-      visibility: `${overlay === "asmp" ? "visible" : "none"}`
-    },
-    paint: {
-      "line-color": "#A50F15",
-      "line-width": 2
-    }
-  };
-
-  const asmp3Layer = {
-    id: "asmp_street_network/3",
-    type: "line",
-    source: {
-      type: "vector",
-      tiles: [
-        "https://tiles.arcgis.com/tiles/0L95CJ0VTaxqcmED/arcgis/rest/services/ASMP_Streets_VectorTile/VectorTileServer/tile/{z}/{y}/{x}.pbf"
-      ]
-    },
-    "source-layer": "asmp_street_network",
-    filter: ["==", "_symbol", 2],
-    layout: {
-      "line-cap": "round",
-      "line-join": "round",
-      visibility: `${overlay === "asmp" ? "visible" : "none"}`
-    },
-    paint: {
-      "line-color": "#E60000",
-      "line-width": 2
-    }
-  };
-
-  const asmp2Layer = {
-    id: "asmp_street_network/2",
-    type: "line",
-    source: {
-      type: "vector",
-      tiles: [
-        "https://tiles.arcgis.com/tiles/0L95CJ0VTaxqcmED/arcgis/rest/services/ASMP_Streets_VectorTile/VectorTileServer/tile/{z}/{y}/{x}.pbf"
-      ]
-    },
-    "source-layer": "asmp_street_network",
-    filter: ["==", "_symbol", 1],
-    layout: {
-      "line-cap": "round",
-      "line-join": "round",
-      visibility: `${overlay === "asmp" ? "visible" : "none"}`
-    },
-    paint: {
-      "line-color": "#F66A4A",
-      "line-width": 2
-    }
-  };
-
-  const asmp1Layer = {
-    id: "asmp_street_network/1",
-    type: "line",
-    source: {
-      type: "vector",
-      tiles: [
-        "https://tiles.arcgis.com/tiles/0L95CJ0VTaxqcmED/arcgis/rest/services/ASMP_Streets_VectorTile/VectorTileServer/tile/{z}/{y}/{x}.pbf"
-      ]
-    },
-    "source-layer": "asmp_street_network",
-    filter: ["==", "_symbol", 0],
-    layout: {
-      "line-cap": "round",
-      "line-join": "round",
-      visibility: `${overlay === "asmp" ? "visible" : "none"}`
-    },
-    paint: {
-      "line-color": "#F9AE91",
-      "line-width": 2
-    }
-  };
-
   return (
     <ReactMapGL
       {...viewport}
@@ -210,12 +100,11 @@ const Map = () => {
           <Layer {...crashDataLayer} />
         </Source>
       )}
-      {/* ASMP Street Levels */}
-      <Layer {...asmp5Layer} />
-      <Layer {...asmp4Layer} />
-      <Layer {...asmp3Layer} />
-      <Layer {...asmp2Layer} />
-      <Layer {...asmp1Layer} />
+
+      {/* ASMP Street Level Layers */}
+      {buildAsmpLayers(asmpConfig, overlay)}
+
+      {/* Render crash point tooltips */}
       {hoveredFeature && _renderTooltip()}
     </ReactMapGL>
   );

--- a/atd-vzv/src/views/map/Map.js
+++ b/atd-vzv/src/views/map/Map.js
@@ -111,6 +111,27 @@ const Map = () => {
     );
   };
 
+  const asmpLayer = {
+    id: "asmp_street_network/4",
+    type: "line",
+    source: {
+      type: "vector",
+      tiles: [
+        "https://tiles.arcgis.com/tiles/0L95CJ0VTaxqcmED/arcgis/rest/services/ASMP_Streets_VectorTile/VectorTileServer/tile/{z}/{y}/{x}.pbf"
+      ]
+    },
+    "source-layer": "asmp_street_network",
+    filter: ["==", "_symbol", 4],
+    layout: {
+      "line-cap": "round",
+      "line-join": "round"
+    },
+    paint: {
+      "line-color": "#1B519D",
+      "line-width": 2.66667
+    }
+  };
+
   return (
     <ReactMapGL
       {...viewport}
@@ -121,7 +142,7 @@ const Map = () => {
       getCursor={_getCursor}
       onHover={_onHover}
     >
-      {!!overlayDataFeatures && overlay === "asmp" && (
+      {/* {!!overlayDataFeatures && overlay === "asmp" && (
         <Source
           id="asmp"
           type="geojson"
@@ -129,7 +150,8 @@ const Map = () => {
         >
           <Layer beforeId="crashes" {...asmpDataLayer} />
         </Source>
-      )}
+      )} */}
+      <Layer {...asmpLayer} />
       {!!mapData && (
         <Source id="crashes" type="geojson" data={mapData}>
           <Layer {...crashDataLayer} />

--- a/atd-vzv/src/views/map/Map.js
+++ b/atd-vzv/src/views/map/Map.js
@@ -32,38 +32,12 @@ const Map = () => {
 
   const [mapData, setMapData] = useState("");
   const [hoveredFeature, setHoveredFeature] = useState(null);
-  const [overlayDataFeatures, setOverlayData] = useState([]);
 
   const {
     mapFilters: [filters],
     mapDateRange: [dateRange],
     mapOverlay: [overlay]
   } = React.useContext(StoreContext);
-
-  useEffect(() => {
-    // TODO: Use viewport as parameter to query ArcGIS? Don't need to query all records for entire map at once
-    // Url needs &outFields=* in query to get all metadata
-    // Street Level >= 0 & orderByFields=OBJECTID ASC & 1000 results with 0 offset
-    let offset = 0;
-    const getOverlayData = offset => {
-      const overlayUrl = `https://services.arcgis.com/0L95CJ0VTaxqcmED/ArcGIS/rest/services/TRANSPORTATION_asmp_street_network/FeatureServer/0/query?where=STREET_LEVEL%20%3E=%203&orderByFields=OBJECTID%20ASC&resultRecordCount=1000&resultOffset=${offset}&outFields=STREET_LEVEL,NAME&f=geojson`;
-      axios.get(overlayUrl).then(res => {
-        const transferLimitResult =
-          (res.data.properties && res.data.properties.exceededTransferLimit) ||
-          false;
-        if (transferLimitResult) {
-          offset += 1000;
-          const newFeatures = res.data.features;
-          setOverlayData(prevState => [...prevState, ...newFeatures]);
-          setTimeout(() => {
-            getOverlayData(offset);
-          }, 1000);
-        }
-      });
-    };
-
-    getOverlayData(offset);
-  }, []);
 
   // Fetch initial crash data and refetch upon filters change
   useEffect(() => {
@@ -111,8 +85,8 @@ const Map = () => {
     );
   };
 
-  const asmpLayer = {
-    id: "asmp_street_network/4",
+  const asmp5Layer = {
+    id: "asmp_street_network/5",
     type: "line",
     source: {
       type: "vector",
@@ -124,11 +98,100 @@ const Map = () => {
     filter: ["==", "_symbol", 4],
     layout: {
       "line-cap": "round",
-      "line-join": "round"
+      "line-join": "round",
+      visibility: `${overlay === "asmp" ? "visible" : "none"}`
     },
     paint: {
       "line-color": "#1B519D",
-      "line-width": 2.66667
+      "line-width": 2
+    }
+  };
+
+  const asmp4Layer = {
+    id: "asmp_street_network/4",
+    type: "line",
+    source: {
+      type: "vector",
+      tiles: [
+        "https://tiles.arcgis.com/tiles/0L95CJ0VTaxqcmED/arcgis/rest/services/ASMP_Streets_VectorTile/VectorTileServer/tile/{z}/{y}/{x}.pbf"
+      ]
+    },
+    "source-layer": "asmp_street_network",
+    filter: ["==", "_symbol", 3],
+    layout: {
+      "line-cap": "round",
+      "line-join": "round",
+      visibility: `${overlay === "asmp" ? "visible" : "none"}`
+    },
+    paint: {
+      "line-color": "#A50F15",
+      "line-width": 2
+    }
+  };
+
+  const asmp3Layer = {
+    id: "asmp_street_network/3",
+    type: "line",
+    source: {
+      type: "vector",
+      tiles: [
+        "https://tiles.arcgis.com/tiles/0L95CJ0VTaxqcmED/arcgis/rest/services/ASMP_Streets_VectorTile/VectorTileServer/tile/{z}/{y}/{x}.pbf"
+      ]
+    },
+    "source-layer": "asmp_street_network",
+    filter: ["==", "_symbol", 2],
+    layout: {
+      "line-cap": "round",
+      "line-join": "round",
+      visibility: `${overlay === "asmp" ? "visible" : "none"}`
+    },
+    paint: {
+      "line-color": "#E60000",
+      "line-width": 2
+    }
+  };
+
+  const asmp2Layer = {
+    id: "asmp_street_network/2",
+    type: "line",
+    source: {
+      type: "vector",
+      tiles: [
+        "https://tiles.arcgis.com/tiles/0L95CJ0VTaxqcmED/arcgis/rest/services/ASMP_Streets_VectorTile/VectorTileServer/tile/{z}/{y}/{x}.pbf"
+      ]
+    },
+    "source-layer": "asmp_street_network",
+    filter: ["==", "_symbol", 1],
+    layout: {
+      "line-cap": "round",
+      "line-join": "round",
+      visibility: `${overlay === "asmp" ? "visible" : "none"}`
+    },
+    paint: {
+      "line-color": "#F66A4A",
+      "line-width": 2
+    }
+  };
+
+  const asmp1Layer = {
+    id: "asmp_street_network/1",
+    type: "line",
+    source: {
+      type: "vector",
+      tiles: [
+        "https://tiles.arcgis.com/tiles/0L95CJ0VTaxqcmED/arcgis/rest/services/ASMP_Streets_VectorTile/VectorTileServer/tile/{z}/{y}/{x}.pbf"
+      ]
+    },
+    "source-layer": "asmp_street_network",
+    filter: ["==", "_symbol", 0],
+    layout: {
+      "line-cap": "round",
+      "line-join": "round",
+      visibility: `${overlay === "asmp" ? "visible" : "none"}`
+    },
+    paint: {
+      "line-color": "#F9AE91",
+      "line-width": 2
     }
   };
 
@@ -142,21 +205,17 @@ const Map = () => {
       getCursor={_getCursor}
       onHover={_onHover}
     >
-      {/* {!!overlayDataFeatures && overlay === "asmp" && (
-        <Source
-          id="asmp"
-          type="geojson"
-          data={{ type: "FeatureCollection", features: overlayDataFeatures }}
-        >
-          <Layer beforeId="crashes" {...asmpDataLayer} />
-        </Source>
-      )} */}
-      <Layer {...asmpLayer} />
       {!!mapData && (
         <Source id="crashes" type="geojson" data={mapData}>
           <Layer {...crashDataLayer} />
         </Source>
       )}
+      {/* ASMP Street Levels */}
+      <Layer {...asmp5Layer} />
+      <Layer {...asmp4Layer} />
+      <Layer {...asmp3Layer} />
+      <Layer {...asmp2Layer} />
+      <Layer {...asmp1Layer} />
       {hoveredFeature && _renderTooltip()}
     </ReactMapGL>
   );

--- a/atd-vzv/src/views/map/Map.js
+++ b/atd-vzv/src/views/map/Map.js
@@ -32,7 +32,7 @@ const Map = () => {
 
   const [mapData, setMapData] = useState("");
   const [hoveredFeature, setHoveredFeature] = useState(null);
-  const [overlay, setOverlay] = useState("");
+  const [overlayDataFeatures, setOverlayData] = useState([]);
 
   const {
     mapFilters: [filters],
@@ -40,15 +40,38 @@ const Map = () => {
   } = React.useContext(StoreContext);
 
   useEffect(() => {
-    const overlayUrl = `https://services.arcgis.com/0L95CJ0VTaxqcmED/ArcGIS/rest/services/TRANSPORTATION_asmp_street_network/FeatureServer/0/query?where=STREET_LEVEL%20%3E=%200&orderByFields=OBJECTID%20ASC&resultRecordCount=1000&resultOffset=0&outFields=*&f=geojson`;
     // TODO: Use viewport as parameter to query ArcGIS? Don't need to query all records for entire map at once
     // Url needs &outFields=* in query to get all metadata
     // Street Level >= 0 & orderByFields=OBJECTID ASC & 1000 results with 0 offset
     // https://services.arcgis.com/0L95CJ0VTaxqcmED/ArcGIS/rest/services/TRANSPORTATION_asmp_street_network/FeatureServer/0/query?where=STREET_LEVEL%20%3E=%200&orderByFields=OBJECTID%20ASC&resultRecordCount=1000&resultOffset=0&outFields=*&f=geojson
     // Paging through data https://github.com/koopjs/FeatureServer/issues/141
-    axios.get(overlayUrl).then(res => {
-      setOverlay(res.data);
-    });
+
+    let offset = 0;
+    const getOverlayData = offset => {
+      const overlayUrl = `https://services.arcgis.com/0L95CJ0VTaxqcmED/ArcGIS/rest/services/TRANSPORTATION_asmp_street_network/FeatureServer/0/query?where=STREET_LEVEL%20%3E=%200&orderByFields=OBJECTID%20ASC&resultRecordCount=1000&resultOffset=${offset}&outFields=*&f=geojson`;
+      axios.get(overlayUrl).then(res => {
+        const transferLimitResult =
+          (res.data.properties && res.data.properties.exceededTransferLimit) ||
+          false;
+        if (offset === 0) {
+          offset += 1000;
+          const newFeatures = res.data.features;
+          setOverlayData(prevState => [...prevState, ...newFeatures]);
+          setTimeout(() => {
+            getOverlayData(offset);
+          }, 1000);
+        } else if (transferLimitResult && offset >= 1000) {
+          offset += 1000;
+          const newFeatures = res.data.features;
+          setOverlayData(prevState => [...prevState, ...newFeatures]);
+          setTimeout(() => {
+            getOverlayData(offset);
+          }, 1000);
+        }
+      });
+    };
+
+    getOverlayData(offset);
   }, []);
 
   // Fetch initial crash data and refetch upon filters change
@@ -112,8 +135,11 @@ const Map = () => {
           <Layer {...crashDataLayer} />
         </Source>
       )} */}
-      {!!overlay && (
-        <Source type="geojson" data={overlay}>
+      {!!overlayDataFeatures && (
+        <Source
+          type="geojson"
+          data={{ type: "FeatureCollection", features: overlayDataFeatures }}
+        >
           <Layer {...asmpDataLayer} />
         </Source>
       )}

--- a/atd-vzv/src/views/map/Map.js
+++ b/atd-vzv/src/views/map/Map.js
@@ -43,24 +43,14 @@ const Map = () => {
     // TODO: Use viewport as parameter to query ArcGIS? Don't need to query all records for entire map at once
     // Url needs &outFields=* in query to get all metadata
     // Street Level >= 0 & orderByFields=OBJECTID ASC & 1000 results with 0 offset
-    // https://services.arcgis.com/0L95CJ0VTaxqcmED/ArcGIS/rest/services/TRANSPORTATION_asmp_street_network/FeatureServer/0/query?where=STREET_LEVEL%20%3E=%200&orderByFields=OBJECTID%20ASC&resultRecordCount=1000&resultOffset=0&outFields=*&f=geojson
-    // Paging through data https://github.com/koopjs/FeatureServer/issues/141
-
     let offset = 0;
     const getOverlayData = offset => {
-      const overlayUrl = `https://services.arcgis.com/0L95CJ0VTaxqcmED/ArcGIS/rest/services/TRANSPORTATION_asmp_street_network/FeatureServer/0/query?where=STREET_LEVEL%20%3E=%200&orderByFields=OBJECTID%20ASC&resultRecordCount=1000&resultOffset=${offset}&outFields=*&f=geojson`;
+      const overlayUrl = `https://services.arcgis.com/0L95CJ0VTaxqcmED/ArcGIS/rest/services/TRANSPORTATION_asmp_street_network/FeatureServer/0/query?where=STREET_LEVEL%20%3E=%204&orderByFields=OBJECTID%20ASC&resultRecordCount=1000&resultOffset=${offset}&outFields=STREET_LEVEL,NAME&f=geojson`;
       axios.get(overlayUrl).then(res => {
         const transferLimitResult =
           (res.data.properties && res.data.properties.exceededTransferLimit) ||
           false;
-        if (offset === 0) {
-          offset += 1000;
-          const newFeatures = res.data.features;
-          setOverlayData(prevState => [...prevState, ...newFeatures]);
-          setTimeout(() => {
-            getOverlayData(offset);
-          }, 1000);
-        } else if (transferLimitResult && offset >= 1000) {
+        if (transferLimitResult) {
           offset += 1000;
           const newFeatures = res.data.features;
           setOverlayData(prevState => [...prevState, ...newFeatures]);
@@ -92,7 +82,7 @@ const Map = () => {
       srcEvent: { offsetX, offsetY }
     } = event;
     const hoveredFeature =
-      features && features.find(f => f.layer.id === "data");
+      features && features.find(f => f.layer.id === "crashes");
     setHoveredFeature({ feature: hoveredFeature, x: offsetX, y: offsetY });
   };
 
@@ -130,17 +120,18 @@ const Map = () => {
       getCursor={_getCursor}
       onHover={_onHover}
     >
-      {/* {!!mapData && (
-        <Source type="geojson" data={mapData}>
-          <Layer {...crashDataLayer} />
-        </Source>
-      )} */}
       {!!overlayDataFeatures && (
         <Source
+          id="asmp"
           type="geojson"
           data={{ type: "FeatureCollection", features: overlayDataFeatures }}
         >
           <Layer {...asmpDataLayer} />
+        </Source>
+      )}
+      {!!mapData && (
+        <Source id="crashes" type="geojson" data={mapData}>
+          <Layer {...crashDataLayer} />
         </Source>
       )}
       {hoveredFeature && _renderTooltip()}

--- a/atd-vzv/src/views/map/Map.js
+++ b/atd-vzv/src/views/map/Map.js
@@ -36,7 +36,8 @@ const Map = () => {
 
   const {
     mapFilters: [filters],
-    mapDateRange: [dateRange]
+    mapDateRange: [dateRange],
+    mapOverlay: [overlay]
   } = React.useContext(StoreContext);
 
   useEffect(() => {
@@ -45,7 +46,7 @@ const Map = () => {
     // Street Level >= 0 & orderByFields=OBJECTID ASC & 1000 results with 0 offset
     let offset = 0;
     const getOverlayData = offset => {
-      const overlayUrl = `https://services.arcgis.com/0L95CJ0VTaxqcmED/ArcGIS/rest/services/TRANSPORTATION_asmp_street_network/FeatureServer/0/query?where=STREET_LEVEL%20%3E=%204&orderByFields=OBJECTID%20ASC&resultRecordCount=1000&resultOffset=${offset}&outFields=STREET_LEVEL,NAME&f=geojson`;
+      const overlayUrl = `https://services.arcgis.com/0L95CJ0VTaxqcmED/ArcGIS/rest/services/TRANSPORTATION_asmp_street_network/FeatureServer/0/query?where=STREET_LEVEL%20%3E=%203&orderByFields=OBJECTID%20ASC&resultRecordCount=1000&resultOffset=${offset}&outFields=STREET_LEVEL,NAME&f=geojson`;
       axios.get(overlayUrl).then(res => {
         const transferLimitResult =
           (res.data.properties && res.data.properties.exceededTransferLimit) ||
@@ -120,13 +121,13 @@ const Map = () => {
       getCursor={_getCursor}
       onHover={_onHover}
     >
-      {!!overlayDataFeatures && (
+      {!!overlayDataFeatures && overlay === "asmp" && (
         <Source
           id="asmp"
           type="geojson"
           data={{ type: "FeatureCollection", features: overlayDataFeatures }}
         >
-          <Layer {...asmpDataLayer} />
+          <Layer beforeId="crashes" {...asmpDataLayer} />
         </Source>
       )}
       {!!mapData && (

--- a/atd-vzv/src/views/map/Map.js
+++ b/atd-vzv/src/views/map/Map.js
@@ -32,11 +32,22 @@ const Map = () => {
 
   const [mapData, setMapData] = useState("");
   const [hoveredFeature, setHoveredFeature] = useState(null);
+  const [overlay, setOverlay] = useState("");
 
   const {
     mapFilters: [filters],
     mapDateRange: [dateRange]
   } = React.useContext(StoreContext);
+
+  useEffect(() => {
+    const overlayUrl = `https://services.arcgis.com/0L95CJ0VTaxqcmED/ArcGIS/rest/services/TRANSPORTATION_asmp_street_network/FeatureServer/0/query?where=1=1&f=geojson`;
+    // TODO: Need to get street level metadata from ArcGIS in order to style the layer based on level
+    // Street Level 2
+    // https://services.arcgis.com/0L95CJ0VTaxqcmED/ArcGIS/rest/services/TRANSPORTATION_asmp_street_network/FeatureServer/0/query?where=STREET_LEVEL=2&f=geojson
+    axios.get(overlayUrl).then(res => {
+      setOverlay(res.data);
+    });
+  }, []);
 
   // Fetch initial crash data and refetch upon filters change
   useEffect(() => {
@@ -96,6 +107,11 @@ const Map = () => {
     >
       {!!mapData && (
         <Source type="geojson" data={mapData}>
+          <Layer {...dataLayer} />
+        </Source>
+      )}
+      {!!overlay && (
+        <Source type="geojson" data={overlay}>
           <Layer {...dataLayer} />
         </Source>
       )}

--- a/atd-vzv/src/views/map/map-style.js
+++ b/atd-vzv/src/views/map/map-style.js
@@ -56,7 +56,7 @@ export const buildAsmpLayers = (config, overlay) =>
         "line-cap": "round",
         "line-join": "round",
         visibility: `${
-          overlay.overlayOptions && overlay.overlayOptions.includes(asmpLevel)
+          overlay.options && overlay.options.includes(asmpLevel)
             ? "visible"
             : "none"
         }`

--- a/atd-vzv/src/views/map/map-style.js
+++ b/atd-vzv/src/views/map/map-style.js
@@ -9,28 +9,3 @@ export const crashDataLayer = {
     "circle-color": `${colors.info}`
   }
 };
-
-export const asmpDataLayer = {
-  id: "asmp",
-  type: "line",
-  paint: {
-    "line-width": 3,
-    "line-color": [
-      "interpolate",
-      ["linear"],
-      ["get", "STREET_LEVEL"],
-      0,
-      colors.warning,
-      1,
-      colors.redGradient2Of5,
-      2,
-      colors.chartOrange,
-      3,
-      colors.chartRedOrange,
-      4,
-      colors.chartRed,
-      5,
-      colors.chartBlue
-    ]
-  }
-};

--- a/atd-vzv/src/views/map/map-style.js
+++ b/atd-vzv/src/views/map/map-style.js
@@ -1,3 +1,5 @@
+import React from "react";
+import { Layer } from "react-map-gl";
 import { colors } from "../../constants/colors";
 
 // For more information on data-driven styles, see https://www.mapbox.com/help/gl-dds-ref/
@@ -9,3 +11,54 @@ export const crashDataLayer = {
     "circle-color": `${colors.info}`
   }
 };
+
+// Config ASMP Street Level layers
+export const asmpConfig = {
+  asmp_1: {
+    filter: 0,
+    color: "#F9AE91"
+  },
+  asmp_2: {
+    filter: 1,
+    color: "#F66A4A"
+  },
+  asmp_3: {
+    filter: 2,
+    color: "#E60000"
+  },
+  asmp_4: {
+    filter: 3,
+    color: "#A50F15"
+  },
+  asmp_5: {
+    filter: 4,
+    color: "#1B519D"
+  }
+};
+
+export const buildAsmpLayers = (config, overlay) =>
+  Object.entries(config).map(([level, parameters], i) => {
+    const asmpLayerConfig = {
+      id: level,
+      type: "line",
+      source: {
+        type: "vector",
+        tiles: [
+          "https://tiles.arcgis.com/tiles/0L95CJ0VTaxqcmED/arcgis/rest/services/ASMP_Streets_VectorTile/VectorTileServer/tile/{z}/{y}/{x}.pbf"
+        ]
+      },
+      "source-layer": "asmp_street_network",
+      filter: ["==", "_symbol", parameters.filter],
+      layout: {
+        "line-cap": "round",
+        "line-join": "round",
+        visibility: `${overlay === "asmp" ? "visible" : "none"}`
+      },
+      paint: {
+        "line-color": parameters.color,
+        "line-width": 2
+      }
+    };
+
+    return <Layer key={i} {...asmpLayerConfig} />;
+  });

--- a/atd-vzv/src/views/map/map-style.js
+++ b/atd-vzv/src/views/map/map-style.js
@@ -1,11 +1,38 @@
 import { colors } from "../../constants/colors";
 
 // For more information on data-driven styles, see https://www.mapbox.com/help/gl-dds-ref/
-export const dataLayer = {
+export const crashDataLayer = {
   id: "data",
   type: "circle",
   paint: {
     "circle-radius": 5,
     "circle-color": `${colors.info}`
+  }
+};
+
+export const asmpDataLayer = {
+  id: "data",
+  type: "line",
+  paint: {
+    "line-width": 3,
+    // "line-color": `${colors.info}`
+    "line-color": [
+      "interpolate",
+      ["linear"],
+      // "match", ["string", ["get", ""]],
+      ["get", "STREET_LEVEL"],
+      0,
+      colors.warning,
+      1,
+      colors.redGradient2Of5,
+      2,
+      colors.chartOrange,
+      3,
+      colors.chartRedOrange,
+      4,
+      colors.chartRed,
+      5,
+      colors.chartBlue
+    ]
   }
 };

--- a/atd-vzv/src/views/map/map-style.js
+++ b/atd-vzv/src/views/map/map-style.js
@@ -2,7 +2,7 @@ import { colors } from "../../constants/colors";
 
 // For more information on data-driven styles, see https://www.mapbox.com/help/gl-dds-ref/
 export const crashDataLayer = {
-  id: "data",
+  id: "crashes",
   type: "circle",
   paint: {
     "circle-radius": 5,
@@ -11,15 +11,13 @@ export const crashDataLayer = {
 };
 
 export const asmpDataLayer = {
-  id: "data",
+  id: "asmp",
   type: "line",
   paint: {
     "line-width": 3,
-    // "line-color": `${colors.info}`
     "line-color": [
       "interpolate",
       ["linear"],
-      // "match", ["string", ["get", ""]],
       ["get", "STREET_LEVEL"],
       0,
       colors.warning,

--- a/atd-vzv/src/views/map/map-style.js
+++ b/atd-vzv/src/views/map/map-style.js
@@ -16,23 +16,23 @@ export const crashDataLayer = {
 export const asmpConfig = {
   asmp_1: {
     filter: 0,
-    color: "#F9AE91"
+    color: colors.mapAsmp1
   },
   asmp_2: {
     filter: 1,
-    color: "#F66A4A"
+    color: colors.mapAsmp2
   },
   asmp_3: {
     filter: 2,
-    color: "#E60000"
+    color: colors.mapAsmp3
   },
   asmp_4: {
     filter: 3,
-    color: "#A50F15"
+    color: colors.mapAsmp4
   },
   asmp_5: {
     filter: 4,
-    color: "#1B519D"
+    color: colors.mapAsmp5
   }
 };
 
@@ -41,6 +41,7 @@ export const buildAsmpLayers = (config, overlay) =>
   Object.entries(config).map(([level, parameters], i) => {
     const asmpLevel = level.split("").pop();
 
+    // Set config for each ASMP level layer
     const asmpLayerConfig = {
       id: level,
       type: "line",
@@ -67,5 +68,6 @@ export const buildAsmpLayers = (config, overlay) =>
       }
     };
 
+    // Return a Layer component with config prop passed for each level
     return <Layer key={i} {...asmpLayerConfig} />;
   });

--- a/atd-vzv/src/views/map/map-style.js
+++ b/atd-vzv/src/views/map/map-style.js
@@ -39,6 +39,8 @@ export const asmpConfig = {
 // Build Mapbox GL layers for each ASMP Street Level in config
 export const buildAsmpLayers = (config, overlay) =>
   Object.entries(config).map(([level, parameters], i) => {
+    const asmpLevel = level.split("").pop();
+
     const asmpLayerConfig = {
       id: level,
       type: "line",
@@ -53,7 +55,11 @@ export const buildAsmpLayers = (config, overlay) =>
       layout: {
         "line-cap": "round",
         "line-join": "round",
-        visibility: `${overlay === "asmp" ? "visible" : "none"}`
+        visibility: `${
+          overlay.overlayOptions && overlay.overlayOptions.includes(asmpLevel)
+            ? "visible"
+            : "none"
+        }`
       },
       paint: {
         "line-color": parameters.color,

--- a/atd-vzv/src/views/map/map-style.js
+++ b/atd-vzv/src/views/map/map-style.js
@@ -41,7 +41,8 @@ export const buildAsmpLayers = (config, overlay) =>
   Object.entries(config).map(([level, parameters], i) => {
     const asmpLevel = level.split("").pop();
 
-    // Set config for each ASMP level layer
+    // Set config for each ASMP level layer based on ArcGIS VectorTileServer styles
+    // https://tiles.arcgis.com/tiles/0L95CJ0VTaxqcmED/arcgis/rest/services/ASMP_Streets_VectorTile/VectorTileServer/resources/styles/root.json?f=pjson
     const asmpLayerConfig = {
       id: level,
       type: "line",

--- a/atd-vzv/src/views/map/map-style.js
+++ b/atd-vzv/src/views/map/map-style.js
@@ -36,6 +36,7 @@ export const asmpConfig = {
   }
 };
 
+// Build Mapbox GL layers for each ASMP Street Level in config
 export const buildAsmpLayers = (config, overlay) =>
   Object.entries(config).map(([level, parameters], i) => {
     const asmpLayerConfig = {

--- a/atd-vzv/src/views/nav/SideMapControl.js
+++ b/atd-vzv/src/views/nav/SideMapControl.js
@@ -3,6 +3,7 @@ import { StoreContext } from "../../utils/store";
 import "react-infinite-calendar/styles.css";
 
 import SideMapControlDateRange from "./SideMapControlDateRange";
+import SideMapControlOverlays from "./SideMapControlOverlays";
 import { colors } from "../../constants/colors";
 import { ButtonGroup, Button, Card, Label } from "reactstrap";
 import styled from "styled-components";
@@ -34,8 +35,7 @@ const StyledCard = styled.div`
 
 const SideMapControl = () => {
   const {
-    mapFilters: [filters, setFilters],
-    mapOverlay: [overlay, setOverlay]
+    mapFilters: [filters, setFilters]
   } = React.useContext(StoreContext);
 
   // Clear all filters that match group arg
@@ -97,23 +97,6 @@ const SideMapControl = () => {
         type: `where`,
         operator: `AND`
       }
-    }
-  };
-
-  const overlays = {
-    asmp: {
-      title: "ASMP Street Levels"
-    }
-  };
-
-  const handleOverlayClick = event => {
-    // Set overlay in Context store or remove it
-    const overlayName = event.currentTarget.id;
-
-    if (overlay !== overlayName) {
-      setOverlay(overlayName);
-    } else if (overlay === overlayName) {
-      setOverlay("");
     }
   };
 
@@ -184,23 +167,7 @@ const SideMapControl = () => {
         ))}
         <SideMapControlDateRange />
       </Card>
-      <Card className="mt-3 p-3 card-body">
-        <Label className="section-title">Overlays</Label>
-        {/* Create a button group for each overlay */}
-        {Object.entries(overlays).map(([name, parameters], i) => (
-          <Button
-            key={i}
-            id={name}
-            color="info"
-            className="w-100 pt-1 pb-1 pl-0 pr-0"
-            onClick={handleOverlayClick}
-            active={name === overlay}
-            outline={name !== overlay}
-          >
-            {parameters.title}
-          </Button>
-        ))}
-      </Card>
+      <SideMapControlOverlays />
     </StyledCard>
   );
 };

--- a/atd-vzv/src/views/nav/SideMapControl.js
+++ b/atd-vzv/src/views/nav/SideMapControl.js
@@ -34,7 +34,8 @@ const StyledCard = styled.div`
 
 const SideMapControl = () => {
   const {
-    mapFilters: [filters, setFilters]
+    mapFilters: [filters, setFilters],
+    mapOverlay: [overlay, setOverlay]
   } = React.useContext(StoreContext);
 
   // Clear all filters that match group arg
@@ -96,6 +97,23 @@ const SideMapControl = () => {
         type: `where`,
         operator: `AND`
       }
+    }
+  };
+
+  const overlays = {
+    asmp: {
+      title: "ASMP Street Levels"
+    }
+  };
+
+  const handleOverlayClick = event => {
+    // Set overlay in Context store or remove it
+    const overlayName = event.currentTarget.id;
+
+    if (overlay !== overlayName) {
+      setOverlay(overlayName);
+    } else if (overlay === overlayName) {
+      setOverlay("");
     }
   };
 
@@ -165,6 +183,23 @@ const SideMapControl = () => {
           </ButtonGroup>
         ))}
         <SideMapControlDateRange />
+      </Card>
+      <Card className="mt-3 p-3 card-body">
+        <Label className="section-title">Overlays</Label>
+        {/* Create a button group for each overlay */}
+        {Object.entries(overlays).map(([name, parameters], i) => (
+          <Button
+            key={i}
+            id={name}
+            color="info"
+            className="w-100 pt-1 pb-1 pl-0 pr-0"
+            onClick={handleOverlayClick}
+            active={name === overlay}
+            outline={name !== overlay}
+          >
+            {parameters.title}
+          </Button>
+        ))}
       </Card>
     </StyledCard>
   );

--- a/atd-vzv/src/views/nav/SideMapControlOverlays.js
+++ b/atd-vzv/src/views/nav/SideMapControlOverlays.js
@@ -1,0 +1,49 @@
+import React from "react";
+import { StoreContext } from "../../utils/store";
+
+import { Button, Card, Label } from "reactstrap";
+
+const SideMapControlOverlays = () => {
+  const {
+    mapOverlay: [overlay, setOverlay]
+  } = React.useContext(StoreContext);
+
+  const overlays = {
+    asmp: {
+      title: "ASMP Street Levels"
+    }
+  };
+
+  const handleOverlayClick = event => {
+    // Set overlay in Context store or remove it
+    const overlayName = event.currentTarget.id;
+
+    if (overlay !== overlayName) {
+      setOverlay(overlayName);
+    } else if (overlay === overlayName) {
+      setOverlay("");
+    }
+  };
+
+  return (
+    <Card className="mt-3 p-3 card-body">
+      <Label className="section-title">Overlays</Label>
+      {/* Create a button group for each overlay */}
+      {Object.entries(overlays).map(([name, parameters], i) => (
+        <Button
+          key={i}
+          id={name}
+          color="info"
+          className="w-100 pt-1 pb-1 pl-0 pr-0"
+          onClick={handleOverlayClick}
+          active={name === overlay}
+          outline={name !== overlay}
+        >
+          {parameters.title}
+        </Button>
+      ))}
+    </Card>
+  );
+};
+
+export default SideMapControlOverlays;

--- a/atd-vzv/src/views/nav/SideMapControlOverlays.js
+++ b/atd-vzv/src/views/nav/SideMapControlOverlays.js
@@ -8,6 +8,7 @@ const SideMapControlOverlays = () => {
     mapOverlay: [overlay, setOverlay]
   } = React.useContext(StoreContext);
 
+  // Set overlay title and optional options
   const overlays = {
     asmp: {
       title: "ASMP Street Levels",
@@ -53,7 +54,7 @@ const SideMapControlOverlays = () => {
       <Label className="section-title">Overlays</Label>
       {/* Create a button group for each overlay */}
       {Object.entries(overlays).map(([name, parameters], i) => (
-        <ButtonGroup vertical={true} key={i}>
+        <ButtonGroup vertical key={i}>
           <Button
             key={i}
             id={name}
@@ -65,8 +66,8 @@ const SideMapControlOverlays = () => {
           >
             {parameters.title}
           </Button>
-
-          {overlay.name === name && (
+          {/* If options set in config, render button group for each option */}
+          {overlay.name === name && parameters.options && (
             <ButtonGroup>
               {parameters.options.map((option, i) => (
                 <Button

--- a/atd-vzv/src/views/nav/SideMapControlOverlays.js
+++ b/atd-vzv/src/views/nav/SideMapControlOverlays.js
@@ -19,12 +19,12 @@ const SideMapControlOverlays = () => {
     // Set overlay in Context store or remove it
     const overlayName = event.currentTarget.id;
 
-    if (overlay === "" || overlay.overlayName !== overlayName) {
+    if (overlay === "" || overlay.name !== overlayName) {
       setOverlay({
-        overlayName: overlayName,
-        overlayOptions: parameters.options
+        name: overlayName,
+        options: parameters.options
       });
-    } else if (overlay.overlayName === overlayName) {
+    } else if (overlay.name === overlayName) {
       setOverlay("");
     }
   };
@@ -33,22 +33,18 @@ const SideMapControlOverlays = () => {
     // Set overlay in Context store or remove it
     const overlayOption = event.currentTarget.id;
 
-    if (!overlay.overlayOptions.includes(overlayOption)) {
-      // set overlay level
-      const updatedOverlay = overlay;
-      updatedOverlay.overlayOptions = [
-        ...overlay.overlayOptions,
-        ...overlayOption
-      ];
-      setOverlay(updatedOverlay);
-    } else if (overlay.overlayOptions.includes(overlayOption)) {
-      // remove overlay level
-      const updatedOverlay = overlay;
-      updatedOverlay.overlayOptions = overlay.overlayOptions.filter(
-        option => option !== overlayOption
-      );
-
-      setOverlay(updatedOverlay);
+    if (!overlay.options.includes(overlayOption)) {
+      // Add clicked option to state
+      setOverlay(prevState => ({
+        ...prevState,
+        options: [...prevState.options, ...overlayOption]
+      }));
+    } else if (overlay.options.includes(overlayOption)) {
+      // Remove clicked option from state
+      setOverlay(prevState => ({
+        ...prevState,
+        options: prevState.options.filter(option => option !== overlayOption)
+      }));
     }
   };
 
@@ -63,13 +59,13 @@ const SideMapControlOverlays = () => {
           color="info"
           className="w-100 pt-1 pb-1 pl-0 pr-0"
           onClick={event => handleOverlayClick(event, parameters)}
-          active={name === overlay.overlayName}
-          outline={name !== overlay.overlayName}
+          active={name === overlay.name}
+          outline={name !== overlay.name}
         >
           {parameters.title}
         </Button>
       ))}
-      {overlay.overlayName === "asmp" && (
+      {overlay.name === "asmp" && (
         <ButtonGroup>
           {overlays.asmp.options.map((level, i) => (
             <Button
@@ -78,8 +74,8 @@ const SideMapControlOverlays = () => {
               color="info"
               className="w-100 pt-1 pb-1 pl-0 pr-0"
               //   TODO: Fix active and outline logic
-              active={overlay.overlayOptions.includes(level)}
-              outline={!overlay.overlayOptions.includes(level)}
+              active={overlay.options.includes(level)}
+              outline={!overlay.options.includes(level)}
               onClick={handleOverlayOptionClick}
             >
               {level}

--- a/atd-vzv/src/views/nav/SideMapControlOverlays.js
+++ b/atd-vzv/src/views/nav/SideMapControlOverlays.js
@@ -19,7 +19,7 @@ const SideMapControlOverlays = () => {
     // Set overlay in Context store or remove it
     const overlayName = event.currentTarget.id;
 
-    if (overlay === "" || overlay.name !== overlayName) {
+    if (overlay.name !== overlayName) {
       setOverlay({
         name: overlayName,
         options: parameters.options
@@ -53,36 +53,38 @@ const SideMapControlOverlays = () => {
       <Label className="section-title">Overlays</Label>
       {/* Create a button group for each overlay */}
       {Object.entries(overlays).map(([name, parameters], i) => (
-        <Button
-          key={i}
-          id={name}
-          color="info"
-          className="w-100 pt-1 pb-1 pl-0 pr-0"
-          onClick={event => handleOverlayClick(event, parameters)}
-          active={name === overlay.name}
-          outline={name !== overlay.name}
-        >
-          {parameters.title}
-        </Button>
-      ))}
-      {overlay.name === "asmp" && (
-        <ButtonGroup>
-          {overlays.asmp.options.map((level, i) => (
-            <Button
-              key={i}
-              id={level}
-              color="info"
-              className="w-100 pt-1 pb-1 pl-0 pr-0"
-              //   TODO: Fix active and outline logic
-              active={overlay.options.includes(level)}
-              outline={!overlay.options.includes(level)}
-              onClick={handleOverlayOptionClick}
-            >
-              {level}
-            </Button>
-          ))}
+        <ButtonGroup vertical={true} key={i}>
+          <Button
+            key={i}
+            id={name}
+            color="info"
+            className="w-100 pt-1 pb-1 pl-0 pr-0"
+            onClick={event => handleOverlayClick(event, parameters)}
+            active={name === overlay.name}
+            outline={name !== overlay.name}
+          >
+            {parameters.title}
+          </Button>
+
+          {overlay.name === name && (
+            <ButtonGroup>
+              {parameters.options.map((option, i) => (
+                <Button
+                  key={i}
+                  id={option}
+                  color="info"
+                  className="w-100 pt-1 pb-1 pl-0 pr-0"
+                  active={overlay.options.includes(option)}
+                  outline={!overlay.options.includes(option)}
+                  onClick={handleOverlayOptionClick}
+                >
+                  {option}
+                </Button>
+              ))}
+            </ButtonGroup>
+          )}
         </ButtonGroup>
-      )}
+      ))}
     </Card>
   );
 };

--- a/atd-vzv/src/views/nav/SideMapControlOverlays.js
+++ b/atd-vzv/src/views/nav/SideMapControlOverlays.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { StoreContext } from "../../utils/store";
 
-import { Button, Card, Label } from "reactstrap";
+import { ButtonGroup, Button, Card, Label } from "reactstrap";
 
 const SideMapControlOverlays = () => {
   const {
@@ -10,18 +10,45 @@ const SideMapControlOverlays = () => {
 
   const overlays = {
     asmp: {
-      title: "ASMP Street Levels"
+      title: "ASMP Street Levels",
+      options: ["1", "2", "3", "4", "5"]
     }
   };
 
-  const handleOverlayClick = event => {
+  const handleOverlayClick = (event, parameters) => {
     // Set overlay in Context store or remove it
     const overlayName = event.currentTarget.id;
 
-    if (overlay !== overlayName) {
-      setOverlay(overlayName);
-    } else if (overlay === overlayName) {
+    if (overlay === "" || overlay.overlayName !== overlayName) {
+      setOverlay({
+        overlayName: overlayName,
+        overlayOptions: parameters.options
+      });
+    } else if (overlay.overlayName === overlayName) {
       setOverlay("");
+    }
+  };
+
+  const handleOverlayOptionClick = event => {
+    // Set overlay in Context store or remove it
+    const overlayOption = event.currentTarget.id;
+
+    if (!overlay.overlayOptions.includes(overlayOption)) {
+      // set overlay level
+      const updatedOverlay = overlay;
+      updatedOverlay.overlayOptions = [
+        ...overlay.overlayOptions,
+        ...overlayOption
+      ];
+      setOverlay(updatedOverlay);
+    } else if (overlay.overlayOptions.includes(overlayOption)) {
+      // remove overlay level
+      const updatedOverlay = overlay;
+      updatedOverlay.overlayOptions = overlay.overlayOptions.filter(
+        option => option !== overlayOption
+      );
+
+      setOverlay(updatedOverlay);
     }
   };
 
@@ -35,13 +62,31 @@ const SideMapControlOverlays = () => {
           id={name}
           color="info"
           className="w-100 pt-1 pb-1 pl-0 pr-0"
-          onClick={handleOverlayClick}
-          active={name === overlay}
-          outline={name !== overlay}
+          onClick={event => handleOverlayClick(event, parameters)}
+          active={name === overlay.overlayName}
+          outline={name !== overlay.overlayName}
         >
           {parameters.title}
         </Button>
       ))}
+      {overlay.overlayName === "asmp" && (
+        <ButtonGroup>
+          {overlays.asmp.options.map((level, i) => (
+            <Button
+              key={i}
+              id={level}
+              color="info"
+              className="w-100 pt-1 pb-1 pl-0 pr-0"
+              //   TODO: Fix active and outline logic
+              active={overlay.overlayOptions.includes(level)}
+              outline={!overlay.overlayOptions.includes(level)}
+              onClick={handleOverlayOptionClick}
+            >
+              {level}
+            </Button>
+          ))}
+        </ButtonGroup>
+      )}
     </Card>
   );
 };


### PR DESCRIPTION
Closes #564 

This PR adds a pattern for adding overlays to the VZV map along with the ASMP street level overlay. I added a new component `SideMapControlOverlays` to contain the config for each overlay and to render button groups based on that config in a new card below the filters card. Also, another piece of state was added to the Context store to keep the selected overlay and any overlay options selected (ASMP street levels in this case). The `Map` component was also modified to render new map layers generated by some new helpers upon selecting an overlay.

### ASMP overlay not selected
<img width="1035" alt="Screen Shot 2020-01-22 at 9 22 50 PM" src="https://user-images.githubusercontent.com/37249039/72954656-c0421d80-3d5e-11ea-93fe-31f98b64665e.png">

### ASMP overlay selected
<img width="1035" alt="Screen Shot 2020-01-22 at 9 22 57 PM" src="https://user-images.githubusercontent.com/37249039/72954659-c46e3b00-3d5e-11ea-8176-d8965be72796.png">

### ASMP overlay selected with some levels disabled
<img width="1035" alt="Screen Shot 2020-01-22 at 9 23 06 PM" src="https://user-images.githubusercontent.com/37249039/72954663-c801c200-3d5e-11ea-8d34-0cee2a48429d.png">
