### PR TITLE
Fix time of day january issue

### DIFF
--- a/atd-vzv/src/constants/time.js
+++ b/atd-vzv/src/constants/time.js
@@ -2,15 +2,25 @@ import moment from "moment";
 
 // Time data
 export const today = moment().format("YYYY-MM-DD");
+export const thisYear = moment().format("YYYY");
 export const oneYearAgo = moment()
   .subtract(1, "year")
   .format("YYYY-MM-DD");
 export const todayMonthYear = moment().format("-MM-DD");
 export const thisMonth = moment().format("MM");
-export const thisYear = moment().format("YYYY");
+export const lastMonth = moment()
+  .subtract(1, "month")
+  .format("MM");
+export const lastDayOfLastMonth = moment(
+  `${thisYear}-${lastMonth}`,
+  "YYYY-MM"
+).daysInMonth();
 export const lastYear = moment()
   .subtract(1, "year")
   .format("YYYY");
+export const lastMonthString = moment()
+  .subtract(1, "month")
+  .format("MMMM");
 
 // Map time data
 const rollingYearsOfData = 5;

--- a/atd-vzv/src/views/summary/FatalitiesByTimeOfDay.js
+++ b/atd-vzv/src/views/summary/FatalitiesByTimeOfDay.js
@@ -5,7 +5,7 @@ import moment from "moment";
 import { Nav, NavItem, NavLink, Row, Col, Container } from "reactstrap";
 import classnames from "classnames";
 import { Heatmap, HeatmapSeries } from "reaviz";
