### PR TITLE
ETL/VZD: Precalculate death & serious injury counts by ETL mode category and publish to Socrata

### DIFF
--- a/atd-etl/app/process/helpers_socrata.py
+++ b/atd-etl/app/process/helpers_socrata.py
@@ -16,13 +16,22 @@ from copy import deepcopy
 from process.config import ATD_ETL_CONFIG
 
 # Dict to translate canonical modes to broader categories for VZV
-mode_category_flags = {
-    "motor_vehicle_fl": [1, 2, 4],
-    "motorcycle_fl": [3],
-    "bicycle_fl": [5],
-    "pedestrian_fl": [7],
-    "other_fl": [6, 8, 9]
+mode_categories = {
+    "motor_vehicle": [1, 2, 4],
+    "motorcycle": [3],
+    "bicycle": [5],
+    "pedestrian": [7],
+    "other": [6, 8, 9]
 }
+
+
+# TODO Look through objects in atd_mode_category_metadata array
+# TODO For each record, initialize totals list per 5 flags and each injury type (in same order as mode_count_flags)
+# TODO At end of each record, assign mode_count_flags[0] = totals_list[0] to each record
+
+# List of mode fatality and serious injury counts (preserve order to assign totals correctly)
+mode_count_flags = ["motor_vehicle_death_count", "motor_vehicle_serious_injury_count", "bicycle_death_count", "bicycle_serious_injury_count", "pedestrian_death_count",
+                    "pedestrian_serious_injury_count", "pedestrian_serious_injury_count", "motorcycle_serious_injury_count", "other_death_count", "other_serious_injury_count"]
 
 
 def replace_chars(target_str, char_list, replacement_str):
@@ -138,9 +147,9 @@ def create_mode_flags(records):
 
         # Check for id matches in flags dict and set flags to Y for matches
         for id in mode_ids:
-            for flag_key, flag_value in mode_category_flags.items():
+            for flag_key, flag_value in mode_categories.items():
                 if id in flag_value:
-                    record[flag_key] = "Y"
+                    record[flag_key + "_fl"] = "Y"
     return records
 
 

--- a/atd-etl/app/process/helpers_socrata.py
+++ b/atd-etl/app/process/helpers_socrata.py
@@ -24,10 +24,6 @@ mode_categories = {
     "other": [6, 8, 9]
 }
 
-# List of mode fatality and serious injury counts
-mode_count_flags = ["motor_vehicle_death_count", "motor_vehicle_serious_injury_count", "bicycle_death_count", "bicycle_serious_injury_count", "pedestrian_death_count",
-                    "pedestrian_serious_injury_count", "motorcycle_death_count", "motorcycle_serious_injury_count", "other_death_count", "other_serious_injury_count"]
-
 
 def replace_chars(target_str, char_list, replacement_str):
     """
@@ -171,11 +167,12 @@ def calc_mode_injury_totals(records):
     for record in records:
         # Initialize counts
         total_dict = {}
-        for flag in mode_count_flags:
-            total_dict[flag] = 0
+        for mode in mode_categories.keys():
+            total_dict[mode + "_death_count"] = 0
+            total_dict[mode + "_serious_injury_count"] = 0
 
         crash_metadata = record.get("atd_mode_category_metadata")
-        # Total number of injuries per mode of units in metadata
+        # Count number of injuries per mode of units in metadata
         if crash_metadata != None:
             for unit in crash_metadata:
                 unit_mode_id = unit.get("mode_id")


### PR DESCRIPTION
Closes https://github.com/cityofaustin/atd-data-tech/issues/1626

This PR updates the VZ Socrata ETL to precalculate the total fatalities and serious injuries by mode per crash. I repurposed the `mode_category_flags` dictionary as `mode_categories` to provide mode info for both the `create_mode_flags` method and the new `calc_mode_injury_totals ` method. The TEST crash dataset is updated with the new columns, and I'll update PROD after merging.