### PR TITLE
Speed mgmt points & cost calculations bug

### DIFF
--- a/atd-vzd/triggers/atd_txdot_crashes_updates_audit_log.sql
+++ b/atd-vzd/triggers/atd_txdot_crashes_updates_audit_log.sql
@@ -94,7 +94,7 @@ BEGIN
     estCompEconList = ARRAY(SELECT est_econ_cost_amount FROM atd_txdot__est_econ_cost ORDER BY est_econ_cost_id ASC);
 
     NEW.est_comp_cost = (0
-       + (NEW.apd_confirmed_death_count * (estCompCostList[2]))
+       + (NEW.death_cnt * (estCompCostList[2]))
        + (NEW.sus_serious_injry_cnt * (estCompCostList[3]))
        + (NEW.nonincap_injry_cnt * (estCompCostList[4]))
        + (NEW.poss_injry_cnt * (estCompCostList[5]))
@@ -102,7 +102,7 @@ BEGIN
    )::decimal(10,2);
 
     NEW.est_econ_cost = (0
-       + (NEW.apd_confirmed_death_count * (estCompEconList[2]))
+       + (NEW.death_cnt * (estCompEconList[2]))
        + (NEW.sus_serious_injry_cnt * (estCompEconList[3]))
        + (NEW.nonincap_injry_cnt * (estCompEconList[4]))
        + (NEW.poss_injry_cnt * (estCompEconList[5]))
@@ -117,7 +117,7 @@ BEGIN
     speedMgmtList = ARRAY (SELECT speed_mgmt_points FROM atd_txdot__speed_mgmt_lkp ORDER BY speed_mgmt_id ASC);
 
 	NEW.speed_mgmt_points = (0 
-		+ (NEW.apd_confirmed_death_count * (speedMgmtList [2])) 
+		+ (NEW.death_cnt * (speedMgmtList [2])) 
         + (NEW.sus_serious_injry_cnt * (speedMgmtList [3])) 
         + (NEW.nonincap_injry_cnt * (speedMgmtList [4])) 
         + (NEW.poss_injry_cnt * (speedMgmtList [5])) 
@@ -130,5 +130,3 @@ BEGIN
     RETURN NEW;
 END;
 $function$
-
-ALTER FUNCTION atd_txdot_crashes_updates_audit_log() OWNER TO atd_vz_data;

--- a/atd-vze/src/Components/DataTable.js
+++ b/atd-vze/src/Components/DataTable.js
@@ -111,7 +111,11 @@ const DataTable = ({
 
                       const renderLookupDescString = () => {
                         // make sure the value isn't null blank
-                        if (!fieldValue) return "";
+                        if (
+                          fieldValue === null ||
+                          typeof fieldValue === "undefined"
+                        )
+                          return "";
 
                         // make sure there is a lookup object in the config
                         if (!selectOptions || !fieldConfigObject.lookupOptions)


### PR DESCRIPTION
Closes #577 

Previously, we were using the `apd_confirmed_death_count` as the base for calculating speed management points, economic costs and comprehensive cost values.

We've learned that the original CRIS fatality count is the correct field to use. So I've updated the trigger function in staging and in production in line with the SQL in the PR. And I've recalculated all the management points, economic costs and comprehensive cost values in both staging and production.

I also noticed a bug where fields that had values of `0` where not being displayed in all cases so I've updated the logic to be more permissive of falsely values and target undefined and nulls exclusively. 

### Before

![Screen Shot 2020-01-29 at 12 36 23 PM](https://user-images.githubusercontent.com/5697474/73404446-2676f500-42b7-11ea-8361-54548144a8eb.png)

### After

![Screen Shot 2020-01-29 at 4 39 07 PM](https://user-images.githubusercontent.com/5697474/73404438-22e36e00-42b7-11ea-9d64-91219c27876a.png)
