### PR TITLE
VZD | Update Socrata ETL with ATD Mode Category metadata

### DIFF
--- a/atd-etl/app/process/helpers_socrata.py
+++ b/atd-etl/app/process/helpers_socrata.py
@@ -229,6 +229,5 @@ def format_person_data(data, formatter_config):
         people_records, formatter_config["columns_to_rename"])
     formatted_records = flatten_hasura_response(
         formatted_records)
-    for record in formatted_records:
-        print(record)
+
     return formatted_records

--- a/atd-etl/app/process/helpers_socrata.py
+++ b/atd-etl/app/process/helpers_socrata.py
@@ -100,7 +100,7 @@ def set_mode_columns(records):
         # Create copy of record to mutate
         formatted_record = deepcopy(record)
         metadata_column = "atd_mode_category_metadata"
-        if metadata_column in record.keys():
+        if metadata_column in record.keys() and record[metadata_column] != None:
             # Concat mode_desc strings for all units
             units_involved = []
             for unit in record[metadata_column]:
@@ -223,11 +223,11 @@ def format_crash_data(data, formatter_config):
     records = data['data'][formatter_config["tables"][0]]
 
     # Format records
-    formatted_records = flatten_hasura_response(records)
+    formatted_records = set_mode_columns(
+        records)
+    formatted_records = flatten_hasura_response(formatted_records)
     formatted_records = rename_record_columns(
         formatted_records, formatter_config["columns_to_rename"])
-    formatted_records = set_mode_columns(
-        formatted_records)
     formatted_records = create_point_datatype(formatted_records)
 
     return formatted_records

--- a/atd-etl/app/process/helpers_socrata.py
+++ b/atd-etl/app/process/helpers_socrata.py
@@ -211,6 +211,7 @@ def set_person_mode(records):
                 if unit.get("unit_id") == unit_id:
                     record["mode_desc"] = unit.get("mode_desc")
                     mode_id = unit.get("mode_id")
+                    record["mode_id"] = mode_id
         del record["crash"]["units"]
         del record["crash"]["atd_mode_category_metadata"]
         del record["unit_nbr"]

--- a/atd-etl/app/process/helpers_socrata.py
+++ b/atd-etl/app/process/helpers_socrata.py
@@ -114,36 +114,6 @@ def set_mode_columns(records):
     return formatted_records
 
 
-def create_mode_flags(records, unit_modes):
-    """
-    Creates mode flag columns in data along with "Y" or "N" value
-    :param records: list - List of record dicts
-    :param unit_modes: list - List of mode strings to create flag columns
-    """
-    for record in records:
-        if "unit_mode" in record.keys():
-            for mode in unit_modes:
-                chars_to_replace = ["/", " ", "-"]
-
-                # Need flag to be camelcase with "_fl" suffix
-                formatted_mode = replace_chars(
-                    mode, chars_to_replace, "_").lower()
-                record_flag_column = f"{formatted_mode}_fl"
-                if mode in record["unit_mode"]:
-                    record[record_flag_column] = "Y"
-                else:
-                    record[record_flag_column] = "N"
-        # Motorcycle crashes are documented in unit desc not mode
-        if "unit_desc" in record.keys():
-            if "MOTORCYCLE" in record["unit_desc"]:
-                record["motorcycle_fl"] = "Y"
-            else:
-                record["motorcycle_fl"] = "N"
-        else:
-            record["motorcycle_fl"] = "N"
-    return records
-
-
 def create_point_datatype(records):
     """
     Creates point datatype to enable fetching GeoJSON from Socrata
@@ -259,5 +229,6 @@ def format_person_data(data, formatter_config):
         people_records, formatter_config["columns_to_rename"])
     formatted_records = flatten_hasura_response(
         formatted_records)
-
+    for record in formatted_records:
+        print(record)
     return formatted_records

--- a/atd-etl/app/process/helpers_socrata.py
+++ b/atd-etl/app/process/helpers_socrata.py
@@ -15,6 +15,9 @@ import json
 from copy import deepcopy
 from process.config import ATD_ETL_CONFIG
 
+# Dict to translate canonical modes to broader categories for VZV
+modeCategories = {}
+
 
 def replace_chars(target_str, char_list, replacement_str):
     """
@@ -112,6 +115,38 @@ def set_mode_columns(records):
                 record[metadata_column])
         formatted_records.append(formatted_record)
     return formatted_records
