### PR TITLE
VZV | Update mode categories in VZV

### DIFF
--- a/atd-vzv/src/constants/filters.js
+++ b/atd-vzv/src/constants/filters.js
@@ -1,7 +1,0 @@
-export const modeCategories = {
-  motorVehicleIds: [1, 2, 4],
-  motorcycleIds: [3],
-  bicycleIds: [5],
-  pedestrianIds: [7],
-  otherIds: [6, 8, 9]
-};

--- a/atd-vzv/src/constants/filters.js
+++ b/atd-vzv/src/constants/filters.js
@@ -1,11 +1,3 @@
-export const otherFiltersArray = [
-  "other_fl",
-  "train_fl",
-  "motorized_conveyance_fl",
-  "non_contact_fl",
-  "towed_pushed_trailer_fl"
-];
-
 export const modeCategories = {
   motorVehicleIds: [1, 2, 4],
   motorcycleIds: [3],

--- a/atd-vzv/src/constants/filters.js
+++ b/atd-vzv/src/constants/filters.js
@@ -5,3 +5,11 @@ export const otherFiltersArray = [
   "non_contact_fl",
   "towed_pushed_trailer_fl"
 ];
+
+export const modeCategories = {
+  motorVehicleIds: [1, 2, 4],
+  motorcycleIds: [3],
+  bicycleIds: [5],
+  pedestrianIds: [7],
+  otherIds: [6, 8, 9]
+};

--- a/atd-vzv/src/views/map/Map.js
+++ b/atd-vzv/src/views/map/Map.js
@@ -50,9 +50,10 @@ const Map = () => {
   useEffect(() => {
     const apiUrl = createMapDataUrl(filters, dateRange);
 
-    axios.get(apiUrl).then(res => {
-      setMapData(res.data);
-    });
+    !!apiUrl &&
+      axios.get(apiUrl).then(res => {
+        setMapData(res.data);
+      });
   }, [filters, dateRange]);
 
   useEffect(() => {

--- a/atd-vzv/src/views/map/helpers.js
+++ b/atd-vzv/src/views/map/helpers.js
@@ -31,11 +31,13 @@ const generateWhereFilters = filters => {
 
 export const createMapDataUrl = (filters, dateRange) => {
   const whereFilterString = generateWhereFilters(filters);
+  const filterCount = filters.length;
 
-  return (
-    `${crashGeoJSONEndpointUrl}?$limit=100000` +
-    `&$where=crash_date between '${dateRange.start}' and '${dateRange.end}'` +
-    // if there are filters applied, add AND operator to create valid query url
-    `${filters.length > 0 ? " AND" : ""} ${whereFilterString || ""}`
-  );
+  // Return empty URL to prevent momentarily populating map unfiltered map data
+  return filterCount === 0
+    ? ``
+    : `${crashGeoJSONEndpointUrl}?$limit=100000` +
+        `&$where=crash_date between '${dateRange.start}' and '${dateRange.end}'` +
+        // if there are filters applied, add AND operator to create valid query url
+        `${filters.length > 0 ? " AND" : ""} ${whereFilterString || ""}`;
 };

--- a/atd-vzv/src/views/map/helpers.js
+++ b/atd-vzv/src/views/map/helpers.js
@@ -33,9 +33,9 @@ export const createMapDataUrl = (filters, dateRange) => {
   const whereFilterString = generateWhereFilters(filters);
   const filterCount = filters.length;
 
-  // Return empty URL to prevent momentarily populating map unfiltered map data
+  // Return null to prevent populating map with unfiltered data
   return filterCount === 0
-    ? ``
+    ? null
     : `${crashGeoJSONEndpointUrl}?$limit=100000` +
         `&$where=crash_date between '${dateRange.start}' and '${dateRange.end}'` +
         // if there are filters applied, add AND operator to create valid query url

--- a/atd-vzv/src/views/nav/SideMapControl.js
+++ b/atd-vzv/src/views/nav/SideMapControl.js
@@ -5,7 +5,6 @@ import "react-infinite-calendar/styles.css";
 import SideMapControlDateRange from "./SideMapControlDateRange";
 import SideMapControlOverlays from "./SideMapControlOverlays";
 import { colors } from "../../constants/colors";
-import { otherFiltersArray } from "../../constants/filters";
 import { ButtonGroup, Button, Card, Label } from "reactstrap";
 import styled from "styled-components";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -41,15 +40,6 @@ const SideMapControl = () => {
 
   const [filterGroupCounts, setFilterGroupCounts] = useState({});
 
-  // Build filter string for Other modes
-  const buildOtherFiltersString = () =>
-    otherFiltersArray
-      .reduce((accumulator, filterString) => {
-        accumulator.push(`${filterString} = "Y"`);
-        return accumulator;
-      }, [])
-      .join(" OR ");
-
   // Define groups of map filters
   const mapFilters = {
     mode: {
@@ -62,7 +52,7 @@ const SideMapControl = () => {
       },
       pedalcyclist: {
         icon: faBiking,
-        syntax: `pedalcyclist_fl = "Y"`,
+        syntax: `bicycle_fl = "Y"`,
         type: `where`,
         operator: `OR`,
         default: true
@@ -83,7 +73,7 @@ const SideMapControl = () => {
       },
       other: {
         text: "Other",
-        syntax: buildOtherFiltersString(),
+        syntax: `other_fl = "Y"`,
         type: `where`,
         operator: `OR`,
         default: true

--- a/atd-vzv/src/views/summary/FatalitiesByMode.js
+++ b/atd-vzv/src/views/summary/FatalitiesByMode.js
@@ -4,7 +4,6 @@ import { Bar } from "react-chartjs-2";
 
 import { Container } from "reactstrap";
 import { colors } from "../../constants/colors";
-import { modeCategories } from "../../constants/filters";
 import {
   dataEndDate,
   thisYear,
@@ -16,27 +15,27 @@ const FatalitiesByMode = () => {
   const modes = [
     {
       label: "Motorist",
-      flags: modeCategories.motorVehicleIds,
+      flags: ["motor_vehicle_fl"],
       color: colors.chartRed
     },
     {
       label: "Pedestrian",
-      flags: modeCategories.pedestrianIds,
+      flags: ["pedestrian_fl"],
       color: colors.chartOrange
     },
     {
       label: "Motorcyclist",
-      flags: modeCategories.motorcycleIds,
+      flags: ["motorcycle_fl"],
       color: colors.chartRedOrange
     },
     {
       label: "Bicyclist",
-      flags: modeCategories.bicycleIds,
+      flags: ["bicycle_fl"],
       color: colors.chartBlue
     },
     {
       label: "Other",
-      flags: modeCategories.otherIds,
+      flags: ["other_fl"],
       color: colors.chartLightBlue
     }
   ];
@@ -81,10 +80,10 @@ const FatalitiesByMode = () => {
   const createChartLabels = () => yearsArray().map(year => `${year}`);
 
   // Tabulate fatalities by mode flags in data
-  const getModeData = ids =>
+  const getModeData = flags =>
     yearsArray().map(year => {
       return chartData[year].reduce((accumulator, record) => {
-        ids.forEach(id => parseInt(record["mode_id"]) === id && accumulator++);
+        flags.forEach(flag => record[`${flag}`] === "Y" && accumulator++);
         return accumulator;
       }, 0);
     });

--- a/atd-vzv/src/views/summary/FatalitiesByMode.js
+++ b/atd-vzv/src/views/summary/FatalitiesByMode.js
@@ -15,7 +15,7 @@ import { demographicsEndpointUrl } from "./queries/socrataQueries";
 const FatalitiesByMode = () => {
   const modes = [
     {
-      label: "Motor",
+      label: "Motorist",
       flags: modeCategories.motorVehicleIds,
       color: colors.chartRed
     },
@@ -25,12 +25,12 @@ const FatalitiesByMode = () => {
       color: colors.chartOrange
     },
     {
-      label: "Motorcycle",
+      label: "Motorcyclist",
       flags: modeCategories.motorcycleIds,
       color: colors.chartRedOrange
     },
     {
-      label: "Bicycle",
+      label: "Bicyclist",
       flags: modeCategories.bicycleIds,
       color: colors.chartBlue
     },

--- a/atd-vzv/src/views/summary/FatalitiesByMode.js
+++ b/atd-vzv/src/views/summary/FatalitiesByMode.js
@@ -26,7 +26,7 @@ const FatalitiesByMode = () => {
     },
     {
       label: "Motorcycle",
-      flags: modeCategories.motorVehicleIds,
+      flags: modeCategories.motorcycleIds,
       color: colors.chartRedOrange
     },
     {
@@ -81,10 +81,10 @@ const FatalitiesByMode = () => {
   const createChartLabels = () => yearsArray().map(year => `${year}`);
 
   // Tabulate fatalities by mode flags in data
-  const getModeData = flags =>
+  const getModeData = ids =>
     yearsArray().map(year => {
       return chartData[year].reduce((accumulator, record) => {
-        flags.forEach(flag => record[`${flag}`] === "Y" && accumulator++);
+        ids.forEach(id => parseInt(record["mode_id"]) === id && accumulator++);
         return accumulator;
       }, 0);
     });

--- a/atd-vzv/src/views/summary/FatalitiesByMode.js
+++ b/atd-vzv/src/views/summary/FatalitiesByMode.js
@@ -4,7 +4,7 @@ import { Bar } from "react-chartjs-2";
 
 import { Container } from "reactstrap";
 import { colors } from "../../constants/colors";
-import { otherFiltersArray } from "../../constants/filters";
+import { modeCategories } from "../../constants/filters";
 import {
   dataEndDate,
   thisYear,
@@ -14,25 +14,29 @@ import { demographicsEndpointUrl } from "./queries/socrataQueries";
 
 const FatalitiesByMode = () => {
   const modes = [
-    { label: "Motor", flags: ["motor_vehicle_fl"], color: colors.chartRed },
+    {
+      label: "Motor",
+      flags: modeCategories.motorVehicleIds,
+      color: colors.chartRed
+    },
     {
       label: "Pedestrian",
-      flags: ["pedestrian_fl"],
+      flags: modeCategories.pedestrianIds,
       color: colors.chartOrange
     },
     {
       label: "Motorcycle",
-      flags: ["motorcycle_fl"],
+      flags: modeCategories.motorVehicleIds,
       color: colors.chartRedOrange
     },
     {
-      label: "Pedalcyclist",
-      flags: ["pedalcyclist_fl"],
+      label: "Bicycle",
+      flags: modeCategories.bicycleIds,
       color: colors.chartBlue
     },
     {
       label: "Other",
-      flags: otherFiltersArray,
+      flags: modeCategories.otherIds,
       color: colors.chartLightBlue
     }
   ];

--- a/atd-vzv/src/views/summary/helpers/helpers.js
+++ b/atd-vzv/src/views/summary/helpers/helpers.js
@@ -3,7 +3,8 @@ import { lifespanYears } from "../../../constants/calc";
 
 export const calculateTotalFatalities = data =>
   data.reduce(
-    (accumulator, record) => (accumulator += parseInt(record.apd_confirmed_death_count)),
+    (accumulator, record) =>
+      (accumulator += parseInt(record.apd_confirmed_death_count)),
     0
   );
 

--- a/atd-vzv/src/views/summary/queries/socrataQueries.js
+++ b/atd-vzv/src/views/summary/queries/socrataQueries.js
@@ -7,7 +7,7 @@ import {
 
 export const crashEndpointUrl = `https://data.austintexas.gov/resource/y2wy-tgr5.json`;
 export const crashGeoJSONEndpointUrl = `https://data.austintexas.gov/resource/y2wy-tgr5.geojson`;
-export const demographicsEndpointUrl = `https://data.austintexas.gov/resource/xecs-rpy9.json`;
+export const demographicsEndpointUrl = `https://data.austintexas.gov/resource/v3x4-fjgm.json`;
 
 // Year to date queries
 export const thisYearFatalitiesUrl = `${crashEndpointUrl}?$where=apd_confirmed_death_count > 0 AND crash_date between '${thisYear}-01-01T00:00:00' and '${thisYear}-${lastMonth}-${lastDayOfLastMonth}T23:59:59'`;

--- a/atd-vzv/src/views/summary/queries/socrataQueries.js
+++ b/atd-vzv/src/views/summary/queries/socrataQueries.js
@@ -7,7 +7,7 @@ import {
 
 export const crashEndpointUrl = `https://data.austintexas.gov/resource/y2wy-tgr5.json`;
 export const crashGeoJSONEndpointUrl = `https://data.austintexas.gov/resource/y2wy-tgr5.geojson`;
-export const demographicsEndpointUrl = `https://data.austintexas.gov/resource/v3x4-fjgm.json`;
+export const demographicsEndpointUrl = `https://data.austintexas.gov/resource/xecs-rpy9.json`;
 
 // Year to date queries
 export const thisYearFatalitiesUrl = `${crashEndpointUrl}?$where=apd_confirmed_death_count > 0 AND crash_date between '${thisYear}-01-01T00:00:00' and '${thisYear}-${lastMonth}-${lastDayOfLastMonth}T23:59:59'`;


### PR DESCRIPTION
Closes #546 

This PR updates VZV to take advantage of the new data published to Socrata by the updated ETL process. Defining what modes constitute "Other" modes is now removed from the front end since this now happens in the ETL. And, the labels for mode in the `FatalitiesByMode` summary component were updated to be more human-centered.
 
I also fixed a bug where the map was momentarily rendering unfiltered data (100,000 records) before the mode and type filters added. This was creating some unpredictable slowdown in rendering the map view. The new logic only fetches data if filters are applied. I can explain more if needed.

To test, you can switch the 4x4 dataset IDs in `/summary/queries/socrataQueries.js` to the test datasets. Otherwise, it is broken until the updated ETL code is merged and the production datasets are updated.

### Updated Fatalities by Mode chart
![Screen Shot 2020-02-12 at 5 35 06 PM](https://user-images.githubusercontent.com/37249039/74387392-0585c800-4dbe-11ea-9121-5d7822b6cc33.png)
