### PR TITLE
override bootstrap hover behavior

### DIFF
--- a/atd-vzv/src/views/nav/CrashTypeSelector.js
+++ b/atd-vzv/src/views/nav/CrashTypeSelector.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from "react";
+import { Button, ButtonGroup } from "reactstrap";
 import styled, { css } from "styled-components";
 import { colors } from "../../constants/colors";
 
@@ -53,10 +54,18 @@ const CrashTypeSelector = ({ setCrashType }) => {
     setActiveTab(placeHolder);
   };
 
+  // Check to see whether a tab is unselected, return true if unselected
   const isUnselected = tab => {
     let filteredObject = activeTab.find(element => element.name === tab.name);
     let unselected = filteredObject ? false : true;
     return unselected;
+  };
+
+  // Set hover class based on whether button is unselected
+  const setHoverClass = (unselected) => {
+    return unselected
+    ? "unselected"
+    : "selected"
   };
 
   useEffect(() => {
@@ -77,66 +86,49 @@ const CrashTypeSelector = ({ setCrashType }) => {
     setCrashType(handleCrashType());
   }, [setCrashType, activeTab]);
 
-  const Button = styled.button`
-    background: ${colors.info};
-    border: 1px solid ${colors.info};
-    color: ${colors.white};
-    margin: 0.5em 0;
-    padding: 0.25em 1em;
-    width: 40%;
-
-    ${props =>
-      props.unselected &&
-      css`
-        background: transparent;
-        color: ${colors.info};
-      `
+  // Set styles to override Bootstrap hover behavior based on whether button is selected
+  const StyledButton = styled.div`
+    .selected:hover {
+      background-color: ${colors.info};
+      border: 1px solid ${colors.info};
+      color: ${colors.white};
     }
-
-    ${props =>
-      props.fatalities &&
-      css`
-        border-radius: 3px 0 0 3px;
-      `
+    .unselected:hover {
+      background-color: ${colors.white};
+      border: 1px solid ${colors.info};
+      color: ${colors.info};
     }
-
-    ${props =>
-      props.seriousInjuries &&
-      css`
-        border-radius: 0 3px 3px 0;
-      `
-    }
-  `;
-
-  const Container = styled.div`
-    text-align: center;
   `;
 
   return (
-    <Container>
-      <Button
-        fatalities
-        id="fatalities-btn"
-        type="button"
-        unselected={isUnselected(fatalities)}
-        onClick={() => {
-          toggle(fatalities);
-        }}
-      >
-        Fatalities
-      </Button>
-      <Button
-        seriousInjuries
-        id="serious-injuries-btn"
-        type="button"
-        unselected={isUnselected(seriousInjuries)}
-        onClick={() => {
-          toggle(seriousInjuries);
-        }}
-      >
-        Serious Injuries
-      </Button>
-    </Container>
+    <StyledButton>
+      <ButtonGroup className="mb-3 d-flex">
+        <Button
+          id="fatalities-btn"
+          type="button"
+          color="info"
+          className={`${setHoverClass(isUnselected(fatalities))} w-100 pt-1 pb-1 pl-0 pr-0`}
+          onClick={() => {
+            toggle(fatalities);
+          }}
+          outline={isUnselected(fatalities)}
+        >
+          Fatalities
+        </Button>
+        <Button
+          id="serious-injuries-btn"
+          type="button"
+          color="info"
+          className={`${setHoverClass(isUnselected(seriousInjuries))} w-100 pt-1 pb-1 pl-0 pr-0`}
+          onClick={() => {
+            toggle(seriousInjuries);
+          }}
+          outline={isUnselected(seriousInjuries)}
+        >
+          Serious Injuries
+        </Button>
+      </ButtonGroup>
+    </StyledButton>
   );
 };
 

--- a/atd-vzv/src/views/nav/CrashTypeSelector.js
+++ b/atd-vzv/src/views/nav/CrashTypeSelector.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from "react";
 import { Button, ButtonGroup } from "reactstrap";
-import styled, { css } from "styled-components";
+import styled from "styled-components";
 import { colors } from "../../constants/colors";
 
 const CrashTypeSelector = ({ setCrashType }) => {


### PR DESCRIPTION
Fixes #689 

Uses styled components to override Bootstrap hover behavior rather than previous method of recreating Bootstrap styles from scratch. Looks and functions exactly as before, but retains Bootstrap responsive styles for improved mobile experience.

<img width="290" alt="Screen Shot 2020-02-24 at 5 06 34 PM" src="https://user-images.githubusercontent.com/35410637/75199229-2805d280-5728-11ea-9c16-552fe4b67e82.png">