+
+
+def create_mode_flags(records, unit_modes):
+
+
+"""
+Creates mode flag columns in data along with "Y" or "N" value
+:param records: list - List of record dicts
+:param unit_modes: list - List of mode strings to create flag columns
+"""
+for record in records:
+    if "unit_mode" in record.keys():
+        for mode in unit_modes:
+            chars_to_replace = ["/", " ", "-"]
+
+            # Need flag to be camelcase with "_fl" suffix
+            formatted_mode = replace_chars(
+                mode, chars_to_replace, "_").lower()
+            record_flag_column = f"{formatted_mode}_fl"
+            if mode in record["unit_mode"]:
+                record[record_flag_column] = "Y"
+            else:
+                record[record_flag_column] = "N"
+    # Motorcycle crashes are documented in unit desc not mode
+    if "unit_desc" in record.keys():
+        if "MOTORCYCLE" in record["unit_desc"]:
+            record["motorcycle_fl"] = "Y"
+        else:
+            record["motorcycle_fl"] = "N"
+    else:
+        record["motorcycle_fl"] = "N"
+return records
 
 
 def create_point_datatype(records):

--- a/atd-etl/app/process/helpers_socrata.py
+++ b/atd-etl/app/process/helpers_socrata.py
@@ -90,6 +90,30 @@ def flatten_hasura_response(records):
     return formatted_records
 
 
