### PR TITLE
VZV | Routing | Fix routing to consider /viewer/ pathname

### DIFF
--- a/atd-vzv/src/constants/nav.js
+++ b/atd-vzv/src/constants/nav.js
@@ -1,7 +1,7 @@
 export const navConfig = [
   {
     title: "Summary",
-    url: "/summary"
+    url: "/"
   },
   { title: "Map", url: "/map" }
 ];

--- a/atd-vzv/src/index.js
+++ b/atd-vzv/src/index.js
@@ -1,10 +1,15 @@
 import React from "react";
 import ReactDOM from "react-dom";
+import { setBasepath } from "hookrouter";
+import { basepath } from "./routes/routes";
 import "./index.css";
 import App from "./App";
 import StoreProvider from "./utils/store";
 import * as serviceWorker from "./serviceWorker";
 import "bootstrap/dist/css/bootstrap.css";
+
+// Account for /viewer/ basepath in all routing
+setBasepath(basepath);
 
 ReactDOM.render(
   <StoreProvider>

--- a/atd-vzv/src/routes/routes.js
+++ b/atd-vzv/src/routes/routes.js
@@ -2,7 +2,10 @@ import React from "react";
 import Summary from "../views/summary/Summary";
 import Map from "../views/map/Map";
 
+// Set basepath for VZV url
+export const basepath = "/viewer";
+
 export const routes = {
-  "/summary": () => <Summary />,
+  "/": () => <Summary />,
   "/map": () => <Map />
 };

--- a/atd-vzv/src/views/nav/Header.js
+++ b/atd-vzv/src/views/nav/Header.js
@@ -96,7 +96,8 @@ const Header = () => {
           <div className="vz-logo-wrapper">
             <img
               className="vz-logo"
-              src="vz_logo.png"
+              // Need to adjust location of public folder to account for /viewer/ basepath
+              src="../vz_logo.png"
               alt="Vision Zero Austin Logo"
             ></img>
           </div>

--- a/atd-vzv/src/views/nav/SideDrawer.js
+++ b/atd-vzv/src/views/nav/SideDrawer.js
@@ -65,7 +65,8 @@ const SideDrawer = () => {
   const drawerContent = (
     <div className="side-menu">
       <StyledDrawerHeader>
-        <img src="vz_logo.png" alt="Vision Zero Austin Logo"></img>
+        {/* Need to adjust location of public folder to account for /viewer/ basepath */}
+        <img src="../vz_logo.png" alt="Vision Zero Austin Logo"></img>
       </StyledDrawerHeader>
       <Container className="pt-3 pb-3">
         {/* TODO: Remove disclaimer when going live */}


### PR DESCRIPTION
Closes #600

This PR adds a basepath ("/viewer") at the top level of routing using `hookrouter`. The links and routing were also adjusted to have the summary view appear as the landing page at `/viewer/`. 

One result of this change is that the `/public/` folder in the React file structure is now relative to the basepath so any file references from this folder (like the logo .png) were updated.

### Landing page with `/viewer/` basepath
![image](https://user-images.githubusercontent.com/37249039/73402477-004f5600-42b3-11ea-87be-d2ea8e5d87c2.png)

### Map view with `/viewer/` basepath 
![image](https://user-images.githubusercontent.com/37249039/73402486-03e2dd00-42b3-11ea-9afa-3385cd4b1db3.png)