-import { thisMonth, thisYear } from "../../constants/time";
+import { thisMonth, thisYear, lastMonth, lastDayOfLastMonth } from "../../constants/time";
 import { colors } from "../../constants/colors";
 
 const FatalitiesByTimeOfDayWeek = () => {
@@ -34,15 +34,6 @@ const FatalitiesByTimeOfDayWeek = () => {
   };
 
   useEffect(() => {
-    const lastMonthNumber = moment()
-      .subtract(1, "month")
-      .format("MM");
-    const lastMonthLastDayNumber = moment(
-      `${thisYear}-${lastMonthNumber}`,
-      "YYYY-MM"
-    ).daysInMonth();
-
-    const lastMonthLastDayDate = `${thisYear}-${lastMonthNumber}-${lastMonthLastDayNumber}`;
 
     const dayOfWeekArray = [
       "Sunday",
@@ -82,7 +73,7 @@ const FatalitiesByTimeOfDayWeek = () => {
 
     const getFatalitiesByYearsAgoUrl = () => {
       if (activeTab === 0) {
-        return `https://data.austintexas.gov/resource/y2wy-tgr5.json?$where=death_cnt > 0 AND crash_date between '${thisYear}-01-01T00:00:00' and '${lastMonthLastDayDate}T23:59:59'`;
+        return `https://data.austintexas.gov/resource/y2wy-tgr5.json?$where=death_cnt > 0 AND crash_date between '${thisYear}-01-01T00:00:00' and '${thisYear}-${lastMonth}-${lastDayOfLastMonth}T23:59:59'`;
       } else {
         let yearsAgoDate = moment()
           .subtract(activeTab, "year")

--- a/atd-vzv/src/views/summary/FatalitiesByTimeOfDay.js
+++ b/atd-vzv/src/views/summary/FatalitiesByTimeOfDay.js
@@ -82,17 +82,11 @@ const FatalitiesByTimeOfDayWeek = () => {
 
     const getFatalitiesByYearsAgoUrl = () => {
       if (activeTab === 0) {
-        console.log(
-          `https://data.austintexas.gov/resource/y2wy-tgr5.json?$where=death_cnt > 0 AND crash_date between '${thisYear}-01-01T00:00:00' and '${lastMonthLastDayDate}T23:59:59'`
-        );
         return `https://data.austintexas.gov/resource/y2wy-tgr5.json?$where=death_cnt > 0 AND crash_date between '${thisYear}-01-01T00:00:00' and '${lastMonthLastDayDate}T23:59:59'`;
       } else {
         let yearsAgoDate = moment()
           .subtract(activeTab, "year")
           .format("YYYY");
-        console.log(
-          `https://data.austintexas.gov/resource/y2wy-tgr5.json?$where=death_cnt > 0 AND crash_date between '${yearsAgoDate}-01-01T00:00:00' and '${yearsAgoDate}-12-31T23:59:59'`
-        );
         return `https://data.austintexas.gov/resource/y2wy-tgr5.json?$where=death_cnt > 0 AND crash_date between '${yearsAgoDate}-01-01T00:00:00' and '${yearsAgoDate}-12-31T23:59:59'`;
       }
     };

--- a/atd-vzv/src/views/summary/FatalitiesByTimeOfDay.js
+++ b/atd-vzv/src/views/summary/FatalitiesByTimeOfDay.js
@@ -5,12 +5,23 @@ import moment from "moment";
 import { Nav, NavItem, NavLink, Row, Col, Container } from "reactstrap";
 import classnames from "classnames";
 import { Heatmap, HeatmapSeries } from "reaviz";
-import { thisYear } from "../../constants/time";
+import { thisMonth, thisYear } from "../../constants/time";
 import { colors } from "../../constants/colors";
 
 const FatalitiesByTimeOfDayWeek = () => {
+  // Check current month before setting the active tab.
+  // If current month is January, display last year's data,
+  // if past January, display this year's data.
+  const checkMonth = () => {
+    if (thisMonth > "01") {
+      return 0;
+    } else {
+      return 1;
+    }
+  };
+
+  const [activeTab, setActiveTab] = useState(checkMonth());
   const [heatmapData, setHeatmapData] = useState([]);
-  const [activeTab, setActiveTab] = useState(0);
 
   const getYearsAgoLabel = yearsAgo => {
     return moment()
@@ -71,11 +82,17 @@ const FatalitiesByTimeOfDayWeek = () => {
 
     const getFatalitiesByYearsAgoUrl = () => {
       if (activeTab === 0) {
+        console.log(
+          `https://data.austintexas.gov/resource/y2wy-tgr5.json?$where=death_cnt > 0 AND crash_date between '${thisYear}-01-01T00:00:00' and '${lastMonthLastDayDate}T23:59:59'`
+        );
         return `https://data.austintexas.gov/resource/y2wy-tgr5.json?$where=death_cnt > 0 AND crash_date between '${thisYear}-01-01T00:00:00' and '${lastMonthLastDayDate}T23:59:59'`;
       } else {
         let yearsAgoDate = moment()
           .subtract(activeTab, "year")
           .format("YYYY");
+        console.log(
+          `https://data.austintexas.gov/resource/y2wy-tgr5.json?$where=death_cnt > 0 AND crash_date between '${yearsAgoDate}-01-01T00:00:00' and '${yearsAgoDate}-12-31T23:59:59'`
+        );
         return `https://data.austintexas.gov/resource/y2wy-tgr5.json?$where=death_cnt > 0 AND crash_date between '${yearsAgoDate}-01-01T00:00:00' and '${yearsAgoDate}-12-31T23:59:59'`;
       }
     };
@@ -115,7 +132,7 @@ const FatalitiesByTimeOfDayWeek = () => {
     };
 
     // Fetch records for selected year
-    axios.get(getFatalitiesByYearsAgoUrl(activeTab)).then(res => {
+    axios.get(getFatalitiesByYearsAgoUrl()).then(res => {
       setHeatmapData(calculateHourBlockTotals(res));
     });
   }, [activeTab]);
@@ -175,16 +192,18 @@ const FatalitiesByTimeOfDayWeek = () => {
                 {getYearsAgoLabel(1)}
               </NavLink>
             </NavItem>
-            <NavItem>
-              <NavLink
-                className={classnames({ active: activeTab === 0 })}
-                onClick={() => {
-                  toggle(0);
-                }}
-              >
-                {getYearsAgoLabel(0)}
-              </NavLink>
-            </NavItem>
+            {thisMonth > "01" && (
+              <NavItem>
+                <NavLink
+                  className={classnames({ active: activeTab === 0 })}
+                  onClick={() => {
+                    toggle(0);
+                  }}
+                >
+                  {getYearsAgoLabel(0)}
+                </NavLink>
+              </NavItem>
+            )}
           </Nav>
         </Col>
       </Row>


### PR DESCRIPTION
Fixes #641 

Only shows current year tab if we are past January of current year. Otherwise, shows previous years.

<img width="478" alt="Screen Shot 2020-01-27 at 11 51 47 AM" src="https://user-images.githubusercontent.com/35410637/73199982-8759ce00-40fb-11ea-8156-ea9ab430c71b.png">
