### PR TITLE
ETL still sets mode flags

### DIFF
--- a/atd-etl/app/process/helpers_socrata.py
+++ b/atd-etl/app/process/helpers_socrata.py
@@ -258,7 +258,7 @@ def set_person_mode(records):
         del record["unit_nbr"]
 
         # Set mode flag for person
-        for flag_key, flag_value in mode_category_flags.items():
+        for flag_key, flag_value in mode_categories.items():
             if mode_id in flag_value:
                 record[flag_key] = "Y"
     return records

--- a/atd-etl/app/process/helpers_socrata.py
+++ b/atd-etl/app/process/helpers_socrata.py
@@ -257,10 +257,6 @@ def set_person_mode(records):
         del record["crash"]["atd_mode_category_metadata"]
         del record["unit_nbr"]
 
-        # Set mode flag for person
-        for flag_key, flag_value in mode_categories.items():
-            if mode_id in flag_value:
-                record[flag_key] = "Y"
     return records
 
 


### PR DESCRIPTION
The ETL process for the `person` and `primary_person` tables was still setting mode flags for the demographics dataset. Since these flags are no longer needed for VZV, the code to create them was removed. A reference to a renamed dictionary was breaking the script.

I tested by clearing the PROD dataset and running the script to update it.