### PR TITLE
VZV | Map | High Injury Network Overlay

### DIFF
--- a/atd-vzv/src/constants/colors.js
+++ b/atd-vzv/src/constants/colors.js
@@ -23,5 +23,6 @@ export const colors = {
   mapAsmp2: "#F66A4A",
   mapAsmp3: "#E60000",
   mapAsmp4: "#A50F15",
-  mapAsmp5: "#1B519D"
+  mapAsmp5: "#1B519D",
+  mapHighInjuryNetwork: "#E60000"
 };

--- a/atd-vzv/src/views/map/Map.js
+++ b/atd-vzv/src/views/map/Map.js
@@ -2,7 +2,12 @@ import React, { useState, useEffect } from "react";
 import { StoreContext } from "../../utils/store";
 import ReactMapGL, { Source, Layer } from "react-map-gl";
 import { createMapDataUrl } from "./helpers";
-import { crashDataLayer, buildAsmpLayers, asmpConfig } from "./map-style";
+import {
+  crashDataLayer,
+  buildAsmpLayers,
+  asmpConfig,
+  buildHighInjuryLayer
+} from "./map-style";
 import axios from "axios";
 
 import { Card, CardBody, CardText } from "reactstrap";
@@ -103,6 +108,9 @@ const Map = () => {
 
       {/* ASMP Street Level Layers */}
       {buildAsmpLayers(asmpConfig, overlay)}
+
+      {/* High Injury Network Layer */}
+      {buildHighInjuryLayer(overlay)}
 
       {/* Render crash point tooltips */}
       {hoveredFeature && _renderTooltip()}

--- a/atd-vzv/src/views/map/map-style.js
+++ b/atd-vzv/src/views/map/map-style.js
@@ -72,3 +72,31 @@ export const buildAsmpLayers = (config, overlay) =>
     // Return a Layer component with config prop passed for each level
     return <Layer key={i} {...asmpLayerConfig} />;
   });
+
+// Build Mapbox GL layer High Injury Network
+export const buildHighInjuryLayer = overlay => {
+  // Set config for each ASMP level layer based on ArcGIS VectorTileServer styles
+  // https://tiles.arcgis.com/tiles/0L95CJ0VTaxqcmED/arcgis/rest/services/HIN_Vector_Tile/VectorTileServer/resources/styles/root.json?f=pjson
+  const highInjuryLayerConfig = {
+    id: overlay.name,
+    type: "line",
+    source: {
+      type: "vector",
+      tiles: [
+        "https://tiles.arcgis.com/tiles/0L95CJ0VTaxqcmED/arcgis/rest/services/HIN_Vector_Tile/VectorTileServer/tile/{z}/{y}/{x}.pbf"
+      ]
+    },
+    "source-layer": "High-Injury Network",
+    layout: {
+      "line-join": "round",
+      visibility: `${overlay.name === "highInjury" ? "visible" : "none"}`
+    },
+    paint: {
+      "line-color": "#0070FF",
+      "line-width": 2
+    }
+  };
+
+  // Return a Layer component with config prop passed for each level
+  return <Layer key={overlay.name} {...highInjuryLayerConfig} />;
+};

--- a/atd-vzv/src/views/map/map-style.js
+++ b/atd-vzv/src/views/map/map-style.js
@@ -103,6 +103,6 @@ export const buildHighInjuryLayer = overlay => {
     }
   };
 
-  // Return a Layer component with config prop passed for each level
+  // Return a Layer component with config prop passed
   return <Layer key={"highInjury"} {...highInjuryLayerConfig} />;
 };

--- a/atd-vzv/src/views/map/map-style.js
+++ b/atd-vzv/src/views/map/map-style.js
@@ -36,6 +36,10 @@ export const asmpConfig = {
   }
 };
 
+// Map Overlay configuration
+// Hide/show based on overlay state, add layers only once and let state determine visibility
+// Using state in any other config parameters will cause layer to add again and break map layer
+
 // Build Mapbox GL layers for each ASMP Street Level in config
 export const buildAsmpLayers = (config, overlay) =>
   Object.entries(config).map(([level, parameters], i) => {
@@ -76,9 +80,11 @@ export const buildAsmpLayers = (config, overlay) =>
 // Build Mapbox GL layer High Injury Network
 export const buildHighInjuryLayer = overlay => {
   // Set config for each ASMP level layer based on ArcGIS VectorTileServer styles
+  const overlayId = "highInjury";
+
   // https://tiles.arcgis.com/tiles/0L95CJ0VTaxqcmED/arcgis/rest/services/HIN_Vector_Tile/VectorTileServer/resources/styles/root.json?f=pjson
   const highInjuryLayerConfig = {
-    id: overlay.name,
+    id: overlayId,
     type: "line",
     source: {
       type: "vector",
@@ -89,14 +95,14 @@ export const buildHighInjuryLayer = overlay => {
     "source-layer": "High-Injury Network",
     layout: {
       "line-join": "round",
-      visibility: `${overlay.name === "highInjury" ? "visible" : "none"}`
+      visibility: `${overlay.name === overlayId ? "visible" : "none"}`
     },
     paint: {
-      "line-color": "#0070FF",
+      "line-color": colors.mapHighInjuryNetwork,
       "line-width": 2
     }
   };
 
   // Return a Layer component with config prop passed for each level
-  return <Layer key={overlay.name} {...highInjuryLayerConfig} />;
+  return <Layer key={"highInjury"} {...highInjuryLayerConfig} />;
 };

--- a/atd-vzv/src/views/nav/SideMapControlOverlays.js
+++ b/atd-vzv/src/views/nav/SideMapControlOverlays.js
@@ -57,7 +57,7 @@ const SideMapControlOverlays = () => {
       <Label className="section-title">Overlays</Label>
       {/* Create a button group for each overlay */}
       {Object.entries(overlays).map(([name, parameters], i) => (
-        <ButtonGroup vertical key={i}>
+        <ButtonGroup vertical className="mb-3" key={i}>
           <Button
             key={i}
             id={name}

--- a/atd-vzv/src/views/nav/SideMapControlOverlays.js
+++ b/atd-vzv/src/views/nav/SideMapControlOverlays.js
@@ -13,6 +13,9 @@ const SideMapControlOverlays = () => {
     asmp: {
       title: "ASMP Street Levels",
       options: ["1", "2", "3", "4", "5"]
+    },
+    highInjury: {
+      title: "High Injury Network"
     }
   };
 


### PR DESCRIPTION
Closes #570 

This PR adds the High Injury Network overlay to the VZV map. This follows the pattern started in #564, but I'm starting to think there could be a better way to add each layer than creating a function for each individual layer. Just a thought for the future.

### High Injury Network overlay and new button
![Screen Shot 2020-01-27 at 3 16 34 PM](https://user-images.githubusercontent.com/37249039/73214738-62c01f00-4118-11ea-807f-6fa5e229e071.png)
