### PR TITLE
VZD/VZV | Update Socrata export ETL with apd_confirmed fields

### DIFF
--- a/atd-etl/app/process/socrata_queries.py
+++ b/atd-etl/app/process/socrata_queries.py
@@ -69,6 +69,7 @@ people_query_template = Template(
             prsn_injry_sev_id
             prsn_age
             prsn_gndr_id
+            prsn_ethnicity_id
             unit_nbr
             crash {
                 crash_date
@@ -88,6 +89,7 @@ people_query_template = Template(
             prsn_injry_sev_id
             prsn_age
             prsn_gndr_id
+            prsn_ethnicity_id
             unit_nbr
             crash {
                 crash_date

--- a/atd-etl/app/process/socrata_queries.py
+++ b/atd-etl/app/process/socrata_queries.py
@@ -15,6 +15,8 @@ crashes_query_template = Template(
     """
     query getCrashesSocrata {
         atd_txdot_crashes (limit: $limit, offset: $offset, order_by: {crash_id: asc}, where: {city_id: {_eq: 22}}) {
+            apd_confirmed_fatality
+            apd_confirmed_death_count
             crash_id
             crash_fatal_fl
             crash_date

--- a/atd-vzv/src/views/map/Map.js
+++ b/atd-vzv/src/views/map/Map.js
@@ -89,7 +89,7 @@ const Map = () => {
             <CardBody>
               <CardText>Crash ID: {feature.properties.crash_id}</CardText>
               <CardText>
-                Fatality Count: {feature.properties.death_cnt}
+                Fatality Count: {feature.properties.apd_confirmed_death_count}
               </CardText>
               <CardText>Modes: {feature.properties.unit_mode}</CardText>
               <CardText>Description: {feature.properties.unit_desc}</CardText>

--- a/atd-vzv/src/views/nav/Header.js
+++ b/atd-vzv/src/views/nav/Header.js
@@ -97,7 +97,7 @@ const Header = () => {
             <img
               className="vz-logo"
               // Need to adjust location of public folder to account for /viewer/ basepath
-              src="../vz_logo.png"
+              src="/vz_logo.png"
               alt="Vision Zero Austin Logo"
             ></img>
           </div>

--- a/atd-vzv/src/views/nav/SideDrawer.js
+++ b/atd-vzv/src/views/nav/SideDrawer.js
@@ -81,7 +81,7 @@ const SideDrawer = () => {
     <div className="side-menu">
       <StyledDrawerHeader>
         {/* Need to adjust location of public folder to account for /viewer/ basepath */}
-        <img src="../vz_logo.png" alt="Vision Zero Austin Logo"></img>
+        <img src="/vz_logo.png" alt="Vision Zero Austin Logo"></img>
       </StyledDrawerHeader>
       <Container className="pt-3 pb-3">
         <SideDrawerMobileNav />

--- a/atd-vzv/src/views/nav/SideMapControl.js
+++ b/atd-vzv/src/views/nav/SideMapControl.js
@@ -93,7 +93,7 @@ const SideMapControl = () => {
       },
       fatal: {
         text: `Fatal`,
-        syntax: `death_cnt > 0`,
+        syntax: `apd_confirmed_death_count > 0`,
         type: `where`,
         operator: `AND`
       }

--- a/atd-vzv/src/views/summary/FatalitiesByTimeOfDay.js
+++ b/atd-vzv/src/views/summary/FatalitiesByTimeOfDay.js
@@ -73,12 +73,12 @@ const FatalitiesByTimeOfDayWeek = () => {
 
     const getFatalitiesByYearsAgoUrl = () => {
       if (activeTab === 0) {
-        return `https://data.austintexas.gov/resource/y2wy-tgr5.json?$where=death_cnt > 0 AND crash_date between '${thisYear}-01-01T00:00:00' and '${thisYear}-${lastMonth}-${lastDayOfLastMonth}T23:59:59'`;
+        return `https://data.austintexas.gov/resource/y2wy-tgr5.json?$where=apd_confirmed_death_count > 0 AND crash_date between '${thisYear}-01-01T00:00:00' and '${thisYear}-${lastMonth}-${lastDayOfLastMonth}T23:59:59'`;
       } else {
         let yearsAgoDate = moment()
           .subtract(activeTab, "year")
           .format("YYYY");
-        return `https://data.austintexas.gov/resource/y2wy-tgr5.json?$where=death_cnt > 0 AND crash_date between '${yearsAgoDate}-01-01T00:00:00' and '${yearsAgoDate}-12-31T23:59:59'`;
+        return `https://data.austintexas.gov/resource/y2wy-tgr5.json?$where=apd_confirmed_death_count > 0 AND crash_date between '${yearsAgoDate}-01-01T00:00:00' and '${yearsAgoDate}-12-31T23:59:59'`;
       }
     };
 

--- a/atd-vzv/src/views/summary/FatalitiesMultiYear.js
+++ b/atd-vzv/src/views/summary/FatalitiesMultiYear.js
@@ -60,7 +60,7 @@ const FatalitiesMultiYear = () => {
       let monthTotal = 0;
       data.data.forEach(record => {
         if (moment(record.crash_date).format("MM") === month) {
-          monthTotal += parseInt(record.death_cnt);
+          monthTotal += parseInt(record.apd_confirmed_death_count);
         }
       });
       cumulativeMonthTotal += monthTotal;
@@ -89,13 +89,13 @@ const FatalitiesMultiYear = () => {
 
   useEffect(() => {
     const lastMonthLastDayDate = `${thisYear}-${lastMonth}-${lastDayOfLastMonth}`;
-    const thisYearUrl = `${crashEndpointUrl}?$where=death_cnt > 0 AND crash_date between '${thisYear}-01-01T00:00:00' and '${lastMonthLastDayDate}T23:59:59'`;
+    const thisYearUrl = `${crashEndpointUrl}?$where=apd_confirmed_death_count > 0 AND crash_date between '${thisYear}-01-01T00:00:00' and '${lastMonthLastDayDate}T23:59:59'`;
 
     const getFatalitiesByYearsAgoUrl = yearsAgo => {
       let yearsAgoDate = moment()
         .subtract(yearsAgo, "year")
         .format("YYYY");
-      return `${crashEndpointUrl}?$where=death_cnt > 0 AND crash_date between '${yearsAgoDate}-01-01T00:00:00' and '${yearsAgoDate}-12-31T23:59:59'`;
+      return `${crashEndpointUrl}?$where=apd_confirmed_death_count > 0 AND crash_date between '${yearsAgoDate}-01-01T00:00:00' and '${yearsAgoDate}-12-31T23:59:59'`;
     };
 
     // If there is a full month of data available for the current year (i.e., we are past January),

--- a/atd-vzv/src/views/summary/helpers/helpers.js
+++ b/atd-vzv/src/views/summary/helpers/helpers.js
@@ -3,7 +3,7 @@ import { lifespanYears } from "../../../constants/calc";
 
 export const calculateTotalFatalities = data =>
   data.reduce(
-    (accumulator, record) => (accumulator += parseInt(record.death_cnt)),
+    (accumulator, record) => (accumulator += parseInt(record.apd_confirmed_death_count)),
     0
   );
 

--- a/atd-vzv/src/views/summary/queries/socrataQueries.js
+++ b/atd-vzv/src/views/summary/queries/socrataQueries.js
@@ -10,13 +10,13 @@ export const crashGeoJSONEndpointUrl = `https://data.austintexas.gov/resource/y2
 export const demographicsEndpointUrl = `https://data.austintexas.gov/resource/xecs-rpy9.json`;
 
 // Year to date queries
-export const thisYearFatalitiesUrl = `${crashEndpointUrl}?$where=death_cnt > 0 AND crash_date between '${thisYear}-01-01T00:00:00' and '${thisYear}-${lastMonth}-${lastDayOfLastMonth}T23:59:59'`;
+export const thisYearFatalitiesUrl = `${crashEndpointUrl}?$where=apd_confirmed_death_count > 0 AND crash_date between '${thisYear}-01-01T00:00:00' and '${thisYear}-${lastMonth}-${lastDayOfLastMonth}T23:59:59'`;
 export const thisYearSeriousInjuriesUrl = `${crashEndpointUrl}?$where=sus_serious_injry_cnt > 0 AND crash_date between '${thisYear}-01-01T00:00:00' and '${thisYear}-${lastMonth}-${lastDayOfLastMonth}T23:59:59'`;
 export const thisYearTotalCrashesUrl = `${crashEndpointUrl}?$where=crash_date between '${thisYear}-01-01T00:00:00' and '${thisYear}-${lastMonth}-${lastDayOfLastMonth}T23:59:59'&$limit=100000`;
 export const thisYearYearsOfLifeLostUrl = `${demographicsEndpointUrl}?$where=prsn_injry_sev_id = '4' AND crash_date between '${thisYear}-01-01T00:00:00' and '${thisYear}-${lastMonth}-${lastDayOfLastMonth}T23:59:59'`;
 
 // Previous year queries
-export const previousYearFatalitiesUrl = `${crashEndpointUrl}?$where=death_cnt > 0 AND crash_date between '${lastYear}-01-01T00:00:00' and '${lastYear}-12-31T23:59:59'`;
+export const previousYearFatalitiesUrl = `${crashEndpointUrl}?$where=apd_confirmed_death_count > 0 AND crash_date between '${lastYear}-01-01T00:00:00' and '${lastYear}-12-31T23:59:59'`;
 export const previousYearSeriousInjuriesUrl = `${crashEndpointUrl}?$where=sus_serious_injry_cnt > 0 AND crash_date between '${lastYear}-01-01T00:00:00' and '${lastYear}-12-31T23:59:59'`;
 export const previousYearTotalCrashesUrl = `${crashEndpointUrl}?$where=crash_date between '${lastYear}-01-01T00:00:00' and '${lastYear}-12-31T23:59:59'&$limit=100000`;
 export const previousYearYearsOfLifeLostUrl = `${demographicsEndpointUrl}?$where=prsn_injry_sev_id = '4' AND crash_date between '${lastYear}-01-01T00:00:00' and '${lastYear}-12-31T23:59:59'`;


### PR DESCRIPTION
Closes #614 

This PR adds columns `apd_confirmed_fatality` and `apd_confirmed_death_count` from the Crashes table and `prsn_ethnicity_id` from the People tables to the Socrata export script. It also changes all cases where `death_cnt` was referenced in VZV to `apd_confirmed_death_count` so that the viewer reflects VZE edits. The ETL script was run to update the Socrata dataset on 1/30/2020.

I also fixed a bug where the VZ logo file references were broken. They are now set to reference the root of the project so they will work in both development and staging/production.