### PR TITLE
VZV | Include "Other" modes in mode comparisons

### DIFF
--- a/atd-vzv/src/constants/colors.js
+++ b/atd-vzv/src/constants/colors.js
@@ -13,6 +13,7 @@ export const colors = {
   chartRed: "#a50f15",
   chartOrange: "#fb6a4a",
   chartRedOrange: "#de2d26",
+  chartLightBlue: "#67a9cf",
   chartBlue: "#08519c",
   redGradient1Of5: "#fee5d9",
   redGradient2Of5: "#fcae91",

--- a/atd-vzv/src/constants/filters.js
+++ b/atd-vzv/src/constants/filters.js
@@ -1,0 +1,7 @@
+export const otherFiltersArray = [
+  "other_fl",
+  "train_fl",
+  "motorized_conveyance_fl",
+  "non_contact_fl",
+  "towed_pushed_trailer_fl"
+];

--- a/atd-vzv/src/constants/time.js
+++ b/atd-vzv/src/constants/time.js
@@ -2,8 +2,7 @@ import moment from "moment";
 
 // Time data
 
-// Last date of records that should be referenced in VZV
-// Show the last complete month of data
+// Last date of records that should be referenced in VZV (through last complete month of data)
 export const dataEndDate = moment()
   .subtract(1, "month")
   .endOf("month");

--- a/atd-vzv/src/constants/time.js
+++ b/atd-vzv/src/constants/time.js
@@ -1,12 +1,14 @@
 import moment from "moment";
 
-// Time data
-
 // Last date of records that should be referenced in VZV (through last complete month of data)
 export const dataEndDate = moment()
   .subtract(1, "month")
   .endOf("month");
 
+// Number of past years data to fetch
+export const rollingYearsOfData = 5;
+
+// Common time variables
 export const today = moment().format("YYYY-MM-DD");
 export const thisYear = moment().format("YYYY");
 export const oneYearAgo = moment()
@@ -29,8 +31,6 @@ export const lastMonthString = moment()
   .format("MMMM");
 
 // Map time data
-const rollingYearsOfData = 5;
-
 export const mapDataMinDate = new Date(
   moment()
     .subtract(rollingYearsOfData, "year")

--- a/atd-vzv/src/constants/time.js
+++ b/atd-vzv/src/constants/time.js
@@ -1,12 +1,18 @@
 import moment from "moment";
 
+// Number of past years data to fetch
+// 4 full years of data, plus data up to the last complete month of the current year
+export const rollingYearsOfData = 4;
+
 // Last date of records that should be referenced in VZV (through last complete month of data)
+export const dataStartDate = moment()
+  .subtract(1, "month")
+  .subtract(rollingYearsOfData, "year")
+  .startOf("year");
+
 export const dataEndDate = moment()
   .subtract(1, "month")
   .endOf("month");
-
-// Number of past years data to fetch
-export const rollingYearsOfData = 5;
 
 // Common time variables
 export const today = moment().format("YYYY-MM-DD");
@@ -31,15 +37,8 @@ export const lastMonthString = moment()
   .format("MMMM");
 
 // Map time data
-export const mapDataMinDate = new Date(
-  moment()
-    .subtract(rollingYearsOfData, "year")
-    .format("MM/DD/YYYY")
-);
-export const mapDataMaxDate = new Date(moment());
+export const mapDataMinDate = new Date(dataStartDate.format("MM/DD/YYYY"));
+export const mapDataMaxDate = new Date(dataEndDate);
 
-export const mapStartDate =
-  moment()
-    .subtract(rollingYearsOfData, "year")
-    .format("YYYY-MM-DD") + "T00:00:00";
-export const mapEndDate = moment().format("YYYY-MM-DD") + "T23:59:59";
+export const mapStartDate = dataStartDate.format("YYYY-MM-DD") + "T00:00:00";
+export const mapEndDate = dataEndDate.format("YYYY-MM-DD") + "T23:59:59";

--- a/atd-vzv/src/constants/time.js
+++ b/atd-vzv/src/constants/time.js
@@ -4,12 +4,13 @@ import moment from "moment";
 // 4 full years of data, plus data up to the last complete month of the current year
 export const rollingYearsOfData = 4;
 
-// Last date of records that should be referenced in VZV (through last complete month of data)
+// First date of records that should be referenced in VZV (start of first year in rolling window)
 export const dataStartDate = moment()
   .subtract(1, "month")
   .subtract(rollingYearsOfData, "year")
   .startOf("year");
 
+// Last date of records that should be referenced in VZV (through last complete month of data)
 export const dataEndDate = moment()
   .subtract(1, "month")
   .endOf("month");

--- a/atd-vzv/src/constants/time.js
+++ b/atd-vzv/src/constants/time.js
@@ -2,12 +2,12 @@ import moment from "moment";
 
 // Number of past years data to fetch
 // 4 full years of data, plus data up to the last complete month of the current year
-export const rollingYearsOfData = 4;
+export const ROLLING_YEARS_OF_DATA = 4;
 
 // First date of records that should be referenced in VZV (start of first year in rolling window)
 export const dataStartDate = moment()
   .subtract(1, "month")
-  .subtract(rollingYearsOfData, "year")
+  .subtract(ROLLING_YEARS_OF_DATA, "year")
   .startOf("year");
 
 // Last date of records that should be referenced in VZV (through last complete month of data)

--- a/atd-vzv/src/constants/time.js
+++ b/atd-vzv/src/constants/time.js
@@ -1,6 +1,13 @@
 import moment from "moment";
 
 // Time data
+
+// Last date of records that should be referenced in VZV
+// Show the last complete month of data
+export const dataEndDate = moment()
+  .subtract(1, "month")
+  .endOf("month");
+
 export const today = moment().format("YYYY-MM-DD");
 export const thisYear = moment().format("YYYY");
 export const oneYearAgo = moment()

--- a/atd-vzv/src/views/map/helpers.js
+++ b/atd-vzv/src/views/map/helpers.js
@@ -33,7 +33,7 @@ export const createMapDataUrl = (filters, dateRange) => {
   const whereFilterString = generateWhereFilters(filters);
 
   return (
-    `${crashGeoJSONEndpointUrl}?$limit=1000` +
+    `${crashGeoJSONEndpointUrl}?$limit=100000` +
     `&$where=crash_date between '${dateRange.start}' and '${dateRange.end}'` +
     // if there are filters applied, add AND operator to create valid query url
     `${filters.length > 0 ? " AND" : ""} ${whereFilterString || ""}`

--- a/atd-vzv/src/views/map/helpers.js
+++ b/atd-vzv/src/views/map/helpers.js
@@ -36,6 +36,6 @@ export const createMapDataUrl = (filters, dateRange) => {
     `${crashGeoJSONEndpointUrl}?$limit=1000` +
     `&$where=crash_date between '${dateRange.start}' and '${dateRange.end}'` +
     // if there are filters applied, add AND operator to create valid query url
-    `${filters.length > 0 ? "AND" : ""} ${whereFilterString || ""}`
+    `${filters.length > 0 ? " AND" : ""} ${whereFilterString || ""}`
   );
 };

--- a/atd-vzv/src/views/nav/SideMapControl.js
+++ b/atd-vzv/src/views/nav/SideMapControl.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useCallback, useState } from "react";
+import React, { useEffect, useState } from "react";
 import { StoreContext } from "../../utils/store";
 import "react-infinite-calendar/styles.css";
 
@@ -54,34 +54,39 @@ const SideMapControl = () => {
   const mapFilters = {
     mode: {
       pedestrian: {
-        icon: faWalking,
-        syntax: `pedestrian_fl = "Y"`,
-        type: `where`,
-        operator: `OR`
+        icon: faWalking, // Font Awesome icon object
+        syntax: `pedestrian_fl = "Y"`, // Socrata SoQL query string
+        type: `where`, // Socrata SoQL query type
+        operator: `OR`, // Logical operator for joining multiple query strings
+        default: true // Apply filter as default on render
       },
       pedalcyclist: {
         icon: faBiking,
         syntax: `pedalcyclist_fl = "Y"`,
         type: `where`,
-        operator: `OR`
+        operator: `OR`,
+        default: true
       },
       motor: {
         icon: faCar,
         syntax: `motor_vehicle_fl = "Y"`,
         type: `where`,
-        operator: `OR`
+        operator: `OR`,
+        default: true
       },
       motorcycle: {
         icon: faMotorcycle,
         syntax: `motorcycle_fl = "Y"`,
         type: `where`,
-        operator: `OR`
+        operator: `OR`,
+        default: true
       },
       other: {
         text: "Other",
         syntax: buildOtherFiltersString(),
         type: `where`,
-        operator: `OR`
+        operator: `OR`,
+        default: true
       }
     },
     type: {
@@ -89,13 +94,15 @@ const SideMapControl = () => {
         text: `Injury`,
         syntax: `sus_serious_injry_cnt > 0`,
         type: `where`,
-        operator: `OR`
+        operator: `OR`,
+        default: true
       },
       fatal: {
         text: `Fatal`,
         syntax: `apd_confirmed_death_count > 0`,
         type: `where`,
-        operator: `OR`
+        operator: `OR`,
+        default: false
       }
     }
   };
@@ -108,9 +115,12 @@ const SideMapControl = () => {
         (accumulator, [type, filtersGroup]) => {
           const groupFilters = Object.entries(filtersGroup).reduce(
             (accumulator, [name, filterConfig]) => {
-              filterConfig["name"] = name;
-              filterConfig["group"] = type;
-              accumulator.push(filterConfig);
+              // Apply filter only if set as a default on render
+              if (filterConfig.default) {
+                filterConfig["name"] = name;
+                filterConfig["group"] = type;
+                accumulator.push(filterConfig);
+              }
               return accumulator;
             },
             []

--- a/atd-vzv/src/views/nav/SideMapControl.js
+++ b/atd-vzv/src/views/nav/SideMapControl.js
@@ -39,18 +39,6 @@ const SideMapControl = () => {
     mapFilters: [filters, setFilters]
   } = React.useContext(StoreContext);
 
-  // Clear all filters that match group arg
-  // const handleAllFiltersClick = (event, group) => {
-  //   const keepFilters = filters.filter(filter => filter.group !== group);
-  //   setFilters(keepFilters);
-  // };
-
-  // // Determine if no filters in a group are applied (used for "All" buttons active/inactive state)
-  // const isUnfiltered = group => {
-  //   const result = filters.filter(filter => filter.group === group);
-  //   return result.length === 0;
-  // };
-
   const buildOtherFiltersString = () =>
     otherFiltersArray
       .reduce((accumulator, filterString) => {
@@ -92,12 +80,6 @@ const SideMapControl = () => {
         type: `where`,
         operator: `OR`
       }
-      // all: {
-      //   text: "All",
-      //   handler: handleAllFiltersClick,
-      //   active: isUnfiltered,
-      //   inactive: isUnfiltered
-      // }
     },
     type: {
       seriousInjury: {
@@ -153,21 +135,9 @@ const SideMapControl = () => {
                 id={name}
                 color="info"
                 className="w-100 pt-1 pb-1 pl-0 pr-0"
-                // Use alternate handler if defined
-                onClick={
-                  parameter.handler
-                    ? event => parameter.handler(event, group)
-                    : event => handleFilterClick(event, group)
-                }
-                // Use alternate active/inactive fn if defined
-                active={
-                  parameter.active ? parameter.active(group) : isFilterSet(name)
-                }
-                outline={
-                  parameter.inactive
-                    ? !parameter.inactive(group)
-                    : !isFilterSet(name)
-                }
+                onClick={event => handleFilterClick(event, group)}
+                active={isFilterSet(name)}
+                outline={!isFilterSet(name)}
               >
                 {parameter.icon && (
                   <FontAwesomeIcon

--- a/atd-vzv/src/views/nav/SideMapControl.js
+++ b/atd-vzv/src/views/nav/SideMapControl.js
@@ -112,21 +112,21 @@ const SideMapControl = () => {
     // If no filters are applied (initial render), set all default filters
     if (Object.keys(filters).length === 0) {
       const initialFiltersArray = Object.entries(mapFilters).reduce(
-        (accumulator, [type, filtersGroup]) => {
+        (allFiltersAccumulator, [type, filtersGroup]) => {
           const groupFilters = Object.entries(filtersGroup).reduce(
-            (accumulator, [name, filterConfig]) => {
+            (groupFiltersAccumulator, [name, filterConfig]) => {
               // Apply filter only if set as a default on render
               if (filterConfig.default) {
                 filterConfig["name"] = name;
                 filterConfig["group"] = type;
-                accumulator.push(filterConfig);
+                groupFiltersAccumulator.push(filterConfig);
               }
-              return accumulator;
+              return groupFiltersAccumulator;
             },
             []
           );
-          accumulator = [...accumulator, ...groupFilters];
-          return accumulator;
+          allFiltersAccumulator = [...allFiltersAccumulator, ...groupFilters];
+          return allFiltersAccumulator;
         },
         []
       );

--- a/atd-vzv/src/views/nav/SideMapControl.js
+++ b/atd-vzv/src/views/nav/SideMapControl.js
@@ -107,9 +107,9 @@ const SideMapControl = () => {
     }
   };
 
-  // Reduce all filters and set all as active on render
+  // Reduce all filters and set defaults as active on render
   useEffect(() => {
-    // If no filters are applied (initial render), set all filters
+    // If no filters are applied (initial render), set all default filters
     if (Object.keys(filters).length === 0) {
       const initialFiltersArray = Object.entries(mapFilters).reduce(
         (accumulator, [type, filtersGroup]) => {

--- a/atd-vzv/src/views/nav/SideMapControl.js
+++ b/atd-vzv/src/views/nav/SideMapControl.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useCallback, useState } from "react";
 import { StoreContext } from "../../utils/store";
 import "react-infinite-calendar/styles.css";
 
@@ -102,24 +102,27 @@ const SideMapControl = () => {
 
   // Reduce all filters and set all as active on render
   useEffect(() => {
-    const initialFiltersArray = Object.entries(mapFilters).reduce(
-      (accumulator, [type, filters]) => {
-        const groupFilters = Object.entries(filters).reduce(
-          (accumulator, [name, filterConfig]) => {
-            filterConfig["name"] = name;
-            filterConfig["group"] = type;
-            accumulator.push(filterConfig);
-            return accumulator;
-          },
-          []
-        );
-        accumulator = [...accumulator, ...groupFilters];
-        return accumulator;
-      },
-      []
-    );
-    setFilters(initialFiltersArray);
-  }, []);
+    // If no filters are applied (initial render), set all filters
+    if (Object.keys(filters).length === 0) {
+      const initialFiltersArray = Object.entries(mapFilters).reduce(
+        (accumulator, [type, filtersGroup]) => {
+          const groupFilters = Object.entries(filtersGroup).reduce(
+            (accumulator, [name, filterConfig]) => {
+              filterConfig["name"] = name;
+              filterConfig["group"] = type;
+              accumulator.push(filterConfig);
+              return accumulator;
+            },
+            []
+          );
+          accumulator = [...accumulator, ...groupFilters];
+          return accumulator;
+        },
+        []
+      );
+      setFilters(initialFiltersArray);
+    }
+  }, [mapFilters, setFilters, filters]);
 
   // Set count of filters applied to keep one of each type applied at all times
   useEffect(() => {

--- a/atd-vzv/src/views/nav/SideMapControl.js
+++ b/atd-vzv/src/views/nav/SideMapControl.js
@@ -5,6 +5,7 @@ import "react-infinite-calendar/styles.css";
 import SideMapControlDateRange from "./SideMapControlDateRange";
 import SideMapControlOverlays from "./SideMapControlOverlays";
 import { colors } from "../../constants/colors";
+import { otherFiltersArray } from "../../constants/filters";
 import { ButtonGroup, Button, Card, Label } from "reactstrap";
 import styled from "styled-components";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -39,16 +40,24 @@ const SideMapControl = () => {
   } = React.useContext(StoreContext);
 
   // Clear all filters that match group arg
-  const handleAllFiltersClick = (event, group) => {
-    const keepFilters = filters.filter(filter => filter.group !== group);
-    setFilters(keepFilters);
-  };
+  // const handleAllFiltersClick = (event, group) => {
+  //   const keepFilters = filters.filter(filter => filter.group !== group);
+  //   setFilters(keepFilters);
+  // };
 
-  // Determine if no filters in a group are applied (used for "All" buttons active/inactive state)
-  const isUnfiltered = group => {
-    const result = filters.filter(filter => filter.group === group);
-    return result.length === 0;
-  };
+  // // Determine if no filters in a group are applied (used for "All" buttons active/inactive state)
+  // const isUnfiltered = group => {
+  //   const result = filters.filter(filter => filter.group === group);
+  //   return result.length === 0;
+  // };
+
+  const buildOtherFiltersString = () =>
+    otherFiltersArray
+      .reduce((accumulator, filterString) => {
+        accumulator.push(`${filterString} = "Y"`);
+        return accumulator;
+      }, [])
+      .join(" OR ");
 
   // Define groups of map filters
   const mapFilters = {
@@ -77,12 +86,18 @@ const SideMapControl = () => {
         type: `where`,
         operator: `OR`
       },
-      all: {
-        text: "All",
-        handler: handleAllFiltersClick,
-        active: isUnfiltered,
-        inactive: isUnfiltered
+      other: {
+        text: "Other",
+        syntax: buildOtherFiltersString(),
+        type: `where`,
+        operator: `OR`
       }
+      // all: {
+      //   text: "All",
+      //   handler: handleAllFiltersClick,
+      //   active: isUnfiltered,
+      //   inactive: isUnfiltered
+      // }
     },
     type: {
       seriousInjury: {

--- a/atd-vzv/src/views/nav/SideMapControl.js
+++ b/atd-vzv/src/views/nav/SideMapControl.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { StoreContext } from "../../utils/store";
 import "react-infinite-calendar/styles.css";
 
@@ -39,6 +39,9 @@ const SideMapControl = () => {
     mapFilters: [filters, setFilters]
   } = React.useContext(StoreContext);
 
+  const [filterGroupCounts, setFilterGroupCounts] = useState({});
+
+  // Build filter string for Other modes
   const buildOtherFiltersString = () =>
     otherFiltersArray
       .reduce((accumulator, filterString) => {
@@ -86,22 +89,50 @@ const SideMapControl = () => {
         text: `Injury`,
         syntax: `sus_serious_injry_cnt > 0`,
         type: `where`,
-        operator: `AND`
+        operator: `OR`
       },
       fatal: {
         text: `Fatal`,
         syntax: `apd_confirmed_death_count > 0`,
         type: `where`,
-        operator: `AND`
+        operator: `OR`
       }
     }
   };
+
+  useEffect(() => {
+    // Reduce all filters and set active filters (apply all filters on render)
+    const initialFiltersArray = Object.entries(mapFilters).reduce(
+      (accumulator, [type, filters]) => {
+        const groupFilters = Object.entries(filters).reduce(
+          (accumulator, [name, filterConfig]) => {
+            filterConfig["name"] = name;
+            filterConfig["group"] = type;
+            accumulator.push(filterConfig);
+            return accumulator;
+          },
+          []
+        );
+        accumulator = [...accumulator, ...groupFilters];
+        return accumulator;
+      },
+      []
+    );
+    setFilters(initialFiltersArray);
+  }, []);
+
+  // useEffect(() => {
+  //   const filtersCount = Object.entries(filters).reduce((accumulator, [type, filterConfig]) => {
+
+  //   }, {})
+  // }, [filters])
 
   const handleFilterClick = (event, filterGroup) => {
     // Set filter or remove if already set
     const filterName = event.currentTarget.id;
 
     if (isFilterSet(filterName)) {
+      // if there is at least one type of each filter set, remove, else don't!
       const updatedFiltersArray = filters.filter(
         setFilter => setFilter.name !== filterName
       );

--- a/atd-vzv/src/views/nav/SideMapControl.js
+++ b/atd-vzv/src/views/nav/SideMapControl.js
@@ -100,7 +100,7 @@ const SideMapControl = () => {
     }
   };
 
-  // Reduce all filters and set active filters (apply all filters on render)
+  // Reduce all filters and set all as active on render
   useEffect(() => {
     const initialFiltersArray = Object.entries(mapFilters).reduce(
       (accumulator, [type, filters]) => {
@@ -121,6 +121,7 @@ const SideMapControl = () => {
     setFilters(initialFiltersArray);
   }, []);
 
+  // Set count of filters applied to keep one of each type applied at all times
   useEffect(() => {
     const filtersCount = filters.reduce((accumulator, filter) => {
       if (accumulator[filter.group]) {
@@ -136,15 +137,21 @@ const SideMapControl = () => {
     setFilterGroupCounts(filtersCount);
   }, [filters]);
 
+  const isFilterSet = filterName => {
+    return !!filters.find(setFilter => setFilter.name === filterName);
+  };
+
+  const isOneFilterOfEachTypeApplied = group => filterGroupCounts[group] > 1;
+
+  // Set filter or remove if already set
   const handleFilterClick = (event, filterGroup) => {
-    // Set filter or remove if already set
     const filterName = event.currentTarget.id;
 
     if (isFilterSet(filterName)) {
-      // if there is at least one type of each filter set, remove, else don't!
-      const updatedFiltersArray = filters.filter(
-        setFilter => setFilter.name !== filterName
-      );
+      // If there is at least one filter from each group set, remove it
+      const updatedFiltersArray = isOneFilterOfEachTypeApplied(filterGroup)
+        ? filters.filter(setFilter => setFilter.name !== filterName)
+        : filters;
       setFilters(updatedFiltersArray);
     } else {
       const filter = mapFilters[filterGroup][filterName];
@@ -154,10 +161,6 @@ const SideMapControl = () => {
       const filtersArray = [...filters, filter];
       setFilters(filtersArray);
     }
-  };
-
-  const isFilterSet = filterName => {
-    return !!filters.find(setFilter => setFilter.name === filterName);
   };
 
   return (

--- a/atd-vzv/src/views/nav/SideMapControl.js
+++ b/atd-vzv/src/views/nav/SideMapControl.js
@@ -154,15 +154,15 @@ const SideMapControl = () => {
     return !!filters.find(setFilter => setFilter.name === filterName);
   };
 
-  const isOneFilterOfEachTypeApplied = group => filterGroupCounts[group] > 1;
+  const isOneFilterOfGroupApplied = group => filterGroupCounts[group] > 1;
 
   // Set filter or remove if already set
   const handleFilterClick = (event, filterGroup) => {
     const filterName = event.currentTarget.id;
 
     if (isFilterSet(filterName)) {
-      // If there is at least one filter from each group set, remove it
-      const updatedFiltersArray = isOneFilterOfEachTypeApplied(filterGroup)
+      // Always leave one filter applied per group
+      const updatedFiltersArray = isOneFilterOfGroupApplied(filterGroup)
         ? filters.filter(setFilter => setFilter.name !== filterName)
         : filters;
       setFilters(updatedFiltersArray);

--- a/atd-vzv/src/views/nav/SideMapControl.js
+++ b/atd-vzv/src/views/nav/SideMapControl.js
@@ -100,8 +100,8 @@ const SideMapControl = () => {
     }
   };
 
+  // Reduce all filters and set active filters (apply all filters on render)
   useEffect(() => {
-    // Reduce all filters and set active filters (apply all filters on render)
     const initialFiltersArray = Object.entries(mapFilters).reduce(
       (accumulator, [type, filters]) => {
         const groupFilters = Object.entries(filters).reduce(
@@ -121,11 +121,20 @@ const SideMapControl = () => {
     setFilters(initialFiltersArray);
   }, []);
 
-  // useEffect(() => {
-  //   const filtersCount = Object.entries(filters).reduce((accumulator, [type, filterConfig]) => {
-
-  //   }, {})
-  // }, [filters])
+  useEffect(() => {
+    const filtersCount = filters.reduce((accumulator, filter) => {
+      if (accumulator[filter.group]) {
+        accumulator = {
+          ...accumulator,
+          [filter.group]: accumulator[filter.group] + 1
+        };
+      } else {
+        accumulator = { ...accumulator, [filter.group]: 1 };
+      }
+      return accumulator;
+    }, {});
+    setFilterGroupCounts(filtersCount);
+  }, [filters]);
 
   const handleFilterClick = (event, filterGroup) => {
     // Set filter or remove if already set

--- a/atd-vzv/src/views/nav/SideMapControlDateRange.js
+++ b/atd-vzv/src/views/nav/SideMapControlDateRange.js
@@ -16,7 +16,7 @@ const CalendarWithRange = withRange(Calendar);
 const StyledDateRangePicker = styled.div`
   /* Resize month and day in header */
   .Cal__Header__day {
-    font-size: 1.3em;
+    font-size: 1.3em !important;
   }
 `;
 

--- a/atd-vzv/src/views/summary/FatalitiesByMode.js
+++ b/atd-vzv/src/views/summary/FatalitiesByMode.js
@@ -1,14 +1,12 @@
 import React, { useEffect, useState, useCallback } from "react";
 import axios from "axios";
-import moment from "moment";
 import { Bar } from "react-chartjs-2";
 import { colors } from "../../constants/colors";
 
 import { Container } from "reactstrap";
 import {
-  thisMonth,
+  dataEndDate,
   thisYear,
-  lastYear,
   lastMonth,
   lastDayOfLastMonth
 } from "../../constants/time";
@@ -51,19 +49,16 @@ const FatalitiesByMode = () => {
   // Create array of ints of last 5 years
   const yearsArray = useCallback(() => {
     let years = [];
-    // If it is past January, display data up to and including current year,
-    // else if it is January, only display data up to the end of last year
-    let year = thisMonth > "01" ? thisYear : lastYear;
+    let year = parseInt(dataEndDate.format("YYYY"));
     for (let i = 0; i < yearLimit; i++) {
-      years.unshift(parseInt(year) - i);
+      years.unshift(year - i);
     }
     return years;
   }, []);
 
   const [chartData, setChartData] = useState("");
-  const [latestRecordDate, setLatestRecordDate] = useState("");
 
-  // Fetch data (Mode of fatality in crash) in one go this time
+  // Fetch data (Mode of fatality in crash)
   useEffect(() => {
     const getChartData = async () => {
       let newData = {};
@@ -88,48 +83,6 @@ const FatalitiesByMode = () => {
 
     getChartData();
   }, [yearsArray]);
-
-  // Fetch data (Mode of fatality in crash)
-  // useEffect(() => {
-  //   const getChartData = async () => {
-  //     let newData = {};
-  //     // Use Promise.all to let all requests resolve before setting chart data by year
-  //     await Promise.all(
-  //       yearsArray().map(async year => {
-  //         // If getting data for current year (only including years past January), set end of query to last day of previous month,
-  //         // else if getting data for previous years, set end of query to last day of year
-  //         let endDate =
-  //           year.toString() === thisYear
-  //             ? `${year}-${lastMonth}-${lastDayOfLastMonth}T23:59:59`
-  //             : `${year}-12-31T23:59:59`;
-  //         let url = `${demographicsEndpointUrl}?$where=(prsn_injry_sev_id = 4) AND crash_date between '${year}-01-01T00:00:00' and '${endDate}'`;
-  //         await axios.get(url).then(res => {
-  //           newData = { ...newData, ...{ [year]: res.data } };
-  //         });
-  //         return null;
-  //       })
-  //     );
-  //     setChartData(newData);
-  //   };
-
-  //   getChartData();
-  // }, [yearsArray]);
-
-  // Fetch latest record from demographics dataset and set for chart subheading
-  useEffect(() => {
-    // If it is past January, set end of query to last day of previous month,
-    // else if it is January, set end of query to last day of last year
-    let endDate =
-      thisMonth > "01"
-        ? `${thisYear}-${lastMonth}-${lastDayOfLastMonth}T23:59:59`
-        : `${lastYear}-12-31T23:59:59`;
-    let url = `${demographicsEndpointUrl}?$limit=1&$order=crash_date DESC&$where=crash_date < '${endDate}'`;
-    axios.get(url).then(res => {
-      const latestRecordDate = res.data[0].crash_date;
-      const formattedLatestDate = moment(latestRecordDate).format("MMMM YYYY");
-      setLatestRecordDate(formattedLatestDate);
-    });
-  }, []);
 
   const createChartLabels = () => yearsArray().map(year => `${year}`);
 
@@ -181,7 +134,9 @@ const FatalitiesByMode = () => {
           }
         }}
       />
-      <p className="text-center">Data Through: {latestRecordDate}</p>
+      <p className="text-center">
+        Data Through: {dataEndDate.format("MMMM YYYY")}
+      </p>
     </Container>
   );
 };

--- a/atd-vzv/src/views/summary/FatalitiesByMode.js
+++ b/atd-vzv/src/views/summary/FatalitiesByMode.js
@@ -2,14 +2,8 @@ import React, { useEffect, useState, useCallback } from "react";
 import axios from "axios";
 import { Bar } from "react-chartjs-2";
 import { colors } from "../../constants/colors";
-
 import { Container } from "reactstrap";
-import {
-  dataEndDate,
-  thisYear,
-  lastMonth,
-  lastDayOfLastMonth
-} from "../../constants/time";
+import { dataEndDate, thisYear } from "../../constants/time";
 import { demographicsEndpointUrl } from "./queries/socrataQueries";
 
 const FatalitiesByMode = () => {
@@ -56,9 +50,9 @@ const FatalitiesByMode = () => {
     return years;
   }, []);
 
-  const [chartData, setChartData] = useState("");
+  const [chartData, setChartData] = useState(""); // {yearInt: [{record}, {record}, ...]}
 
-  // Fetch data (Mode of fatality in crash)
+  // Fetch data and set in state by years in yearsArray
   useEffect(() => {
     const getChartData = async () => {
       let newData = {};
@@ -69,7 +63,7 @@ const FatalitiesByMode = () => {
           // else if getting data for previous years, set end of query to last day of year
           let endDate =
             year.toString() === thisYear
-              ? `${year}-${lastMonth}-${lastDayOfLastMonth}T23:59:59`
+              ? `${dataEndDate.format("YYYY-MM-DD")}T23:59:59`
               : `${year}-12-31T23:59:59`;
           let url = `${demographicsEndpointUrl}?$where=(prsn_injry_sev_id = 4) AND crash_date between '${year}-01-01T00:00:00' and '${endDate}'`;
           await axios.get(url).then(res => {

--- a/atd-vzv/src/views/summary/FatalitiesByMode.js
+++ b/atd-vzv/src/views/summary/FatalitiesByMode.js
@@ -8,7 +8,7 @@ import { otherFiltersArray } from "../../constants/filters";
 import {
   dataEndDate,
   thisYear,
-  rollingYearsOfData
+  ROLLING_YEARS_OF_DATA
 } from "../../constants/time";
 import { demographicsEndpointUrl } from "./queries/socrataQueries";
 
@@ -41,7 +41,7 @@ const FatalitiesByMode = () => {
   const yearsArray = useCallback(() => {
     let years = [];
     let year = parseInt(dataEndDate.format("YYYY"));
-    for (let i = 0; i <= rollingYearsOfData; i++) {
+    for (let i = 0; i <= ROLLING_YEARS_OF_DATA; i++) {
       years.unshift(year - i);
     }
     return years;

--- a/atd-vzv/src/views/summary/FatalitiesByMode.js
+++ b/atd-vzv/src/views/summary/FatalitiesByMode.js
@@ -1,8 +1,10 @@
 import React, { useEffect, useState, useCallback } from "react";
 import axios from "axios";
 import { Bar } from "react-chartjs-2";
-import { colors } from "../../constants/colors";
+
 import { Container } from "reactstrap";
+import { colors } from "../../constants/colors";
+import { otherFiltersArray } from "../../constants/filters";
 import { dataEndDate, thisYear } from "../../constants/time";
 import { demographicsEndpointUrl } from "./queries/socrataQueries";
 
@@ -26,13 +28,7 @@ const FatalitiesByMode = () => {
     },
     {
       label: "Other",
-      flags: [
-        "other_fl",
-        "train_fl",
-        "motorized_conveyance_fl",
-        "non_contact_fl",
-        "towed_push_trailer_fl"
-      ],
+      flags: otherFiltersArray,
       color: colors.chartLightBlue
     }
   ];

--- a/atd-vzv/src/views/summary/FatalitiesByMode.js
+++ b/atd-vzv/src/views/summary/FatalitiesByMode.js
@@ -17,16 +17,35 @@ import { demographicsEndpointUrl } from "./queries/socrataQueries";
 const FatalitiesByMode = () => {
   // Define stacked bar chart properties in order of stack
   const modes = [
-    { label: "Motor", flag: "motor_vehicle_fl", color: colors.chartRed },
-    { label: "Pedestrian", flag: "pedestrian_fl", color: colors.chartOrange },
+    { label: "Motor", flags: ["motor_vehicle_fl"], color: colors.chartRed },
+    {
+      label: "Pedestrian",
+      flags: ["pedestrian_fl"],
+      color: colors.chartOrange
+    },
     {
       label: "Motorcycle",
-      flag: "motorcycle_fl",
+      flags: ["motorcycle_fl"],
       color: colors.chartRedOrange
     },
-    { label: "Pedalcyclist", flag: "pedalcyclist_fl", color: colors.chartBlue }
+    {
+      label: "Pedalcyclist",
+      flags: ["pedalcyclist_fl"],
+      color: colors.chartLightBlue
+    },
+    {
+      label: "Other",
+      flags: [
+        "other_fl",
+        "train_fl",
+        "motorized_conveyance_fl",
+        "non_contact_fl",
+        "towed_push_trailer_fl"
+      ],
+      color: colors.chartBlue
+    }
   ];
-  const yearLimit = 10; // Number of years to display in chart
+  const yearLimit = 5; // Number of years to display in chart
   const yearsArray = useCallback(() => {
     let years = [];
     // If it is past January, display data up to and including current year,
@@ -89,12 +108,14 @@ const FatalitiesByMode = () => {
       .map(year => `${year}`);
 
   // Tabulate fatalities by mode from data
-  const getModeData = flag =>
+  const getModeData = flags =>
     yearsArray()
       .sort()
       .map(year => {
         let fatalities = 0;
-        chartData[year].forEach(f => f[`${flag}`] === "Y" && fatalities++);
+        chartData[year].forEach(record =>
+          flags.forEach(flag => record[`${flag}`] === "Y" && fatalities++)
+        );
         return fatalities;
       });
 
@@ -108,7 +129,7 @@ const FatalitiesByMode = () => {
       hoverBackgroundColor: mode.color,
       hoverBorderColor: mode.color,
       label: mode.label,
-      data: getModeData(mode.flag)
+      data: getModeData(mode.flags)
     }));
 
   const data = {

--- a/atd-vzv/src/views/summary/FatalitiesByMode.js
+++ b/atd-vzv/src/views/summary/FatalitiesByMode.js
@@ -6,7 +6,6 @@ import { Container } from "reactstrap";
 import { colors } from "../../constants/colors";
 import { otherFiltersArray } from "../../constants/filters";
 import {
-  dataStartDate,
   dataEndDate,
   thisYear,
   rollingYearsOfData
@@ -42,7 +41,7 @@ const FatalitiesByMode = () => {
   const yearsArray = useCallback(() => {
     let years = [];
     let year = parseInt(dataEndDate.format("YYYY"));
-    for (let i = 0; i < rollingYearsOfData; i++) {
+    for (let i = 0; i <= rollingYearsOfData; i++) {
       years.unshift(year - i);
     }
     return years;

--- a/atd-vzv/src/views/summary/FatalitiesByMode.js
+++ b/atd-vzv/src/views/summary/FatalitiesByMode.js
@@ -6,6 +6,7 @@ import { Container } from "reactstrap";
 import { colors } from "../../constants/colors";
 import { otherFiltersArray } from "../../constants/filters";
 import {
+  dataStartDate,
   dataEndDate,
   thisYear,
   rollingYearsOfData

--- a/atd-vzv/src/views/summary/FatalitiesByMode.js
+++ b/atd-vzv/src/views/summary/FatalitiesByMode.js
@@ -38,7 +38,7 @@ const FatalitiesByMode = () => {
     }
   ];
 
-  const yearLimit = 5; // Number of years to display in chart
+  const yearLimit = 5; // Set number of years to display in chart
 
   // Create array of ints of last 5 years
   const yearsArray = useCallback(() => {
@@ -59,8 +59,7 @@ const FatalitiesByMode = () => {
       // Use Promise.all to let all requests resolve before setting chart data by year
       await Promise.all(
         yearsArray().map(async year => {
-          // If getting data for current year (only including years past January), set end of query to last day of previous month,
-          // else if getting data for previous years, set end of query to last day of year
+          // If current year, set end of query to last day of previous month, else set to last day of year
           let endDate =
             year.toString() === thisYear
               ? `${dataEndDate.format("YYYY-MM-DD")}T23:59:59`
@@ -80,7 +79,7 @@ const FatalitiesByMode = () => {
 
   const createChartLabels = () => yearsArray().map(year => `${year}`);
 
-  // Tabulate fatalities by mode from data
+  // Tabulate fatalities by mode flags in data
   const getModeData = flags =>
     yearsArray().map(year => {
       let fatalities = 0;
@@ -90,8 +89,7 @@ const FatalitiesByMode = () => {
       return fatalities;
     });
 
-  // Create dataset for each mode type
-  // data property is an array of fatality sums sorted chronologically
+  // Create dataset for each mode type, data property is an array of fatality sums sorted chronologically
   const createTypeDatasets = () =>
     modes.map(mode => ({
       backgroundColor: mode.color,

--- a/atd-vzv/src/views/summary/FatalitiesByMode.js
+++ b/atd-vzv/src/views/summary/FatalitiesByMode.js
@@ -5,7 +5,11 @@ import { Bar } from "react-chartjs-2";
 import { Container } from "reactstrap";
 import { colors } from "../../constants/colors";
 import { otherFiltersArray } from "../../constants/filters";
-import { dataEndDate, thisYear } from "../../constants/time";
+import {
+  dataEndDate,
+  thisYear,
+  rollingYearsOfData
+} from "../../constants/time";
 import { demographicsEndpointUrl } from "./queries/socrataQueries";
 
 const FatalitiesByMode = () => {
@@ -33,13 +37,11 @@ const FatalitiesByMode = () => {
     }
   ];
 
-  const yearLimit = 5; // Set number of years to display in chart
-
   // Create array of ints of last 5 years
   const yearsArray = useCallback(() => {
     let years = [];
     let year = parseInt(dataEndDate.format("YYYY"));
-    for (let i = 0; i < yearLimit; i++) {
+    for (let i = 0; i < rollingYearsOfData; i++) {
       years.unshift(year - i);
     }
     return years;

--- a/atd-vzv/src/views/summary/FatalitiesByMode.js
+++ b/atd-vzv/src/views/summary/FatalitiesByMode.js
@@ -31,7 +31,7 @@ const FatalitiesByMode = () => {
     {
       label: "Pedalcyclist",
       flags: ["pedalcyclist_fl"],
-      color: colors.chartLightBlue
+      color: colors.chartBlue
     },
     {
       label: "Other",
@@ -42,17 +42,20 @@ const FatalitiesByMode = () => {
         "non_contact_fl",
         "towed_push_trailer_fl"
       ],
-      color: colors.chartBlue
+      color: colors.chartLightBlue
     }
   ];
+
   const yearLimit = 5; // Number of years to display in chart
+
+  // Create array of ints of last 5 years
   const yearsArray = useCallback(() => {
     let years = [];
     // If it is past January, display data up to and including current year,
     // else if it is January, only display data up to the end of last year
     let year = thisMonth > "01" ? thisYear : lastYear;
     for (let i = 0; i < yearLimit; i++) {
-      years.push(parseInt(year) - i);
+      years.unshift(parseInt(year) - i);
     }
     return years;
   }, []);
@@ -60,7 +63,7 @@ const FatalitiesByMode = () => {
   const [chartData, setChartData] = useState("");
   const [latestRecordDate, setLatestRecordDate] = useState("");
 
-  // Fetch data (Mode of fatality in crash)
+  // Fetch data (Mode of fatality in crash) in one go this time
   useEffect(() => {
     const getChartData = async () => {
       let newData = {};
@@ -86,6 +89,32 @@ const FatalitiesByMode = () => {
     getChartData();
   }, [yearsArray]);
 
+  // Fetch data (Mode of fatality in crash)
+  // useEffect(() => {
+  //   const getChartData = async () => {
+  //     let newData = {};
+  //     // Use Promise.all to let all requests resolve before setting chart data by year
+  //     await Promise.all(
+  //       yearsArray().map(async year => {
+  //         // If getting data for current year (only including years past January), set end of query to last day of previous month,
+  //         // else if getting data for previous years, set end of query to last day of year
+  //         let endDate =
+  //           year.toString() === thisYear
+  //             ? `${year}-${lastMonth}-${lastDayOfLastMonth}T23:59:59`
+  //             : `${year}-12-31T23:59:59`;
+  //         let url = `${demographicsEndpointUrl}?$where=(prsn_injry_sev_id = 4) AND crash_date between '${year}-01-01T00:00:00' and '${endDate}'`;
+  //         await axios.get(url).then(res => {
+  //           newData = { ...newData, ...{ [year]: res.data } };
+  //         });
+  //         return null;
+  //       })
+  //     );
+  //     setChartData(newData);
+  //   };
+
+  //   getChartData();
+  // }, [yearsArray]);
+
   // Fetch latest record from demographics dataset and set for chart subheading
   useEffect(() => {
     // If it is past January, set end of query to last day of previous month,
@@ -102,22 +131,17 @@ const FatalitiesByMode = () => {
     });
   }, []);
 
-  const createChartLabels = () =>
-    yearsArray()
-      .sort()
-      .map(year => `${year}`);
+  const createChartLabels = () => yearsArray().map(year => `${year}`);
 
   // Tabulate fatalities by mode from data
   const getModeData = flags =>
-    yearsArray()
-      .sort()
-      .map(year => {
-        let fatalities = 0;
-        chartData[year].forEach(record =>
-          flags.forEach(flag => record[`${flag}`] === "Y" && fatalities++)
-        );
-        return fatalities;
-      });
+    yearsArray().map(year => {
+      let fatalities = 0;
+      chartData[year].forEach(record =>
+        flags.forEach(flag => record[`${flag}`] === "Y" && fatalities++)
+      );
+      return fatalities;
+    });
 
   // Create dataset for each mode type
   // data property is an array of fatality sums sorted chronologically


### PR DESCRIPTION
Closes #595 
Closes #613 

This PR updates both the map mode filters and "Fatalities by Mode" summary visualization with an "Other" mode which encompasses all other modes. "Other" modes for both are set in a new constant file, `filters.js`. 

All filter configs now have a `default` parameter to determine which filters are active on render (defined in #613 and #595). A rule of keeping one type filter active at all times was also added to keep users from fetching crashes without fatalities, serious injuries, or both. This same rule is applied to the mode filters to avoid showing a blank map with no crash points. 

I also created new time constants for the time window of data specified in #673 that are used in the map and mode visualization queries.

### Default filters with "Other" instead of "All"
![Screen Shot 2020-02-05 at 1 49 34 PM](https://user-images.githubusercontent.com/37249039/73878800-e1a40e80-4820-11ea-826f-02975ffe901e.png)

### Summary mode visualization with "Other"
![Screen Shot 2020-02-05 at 4 48 10 PM](https://user-images.githubusercontent.com/37249039/73890757-53d41d80-4838-11ea-8dd6-33dd583fb85b.png)



