### PR TITLE
Fix delimiter issues in GridTableExport

### DIFF
--- a/atd-vze/src/Components/GridExportData.js
+++ b/atd-vze/src/Components/GridExportData.js
@@ -98,7 +98,31 @@ const GridExportData = ({ query, columnsToExport, totalRecords }) => {
       return flattenedRow;
     });
 
-    return flattenedData;
+    const cleanedAndFlattenedData = flattenedData.map(item => {
+      // Some fields are presenting issues when they are exported as .csv and
+      // imported into MSFT Excel, Acces & Power BI. For now, we're just going to
+      // modify the data for export to solve issues related to returns and double-quotes
+      // In the future, we may choose to clean these values at the database level.
+
+      const columnsToClean = [
+        "rpt_street_name",
+        "rpt_street_desc",
+        "rpt_sec_street_desc",
+        "rpt_sec_street_name",
+      ];
+
+      columnsToClean.map(col => {
+        if (item[col]) {
+          // remove return carriage and replace with space
+          item[col] = item[col].replace(/(\r\n|\n|\r|")/gm, " ");
+          // remove double-quotes
+          item[col] = item[col].replace(/"/g, "");
+        }
+      });
+      return item;
+    });
+
+    return cleanedAndFlattenedData;
   };
 
   return (
@@ -159,6 +183,7 @@ const GridExportData = ({ query, columnsToExport, totalRecords }) => {
               className=""
               data={formatExportData(data[query.table])}
               filename={query.table + moment(Date.now()).format()}
+              // separator={"|"}
             >
               <Button color="primary" onClick={toggleModal}>
                 Save

--- a/atd-vze/src/Components/GridExportData.js
+++ b/atd-vze/src/Components/GridExportData.js
@@ -111,7 +111,7 @@ const GridExportData = ({ query, columnsToExport, totalRecords }) => {
         "rpt_sec_street_name",
       ];
 
-      columnsToClean.map(col => {
+      columnsToClean.forEach(col => {
         if (item[col]) {
           // remove return carriage and replace with space
           item[col] = item[col].replace(/(\r\n|\n|\r|")/gm, " ");
@@ -183,7 +183,6 @@ const GridExportData = ({ query, columnsToExport, totalRecords }) => {
               className=""
               data={formatExportData(data[query.table])}
               filename={query.table + moment(Date.now()).format()}
-              // separator={"|"}
             >
               <Button color="primary" onClick={toggleModal}>
                 Save


### PR DESCRIPTION
This PR adds a block of string cleaning logic to the `formatData()` function.

After chatting with Xavier, the best solution for now sounds like a fix at the .csv data export level. We may decide in the future to do a bulk change to the values in the database instead. 