### PR TITLE
VZV | Map | Austin City Council Districts Overlay

### DIFF
--- a/atd-vzv/src/constants/colors.js
+++ b/atd-vzv/src/constants/colors.js
@@ -24,5 +24,15 @@ export const colors = {
   mapAsmp3: "#E60000",
   mapAsmp4: "#A50F15",
   mapAsmp5: "#1B519D",
-  mapHighInjuryNetwork: "#E60000"
+  mapHighInjuryNetwork: "#E60000",
+  mapCityCouncil1: " #ffffbf",
+  mapCityCouncil2: "#66c2a5",
+  mapCityCouncil3: "#d53e4f",
+  mapCityCouncil4: "#e076dc",
+  mapCityCouncil5: "#3288bd",
+  mapCityCouncil6: "#fee08b",
+  mapCityCouncil7: "#fdae61",
+  mapCityCouncil8: "#f46d43",
+  mapCityCouncil9: "#abdda4",
+  mapCityCouncil10: "#A50F15"
 };

--- a/atd-vzv/src/views/map/Map.js
+++ b/atd-vzv/src/views/map/Map.js
@@ -56,12 +56,8 @@ const Map = () => {
   }, [filters, dateRange]);
 
   useEffect(() => {
-    const overlayUrl = `https://services.arcgis.com/0L95CJ0VTaxqcmED/ArcGIS/rest/services/BOUNDARIES_single_member_districts/FeatureServer/0/query?where=COUNCIL_DISTRICT%20%3E=%200&outFields=*&f=geojson`;
-    // TODO: Use viewport as parameter to query ArcGIS? Don't need to query all records for entire map at once
-    // Url needs &outFields=* in query to get all metadata
-    // Street Level >= 0 & orderByFields=OBJECTID ASC & 1000 results with 0 offset
-    // https://services.arcgis.com/0L95CJ0VTaxqcmED/ArcGIS/rest/services/TRANSPORTATION_asmp_street_network/FeatureServer/0/query?where=STREET_LEVEL%20%3E=%200&orderByFields=OBJECTID%20ASC&resultRecordCount=1000&resultOffset=0&outFields=*&f=geojson
-    // Paging through data https://github.com/koopjs/FeatureServer/issues/141
+    // Fetch City Council Districts geojson and return OBJECTID metadata for styling in map-style.js
+    const overlayUrl = `https://services.arcgis.com/0L95CJ0VTaxqcmED/ArcGIS/rest/services/BOUNDARIES_single_member_districts/FeatureServer/0/query?where=COUNCIL_DISTRICT%20%3E=%200&outFields=OBJECTID&f=geojson`;
     axios.get(overlayUrl).then(res => {
       setCityCouncilOverlay(res.data);
     });
@@ -128,7 +124,8 @@ const Map = () => {
 
       {!!cityCouncilOverlay && (
         <Source type="geojson" data={cityCouncilOverlay}>
-          <Layer {...cityCouncilDataLayer} />
+          {/* Add beforeId to render beneath crash points */}
+          <Layer beforeId="crashes" {...cityCouncilDataLayer} />
         </Source>
       )}
 

--- a/atd-vzv/src/views/map/Map.js
+++ b/atd-vzv/src/views/map/Map.js
@@ -38,7 +38,7 @@ const Map = () => {
 
   const [mapData, setMapData] = useState("");
   const [hoveredFeature, setHoveredFeature] = useState(null);
-  const [cityCouncilOverlay, setCityCouncilOverlay] = useState("");
+  const [cityCouncilOverlay, setCityCouncilOverlay] = useState(null);
 
   const {
     mapFilters: [filters],
@@ -126,7 +126,7 @@ const Map = () => {
       {/* High Injury Network Layer */}
       {buildHighInjuryLayer(overlay)}
 
-      {!!overlay && (
+      {!!cityCouncilOverlay && (
         <Source type="geojson" data={cityCouncilOverlay}>
           <Layer {...cityCouncilDataLayer} />
         </Source>

--- a/atd-vzv/src/views/map/Map.js
+++ b/atd-vzv/src/views/map/Map.js
@@ -57,7 +57,7 @@ const Map = () => {
 
   useEffect(() => {
     // Fetch City Council Districts geojson and return OBJECTID metadata for styling in map-style.js
-    const overlayUrl = `https://services.arcgis.com/0L95CJ0VTaxqcmED/ArcGIS/rest/services/BOUNDARIES_single_member_districts/FeatureServer/0/query?where=COUNCIL_DISTRICT%20%3E=%200&outFields=OBJECTID&f=geojson`;
+    const overlayUrl = `https://services.arcgis.com/0L95CJ0VTaxqcmED/ArcGIS/rest/services/BOUNDARIES_single_member_districts/FeatureServer/0/query?where=COUNCIL_DISTRICT%20%3E=%200&f=geojson`;
     axios.get(overlayUrl).then(res => {
       setCityCouncilOverlay(res.data);
     });

--- a/atd-vzv/src/views/map/Map.js
+++ b/atd-vzv/src/views/map/Map.js
@@ -6,7 +6,8 @@ import {
   crashDataLayer,
   buildAsmpLayers,
   asmpConfig,
-  buildHighInjuryLayer
+  buildHighInjuryLayer,
+  cityCouncilDataLayer
 } from "./map-style";
 import axios from "axios";
 
@@ -37,6 +38,7 @@ const Map = () => {
 
   const [mapData, setMapData] = useState("");
   const [hoveredFeature, setHoveredFeature] = useState(null);
+  const [cityCouncilOverlay, setCityCouncilOverlay] = useState("");
 
   const {
     mapFilters: [filters],
@@ -52,6 +54,18 @@ const Map = () => {
       setMapData(res.data);
     });
   }, [filters, dateRange]);
+
+  useEffect(() => {
+    const overlayUrl = `https://services.arcgis.com/0L95CJ0VTaxqcmED/ArcGIS/rest/services/BOUNDARIES_single_member_districts/FeatureServer/0/query?where=COUNCIL_DISTRICT%20%3E=%200&outFields=*&f=geojson`;
+    // TODO: Use viewport as parameter to query ArcGIS? Don't need to query all records for entire map at once
+    // Url needs &outFields=* in query to get all metadata
+    // Street Level >= 0 & orderByFields=OBJECTID ASC & 1000 results with 0 offset
+    // https://services.arcgis.com/0L95CJ0VTaxqcmED/ArcGIS/rest/services/TRANSPORTATION_asmp_street_network/FeatureServer/0/query?where=STREET_LEVEL%20%3E=%200&orderByFields=OBJECTID%20ASC&resultRecordCount=1000&resultOffset=0&outFields=*&f=geojson
+    // Paging through data https://github.com/koopjs/FeatureServer/issues/141
+    axios.get(overlayUrl).then(res => {
+      setCityCouncilOverlay(res.data);
+    });
+  }, []);
 
   const _onViewportChange = viewport => setViewport(viewport);
 
@@ -111,6 +125,12 @@ const Map = () => {
 
       {/* High Injury Network Layer */}
       {buildHighInjuryLayer(overlay)}
+
+      {!!overlay && (
+        <Source type="geojson" data={cityCouncilOverlay}>
+          <Layer {...cityCouncilDataLayer} />
+        </Source>
+      )}
 
       {/* Render crash point tooltips */}
       {hoveredFeature && _renderTooltip()}

--- a/atd-vzv/src/views/map/Map.js
+++ b/atd-vzv/src/views/map/Map.js
@@ -122,7 +122,7 @@ const Map = () => {
       {/* High Injury Network Layer */}
       {buildHighInjuryLayer(overlay)}
 
-      {!!cityCouncilOverlay && (
+      {!!cityCouncilOverlay && overlay.name === "cityCouncil" && (
         <Source type="geojson" data={cityCouncilOverlay}>
           {/* Add beforeId to render beneath crash points */}
           <Layer beforeId="crashes" {...cityCouncilDataLayer} />

--- a/atd-vzv/src/views/map/map-style.js
+++ b/atd-vzv/src/views/map/map-style.js
@@ -106,3 +106,46 @@ export const buildHighInjuryLayer = overlay => {
   // Return a Layer component with config prop passed
   return <Layer key={"highInjury"} {...highInjuryLayerConfig} />;
 };
+
+export const cityCouncilDataLayer = {
+  id: "data",
+  type: "fill",
+  paint: {
+    "fill-color": {
+      property: "OBJECTID",
+      stops: [
+        [0, "#3288bd"],
+        [1, "#66c2a5"],
+        [2, "#abdda4"],
+        [3, "#e6f598"],
+        [4, "#ffffbf"],
+        [5, "#fee08b"],
+        [6, "#fdae61"],
+        [7, "#f46d43"],
+        [8, "#d53e4f"]
+      ]
+    },
+    "fill-opacity": 0.8
+  }
+  //   "line-width": 3,
+  //   // "line-color": `${colors.info}`
+  //   "line-color": [
+  //     "interpolate",
+  //     ["linear"],
+  //     // "match", ["string", ["get", ""]],
+  //     ["get", "OBJECTID"],
+  //     0,
+  //     colors.warning,
+  //     1,
+  //     colors.redGradient2Of5,
+  //     2,
+  //     colors.chartOrange,
+  //     3,
+  //     colors.chartRedOrange,
+  //     4,
+  //     colors.chartRed,
+  //     5,
+  //     colors.chartBlue
+  //   ]
+  // }
+};

--- a/atd-vzv/src/views/map/map-style.js
+++ b/atd-vzv/src/views/map/map-style.js
@@ -122,30 +122,10 @@ export const cityCouncilDataLayer = {
         [5, "#fee08b"],
         [6, "#fdae61"],
         [7, "#f46d43"],
-        [8, "#d53e4f"]
+        [8, "#d53e4f"],
+        [9, "#e076dc"]
       ]
     },
-    "fill-opacity": 0.8
+    "fill-opacity": 0.4
   }
-  //   "line-width": 3,
-  //   // "line-color": `${colors.info}`
-  //   "line-color": [
-  //     "interpolate",
-  //     ["linear"],
-  //     // "match", ["string", ["get", ""]],
-  //     ["get", "OBJECTID"],
-  //     0,
-  //     colors.warning,
-  //     1,
-  //     colors.redGradient2Of5,
-  //     2,
-  //     colors.chartOrange,
-  //     3,
-  //     colors.chartRedOrange,
-  //     4,
-  //     colors.chartRed,
-  //     5,
-  //     colors.chartBlue
-  //   ]
-  // }
 };

--- a/atd-vzv/src/views/map/map-style.js
+++ b/atd-vzv/src/views/map/map-style.js
@@ -107,25 +107,27 @@ export const buildHighInjuryLayer = overlay => {
   return <Layer key={"highInjury"} {...highInjuryLayerConfig} />;
 };
 
+// Style geojson returned from ArcGIS that populates the Source and Layer in Map component
+// https://services.arcgis.com/0L95CJ0VTaxqcmED/arcgis/rest/services/BOUNDARIES_single_member_districts/FeatureServer/0?f=pjson
 export const cityCouncilDataLayer = {
   id: "data",
   type: "fill",
   paint: {
     "fill-color": {
-      property: "OBJECTID",
+      property: "COUNCIL_DISTRICT",
       stops: [
-        [0, "#3288bd"],
-        [1, "#66c2a5"],
-        [2, "#abdda4"],
-        [3, "#e6f598"],
-        [4, "#ffffbf"],
-        [5, "#fee08b"],
-        [6, "#fdae61"],
-        [7, "#f46d43"],
-        [8, "#d53e4f"],
-        [9, "#e076dc"]
+        [1, colors.mapCityCouncil1],
+        [2, colors.mapCityCouncil2],
+        [3, colors.mapCityCouncil3],
+        [4, colors.mapCityCouncil4],
+        [5, colors.mapCityCouncil5],
+        [6, colors.mapCityCouncil6],
+        [7, colors.mapCityCouncil7],
+        [8, colors.mapCityCouncil8],
+        [9, colors.mapCityCouncil9],
+        [10, colors.mapCityCouncil10]
       ]
     },
-    "fill-opacity": 0.4
+    "fill-opacity": 0.5
   }
 };

--- a/atd-vzv/src/views/nav/SideMapControlOverlays.js
+++ b/atd-vzv/src/views/nav/SideMapControlOverlays.js
@@ -16,6 +16,9 @@ const SideMapControlOverlays = () => {
     },
     highInjury: {
       title: "High Injury Network"
+    },
+    cityCouncil: {
+      title: "Austin City Council Districts"
     }
   };
 


### PR DESCRIPTION
Closes #573 

This PR adds the City Council districts overlay to the VZV map. Since this is a smaller layer than the other two layers implemented so far, the geojson was fetched from ArcGIS and rendered on the map.

### City Council Districts overlay
![Screen Shot 2020-01-27 at 5 13 00 PM](https://user-images.githubusercontent.com/37249039/73223143-c4898480-412a-11ea-836b-64388f6a5e9e.png)