+def set_mode_columns(records):
+    """
+    Stringify atd_mode_category_metadata and concat mode descriptions
+    :param records: list - List of record dicts
+    """
+    formatted_records = []
+    for record in records:
+        # Create copy of record to mutate
+        formatted_record = deepcopy(record)
+        metadata_column = "atd_mode_category_metadata"
+        if metadata_column in record.keys():
+            # Concat mode_desc strings for all units
+            units_involved = []
+            for unit in record[metadata_column]:
+                units_involved.append(unit.get("mode_desc"))
+            formatted_record["units_involved"] = " & ".join(units_involved)
+
+            # Stringify metadata
+            formatted_record[metadata_column] = json.dumps(
+                record[metadata_column])
+        formatted_records.append(formatted_record)
+    return formatted_records
+
+
 def create_mode_flags(records, unit_modes):
     """
     Creates mode flag columns in data along with "Y" or "N" value
@@ -202,8 +226,8 @@ def format_crash_data(data, formatter_config):
     formatted_records = flatten_hasura_response(records)
     formatted_records = rename_record_columns(
         formatted_records, formatter_config["columns_to_rename"])
-    formatted_records = create_mode_flags(
-        formatted_records, formatter_config["flags_list"])
+    formatted_records = set_mode_columns(
+        formatted_records)
     formatted_records = create_point_datatype(formatted_records)
 
     return formatted_records

--- a/atd-etl/app/process/socrata_queries.py
+++ b/atd-etl/app/process/socrata_queries.py
@@ -71,12 +71,7 @@ people_query_template = Template(
                 atd_mode_category_metadata
                 units {
                     unit_nbr
-                    unit_description {
-                        veh_unit_desc_desc
-                    }
-                    body_style {
-                        veh_body_styl_desc
-                    }
+                    unit_id
                 }
             }
         }
@@ -92,12 +87,7 @@ people_query_template = Template(
                 atd_mode_category_metadata
                 units {
                     unit_nbr
-                    unit_description {
-                        veh_unit_desc_desc
-                    }
-                    body_style {
-                        veh_body_styl_desc
-                    }
+                    unit_id
                 }
             }
         }

--- a/atd-etl/app/process/socrata_queries.py
+++ b/atd-etl/app/process/socrata_queries.py
@@ -44,15 +44,10 @@ crashes_query_template = Template(
             unkn_injry_cnt
             tot_injry_cnt
             death_cnt
+            atd_mode_category_metadata
             units {
                 contrib_factr_p1_id
                 contrib_factr_p2_id
-                body_style {
-                    veh_body_styl_desc
-                }
-                unit_description {
-                    veh_unit_desc_desc
-                }
             }
         }
     }
@@ -73,6 +68,7 @@ people_query_template = Template(
             unit_nbr
             crash {
                 crash_date
+                atd_mode_category_metadata
                 units {
                     unit_nbr
                     unit_description {
@@ -93,6 +89,7 @@ people_query_template = Template(
             unit_nbr
             crash {
                 crash_date
+                atd_mode_category_metadata
                 units {
                     unit_nbr
                     unit_description {

--- a/atd-etl/app/process/socrata_queries.py
+++ b/atd-etl/app/process/socrata_queries.py
@@ -14,7 +14,7 @@ from string import Template
 crashes_query_template = Template(
     """
     query getCrashesSocrata {
-        atd_txdot_crashes (limit: $limit, offset: $offset, order_by: {crash_id: asc}, where: {city_id: {_eq: 22}}) {
+        atd_txdot_crashes (limit: $limit, offset: $offset, order_by: {crash_id: desc}, where: {city_id: {_eq: 22}}) {
             apd_confirmed_fatality
             apd_confirmed_death_count
             crash_id

--- a/atd-etl/app/process/socrata_queries.py
+++ b/atd-etl/app/process/socrata_queries.py
@@ -14,7 +14,7 @@ from string import Template
 crashes_query_template = Template(
     """
     query getCrashesSocrata {
-        atd_txdot_crashes (limit: $limit, offset: $offset, order_by: {crash_id: desc}, where: {city_id: {_eq: 22}}) {
+        atd_txdot_crashes (limit: $limit, offset: $offset, order_by: {crash_id: asc}, where: {city_id: {_eq: 22}}) {
             apd_confirmed_fatality
             apd_confirmed_death_count
             crash_id

--- a/atd-etl/app/process_socrata_export.py
+++ b/atd-etl/app/process_socrata_export.py
@@ -49,31 +49,31 @@ query_configs = [
         # "dataset_uid": "3aut-fhzp"  # TEST
         "dataset_uid": "y2wy-tgr5"  # PROD
     },
-    # {
-    #     "table": "person",
-    #     "template": people_query_template,
-    #     "formatter": format_person_data,
-    #     "formatter_config": {
-    #         "tables": ["atd_txdot_person", "atd_txdot_primaryperson"],
-    #         "columns_to_rename": {
-    #             "primaryperson_id": "person_id"
-    #         },
-    #         "prefixes": {
-    #             "person_id": "P",
-    #             "primaryperson_id": "PP",
-    #         },
-    #         "flags_list": ["MOTOR VEHICLE",
-    #                        "TRAIN",
-    #                        "PEDALCYCLIST",
-    #                        "PEDESTRIAN",
-    #                        "MOTORIZED CONVEYANCE",
-    #                        "TOWED/PUSHED/TRAILER",
-    #                        "NON-CONTACT",
-    #                        "OTHER"]
-    #     },
-    #     # "dataset_uid": "v3x4-fjgm"  # TEST
-    #     "dataset_uid": "xecs-rpy9"  # PROD
-    # }
+    {
+        "table": "person",
+        "template": people_query_template,
+        "formatter": format_person_data,
+        "formatter_config": {
+            "tables": ["atd_txdot_person", "atd_txdot_primaryperson"],
+            "columns_to_rename": {
+                "primaryperson_id": "person_id"
+            },
+            "prefixes": {
+                "person_id": "P",
+                "primaryperson_id": "PP",
+            },
+            "flags_list": ["MOTOR VEHICLE",
+                           "TRAIN",
+                           "PEDALCYCLIST",
+                           "PEDESTRIAN",
+                           "MOTORIZED CONVEYANCE",
+                           "TOWED/PUSHED/TRAILER",
+                           "NON-CONTACT",
+                           "OTHER"]
+        },
+        # "dataset_uid": "v3x4-fjgm"  # TEST
+        "dataset_uid": "xecs-rpy9"  # PROD
+    }
 ]
 
 # Start timer
@@ -99,7 +99,7 @@ for config in query_configs:
         records = config["formatter"](data, config["formatter_config"])
 
         # Upsert records to Socrata
-        # client.upsert(config["dataset_uid"], records)
+        client.upsert(config["dataset_uid"], records)
         total_records += len(records)
 
         if len(records) == 0:

--- a/atd-etl/app/process_socrata_export.py
+++ b/atd-etl/app/process_socrata_export.py
@@ -46,7 +46,8 @@ query_configs = [
                            "NON-CONTACT",
                            "OTHER"]
         },
-        "dataset_uid": "y2wy-tgr5"
+        # "dataset_uid": "3aut-fhzp"  # TEST
+        "dataset_uid": "y2wy-tgr5"  # PROD
     },
     {
         "table": "person",
@@ -70,7 +71,8 @@ query_configs = [
                            "NON-CONTACT",
                            "OTHER"]
         },
-        "dataset_uid": "xecs-rpy9"
+        # "dataset_uid": "v3x4-fjgm"  # TEST
+        "dataset_uid": "xecs-rpy9"  # PROD
     }
 ]
 

--- a/atd-etl/app/process_socrata_export.py
+++ b/atd-etl/app/process_socrata_export.py
@@ -49,31 +49,31 @@ query_configs = [
         # "dataset_uid": "3aut-fhzp"  # TEST
         "dataset_uid": "y2wy-tgr5"  # PROD
     },
-    {
-        "table": "person",
-        "template": people_query_template,
-        "formatter": format_person_data,
-        "formatter_config": {
-            "tables": ["atd_txdot_person", "atd_txdot_primaryperson"],
-            "columns_to_rename": {
-                "primaryperson_id": "person_id"
-            },
-            "prefixes": {
-                "person_id": "P",
-                "primaryperson_id": "PP",
-            },
-            "flags_list": ["MOTOR VEHICLE",
-                           "TRAIN",
-                           "PEDALCYCLIST",
-                           "PEDESTRIAN",
-                           "MOTORIZED CONVEYANCE",
-                           "TOWED/PUSHED/TRAILER",
-                           "NON-CONTACT",
-                           "OTHER"]
-        },
-        # "dataset_uid": "v3x4-fjgm"  # TEST
-        "dataset_uid": "xecs-rpy9"  # PROD
-    }
+    # {
+    #     "table": "person",
+    #     "template": people_query_template,
+    #     "formatter": format_person_data,
+    #     "formatter_config": {
+    #         "tables": ["atd_txdot_person", "atd_txdot_primaryperson"],
+    #         "columns_to_rename": {
+    #             "primaryperson_id": "person_id"
+    #         },
+    #         "prefixes": {
+    #             "person_id": "P",
+    #             "primaryperson_id": "PP",
+    #         },
+    #         "flags_list": ["MOTOR VEHICLE",
+    #                        "TRAIN",
+    #                        "PEDALCYCLIST",
+    #                        "PEDESTRIAN",
+    #                        "MOTORIZED CONVEYANCE",
+    #                        "TOWED/PUSHED/TRAILER",
+    #                        "NON-CONTACT",
+    #                        "OTHER"]
+    #     },
+    #     # "dataset_uid": "v3x4-fjgm"  # TEST
+    #     "dataset_uid": "xecs-rpy9"  # PROD
+    # }
 ]
 
 # Start timer
@@ -99,7 +99,7 @@ for config in query_configs:
         records = config["formatter"](data, config["formatter_config"])
 
         # Upsert records to Socrata
-        client.upsert(config["dataset_uid"], records)
+        # client.upsert(config["dataset_uid"], records)
         total_records += len(records)
 
         if len(records) == 0:


### PR DESCRIPTION
Closes #635

This PR modifies the Socrata ETL script to use the new crash metadata column to set data about mode in both the crash and demographics datasets. The mode flags have been retained to enable SoQL queries to Socrata.

The crash dataset now has columns `units_involved` and `atd_mode_category_metadata`, and the demographics dataset now has the column `mode_desc` (matched from the metadata of the unit the person was in).

I ran the ETL to populate these new TEST datasets in Socrata:
https://data.austintexas.gov/Transportation-and-Mobility/-UNDER-CONSTRUCTION-TEST-Crash-Report-Data/3aut-fhzp
https://data.austintexas.gov/dataset/-UNDER-CONSTRUCTION-TEST-Vision-Zero-Demographic-S/v3x4-fjgm

I'll use them to test #546 and then merge these two branches together so that VZV staging doesn't break.

### New Crash columns
![Screen Shot 2020-02-11 at 1 13 02 PM](https://user-images.githubusercontent.com/37249039/74270073-40113700-4cd0-11ea-8e6b-c22bbf644e2e.png)

### New Demographics columns
![Screen Shot 2020-02-11 at 1 13 55 PM](https://user-images.githubusercontent.com/37249039/74270150-5e773280-4cd0-11ea-846e-b77e505f0f4e.png)
