### PR TITLE
Add Can component to restrict access based on permissions

### DIFF
--- a/atd-vze/src/App.js
+++ b/atd-vze/src/App.js
@@ -41,8 +41,8 @@ const App = () => {
         uri: HASURA_ENDPOINT,
         headers: {
           Authorization: `Bearer ${userClaims.__raw}`,
-          // TODO: Create helper to set either editor or readonly here
-          "x-hasura-role": "editor",
+          // TODO: Create helper to set either admin, editor, or readonly here
+          "x-hasura-role": "readonly",
         },
       };
 

--- a/atd-vze/src/App.js
+++ b/atd-vze/src/App.js
@@ -41,6 +41,7 @@ const App = () => {
         uri: HASURA_ENDPOINT,
         headers: {
           Authorization: `Bearer ${userClaims.__raw}`,
+          // TODO: Create helper to set either editor or readonly here
           "x-hasura-role": "editor",
         },
       };

--- a/atd-vze/src/App.js
+++ b/atd-vze/src/App.js
@@ -24,6 +24,7 @@ const App = () => {
     loginWithRedirect,
     isAuthenticated,
     userClaims,
+    getHasuraRole,
   } = useAuth0();
 
   // Setup initial Apollo instance
@@ -41,8 +42,7 @@ const App = () => {
         uri: HASURA_ENDPOINT,
         headers: {
           Authorization: `Bearer ${userClaims.__raw}`,
-          // TODO: Create helper to set either admin, editor, or readonly here
-          "x-hasura-role": "readonly",
+          "x-hasura-role": getHasuraRole(),
         },
       };
 

--- a/atd-vze/src/App.js
+++ b/atd-vze/src/App.js
@@ -49,7 +49,7 @@ const App = () => {
       client.current = new ApolloClient(clientData);
       setIsApolloLoaded(true);
     }
-  }, [isAuthenticated, client, userClaims, setIsApolloLoaded]);
+  }, [isAuthenticated, client, userClaims, setIsApolloLoaded, getHasuraRole]);
 
   const renderLoading = () => (
     <div className="animated fadeIn pt-3 text-center">Loading...</div>

--- a/atd-vze/src/Components/DataTable.js
+++ b/atd-vze/src/Components/DataTable.js
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { useQuery } from "@apollo/react-hooks";
-import { useAuth0 } from "../auth/authContext";
+import { useAuth0, isReadOnly } from "../auth/authContext";
 import ConfirmModal from "./ConfirmModal";
 import get from "lodash.get";
 import { formatCostToDollars, formatDateTimeString } from "../helpers/format";
@@ -30,7 +30,7 @@ const DataTable = ({
 }) => {
   // Disable edit features if only role is "readonly"
   const { getRoles } = useAuth0();
-  const isReadOnly = getRoles().includes("readonly") && getRoles().length === 1;
+  const roles = getRoles();
 
   const [showModal, setShowModal] = useState(false);
 
@@ -73,7 +73,7 @@ const DataTable = ({
                       const fieldLabel = fieldConfigObject.label;
 
                       // Disable editing if user is only "readonly"
-                      if (fieldConfigObject.editable && isReadOnly) {
+                      if (fieldConfigObject.editable && isReadOnly(roles)) {
                         fieldConfigObject.editable = false;
                       }
 

--- a/atd-vze/src/Components/DataTable.js
+++ b/atd-vze/src/Components/DataTable.js
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import { useQuery } from "@apollo/react-hooks";
+import { useAuth0 } from "../auth/authContext";
 import ConfirmModal from "./ConfirmModal";
 import get from "lodash.get";
 import { formatCostToDollars, formatDateTimeString } from "../helpers/format";
@@ -27,6 +28,10 @@ const DataTable = ({
   handleFieldUpdate,
   handleButtonClick,
 }) => {
+  // Disable edit features if only role is "readonly"
+  const { getRoles } = useAuth0();
+  const isReadOnly = getRoles().includes("readonly") && getRoles().length === 1;
+
   const [showModal, setShowModal] = useState(false);
 
   // Import Lookup tables and aggregate an object of uiType= "select" options
@@ -66,6 +71,11 @@ const DataTable = ({
                       const fieldConfigObject = section.fields[field];
 
                       const fieldLabel = fieldConfigObject.label;
+
+                      // Disable editing if user is only "readonly"
+                      if (fieldConfigObject.editable && isReadOnly) {
+                        fieldConfigObject.editable = false;
+                      }
 
                       // Set data table (alternate if defined in data map)
                       const fieldDataTable =

--- a/atd-vze/src/_nav.js
+++ b/atd-vze/src/_nav.js
@@ -1,37 +1,52 @@
-export default {
-  items: [
-    {
-      title: true,
-      name: "Data",
-      wrapper: {
-        // optional wrapper object
-        element: "", // required valid HTML5 element tag
-        attributes: {}, // optional valid JS object with JS API naming ex: { className: "my-class", style: { fontFamily: "Verdana" }, id: "my-id"}
+import { isAdmin, isItSupervisor } from "./auth/authContext";
+
+export const navigation = roles => {
+  // Default sidebar nav items
+  const nav = {
+    items: [
+      {
+        title: true,
+        name: "Data",
+        wrapper: {
+          // optional wrapper object
+          element: "", // required valid HTML5 element tag
+          attributes: {}, // optional valid JS object with JS API naming ex: { className: "my-class", style: { fontFamily: "Verdana" }, id: "my-id"}
+        },
+        class: "", // optional class names space delimited list for title item ex: "text-center"
       },
-      class: "", // optional class names space delimited list for title item ex: "text-center"
-    },
+      {
+        name: "Dashboard",
+        url: "/dashboard",
+        icon: "icon-speedometer",
+      },
+      {
+        name: "Crashes",
+        url: "/crashes",
+        icon: "icon-shield",
+      },
+      {
+        name: "Locations",
+        url: "/locations",
+        icon: "icon-map",
+      },
+      {
+        divider: true,
+      },
+    ],
+  };
+
+  // Admin nav items
+  const adminNavItems = [
     {
       name: "Users",
       url: "/users",
       icon: "icon-people",
     },
-    {
-      name: "Dashboard",
-      url: "/dashboard",
-      icon: "icon-speedometer",
-    },
-    {
-      name: "Crashes",
-      url: "/crashes",
-      icon: "icon-shield",
-    },
-    {
-      name: "Locations",
-      url: "/locations",
-      icon: "icon-map",
-    },
-    {
-      divider: true,
-    },
-  ],
+  ];
+
+  if (isAdmin(roles) || isItSupervisor(roles)) {
+    adminNavItems.forEach(item => nav.items.splice(1, 0, item));
+  }
+
+  return nav;
 };

--- a/atd-vze/src/_nav.js
+++ b/atd-vze/src/_nav.js
@@ -1,5 +1,6 @@
 import { isAdmin, isItSupervisor } from "./auth/authContext";
 
+// Accept roles arg to restrict nav links by role
 export const navigation = roles => {
   // Default sidebar nav items
   const nav = {

--- a/atd-vze/src/auth/Can.js
+++ b/atd-vze/src/auth/Can.js
@@ -1,6 +1,7 @@
 import rules from "./rbac-rules";
 
 const check = (rules, roles, action, data) => {
+  // Collect user roles and check if any are authorized to render child component
   const isAuthorizedArray = roles.reduce((acc, role) => {
     const permissions = rules[role];
     if (!permissions) {

--- a/atd-vze/src/auth/Can.js
+++ b/atd-vze/src/auth/Can.js
@@ -1,35 +1,40 @@
 import rules from "./rbac-rules";
 
-const check = (rules, role, action, data) => {
-  const permissions = rules[role];
-  if (!permissions) {
-    // role is not present in the rules
-    return false;
-  }
-
-  const staticPermissions = permissions.static;
-
-  if (staticPermissions && staticPermissions.includes(action)) {
-    // static rule not provided for action
-    return true;
-  }
-
-  const dynamicPermissions = permissions.dynamic;
-
-  if (dynamicPermissions) {
-    const permissionCondition = dynamicPermissions[action];
-    if (!permissionCondition) {
-      // dynamic rule not provided for action
-      return false;
+const check = (rules, roles, action, data) => {
+  const isAuthorizedArray = roles.reduce((acc, role) => {
+    const permissions = rules[role];
+    if (!permissions) {
+      // role is not present in the rules
+      acc.push(false);
     }
 
-    return permissionCondition(data);
-  }
-  return false;
+    const staticPermissions = permissions.static;
+
+    if (staticPermissions && staticPermissions.includes(action)) {
+      // static rule not provided for action
+      acc.push(true);
+    }
+    return acc;
+  }, []);
+
+  return isAuthorizedArray.includes(true);
+
+  //   const dynamicPermissions = permissions.dynamic;
+
+  //   if (dynamicPermissions) {
+  //     const permissionCondition = dynamicPermissions[action];
+  //     if (!permissionCondition) {
+  //       // dynamic rule not provided for action
+  //       return false;
+  //     }
+
+  //     return permissionCondition(data);
+  //   }
+  //   return false;
 };
 
 const Can = props =>
-  check(rules, props.role, props.perform, props.data)
+  check(rules, props.roles, props.perform, props.data)
     ? props.yes()
     : props.no();
 

--- a/atd-vze/src/auth/Can.js
+++ b/atd-vze/src/auth/Can.js
@@ -1,0 +1,41 @@
+import rules from "./rbac-rules";
+
+const check = (rules, role, action, data) => {
+  const permissions = rules[role];
+  if (!permissions) {
+    // role is not present in the rules
+    return false;
+  }
+
+  const staticPermissions = permissions.static;
+
+  if (staticPermissions && staticPermissions.includes(action)) {
+    // static rule not provided for action
+    return true;
+  }
+
+  const dynamicPermissions = permissions.dynamic;
+
+  if (dynamicPermissions) {
+    const permissionCondition = dynamicPermissions[action];
+    if (!permissionCondition) {
+      // dynamic rule not provided for action
+      return false;
+    }
+
+    return permissionCondition(data);
+  }
+  return false;
+};
+
+const Can = props =>
+  check(rules, props.role, props.perform, props.data)
+    ? props.yes()
+    : props.no();
+
+Can.defaultProps = {
+  yes: () => null,
+  no: () => null,
+};
+
+export default Can;

--- a/atd-vze/src/auth/Can.js
+++ b/atd-vze/src/auth/Can.js
@@ -19,19 +19,6 @@ const check = (rules, roles, action, data) => {
   }, []);
 
   return isAuthorizedArray.includes(true);
-
-  //   const dynamicPermissions = permissions.dynamic;
-
-  //   if (dynamicPermissions) {
-  //     const permissionCondition = dynamicPermissions[action];
-  //     if (!permissionCondition) {
-  //       // dynamic rule not provided for action
-  //       return false;
-  //     }
-
-  //     return permissionCondition(data);
-  //   }
-  //   return false;
 };
 
 const Can = props =>

--- a/atd-vze/src/auth/authContext.js
+++ b/atd-vze/src/auth/authContext.js
@@ -49,7 +49,6 @@ export const Auth0Provider = ({
         setUserClaims(claims);
 
         localStorage.setItem("hasura_user_email", user["email"]);
-        // TODO: Create helper to set highest level of access in roles to Hasura role
         localStorage.setItem(
           "hasura_user_role",
           user["https://hasura.io/jwt/claims"]["x-hasura-allowed-roles"]
@@ -76,6 +75,10 @@ export const Auth0Provider = ({
     auth0Client.logout({ returnTo: urlPath });
   };
 
+  const getRoles = () => {
+    return user["https://hasura.io/jwt/claims"]["x-hasura-allowed-roles"];
+  };
+
   // Context provider supplies value below at index.js level
   return (
     <Auth0Context.Provider
@@ -85,6 +88,7 @@ export const Auth0Provider = ({
         loading,
         handleRedirectCallback,
         userClaims,
+        getRoles,
         getIdTokenClaims: (...p) => auth0Client.getIdTokenClaims(...p),
         loginWithRedirect: (...p) => auth0Client.loginWithRedirect(...p),
         logout,

--- a/atd-vze/src/auth/authContext.js
+++ b/atd-vze/src/auth/authContext.js
@@ -49,6 +49,7 @@ export const Auth0Provider = ({
         setUserClaims(claims);
 
         localStorage.setItem("hasura_user_email", user["email"]);
+        // TODO: Create helper to set highest level of access in roles to Hasura role
         localStorage.setItem(
           "hasura_user_role",
           user["https://hasura.io/jwt/claims"]["x-hasura-allowed-roles"]

--- a/atd-vze/src/auth/authContext.js
+++ b/atd-vze/src/auth/authContext.js
@@ -12,6 +12,14 @@ export const urlPath =
     ? window.location.origin
     : `${window.location.origin}/editor`;
 
+// Roles helpers for rules-based access
+export const isReadOnly = rolesArray =>
+  rolesArray.includes("readonly") && rolesArray.length === 1;
+
+export const isAdmin = rolesArray => rolesArray.includes("admin");
+
+export const isItSupervisor = rolesArray => rolesArray.includes("itSupervisor");
+
 export const Auth0Provider = ({
   children,
   onRedirectCallback,

--- a/atd-vze/src/auth/authContext.js
+++ b/atd-vze/src/auth/authContext.js
@@ -87,6 +87,13 @@ export const Auth0Provider = ({
     return user["https://hasura.io/jwt/claims"]["x-hasura-allowed-roles"];
   };
 
+  // Get Hasura role needed for Hasura role permissions
+  const getHasuraRole = () => {
+    const role = user["https://hasura.io/jwt/claims"]["x-hasura-allowed-roles"];
+    // If user has more than one role, they are itSupervisor and need admin role for Hasura to return data
+    return role.length > 1 ? "admin" : role[0];
+  };
+
   // Context provider supplies value below at index.js level
   return (
     <Auth0Context.Provider
@@ -97,6 +104,7 @@ export const Auth0Provider = ({
         handleRedirectCallback,
         userClaims,
         getRoles,
+        getHasuraRole,
         getIdTokenClaims: (...p) => auth0Client.getIdTokenClaims(...p),
         loginWithRedirect: (...p) => auth0Client.loginWithRedirect(...p),
         logout,

--- a/atd-vze/src/auth/rbac-rules.js
+++ b/atd-vze/src/auth/rbac-rules.js
@@ -21,7 +21,8 @@ const adminStaticRules = [
 const itSupervisorStaticRules = ["user:makeAdmin"];
 
 const rules = {
-  readOnly: {
+  // Changing readonly to camelCase will break Hasura permissions
+  readonly: {
     static: readOnlyStaticRules,
     // dynamic: {
     //   "posts:edit": ({ userId, postOwnerId }) => {

--- a/atd-vze/src/auth/rbac-rules.js
+++ b/atd-vze/src/auth/rbac-rules.js
@@ -1,6 +1,28 @@
+const readOnlyStaticRules = [
+  "dashboard:visit",
+  "crashes:visit",
+  "crash:visit",
+  "locations:visit",
+  "location:visit",
+];
+
+const editorStaticRules = [];
+
+const adminStaticRules = [
+  "users:get",
+  "user:view",
+  "user:edit",
+  "user:delete",
+  "user:unblock",
+  "home-page:visit",
+  "dashboard-page:visit",
+];
+
+const itSupervisorStaticRules = [];
+
 const rules = {
   readOnly: {
-    static: ["dashboard:visit", "crashes:visit", "locations:visit"],
+    static: readOnlyStaticRules,
     // dynamic: {
     //   "posts:edit": ({ userId, postOwnerId }) => {
     //     if (!userId || !postOwnerId) return false;
@@ -9,40 +31,22 @@ const rules = {
     // },
   },
   editor: {
-    static: [
-      "users:get",
-      "user:view",
-      "user:edit",
-      "user:delete",
-      "user:unblock",
-      "home-page:visit",
-      "dashboard-page:visit",
-    ],
+    static: [...readOnlyStaticRules, ...editorStaticRules],
   },
   admin: {
-    static: [
-      "users:get",
-      "user:view",
-      "user:edit",
-      "user:delete",
-      "user:unblock",
-      "home-page:visit",
-      "dashboard-page:visit",
-    ],
+    static: [...readOnlyStaticRules, ...editorStaticRules, ...adminStaticRules],
   },
   itSupervisor: {
     static: [
-      "posts:list",
-      "posts:create",
-      "posts:edit",
-      "posts:delete",
-      "users:get",
-      "users:getSelf",
-      "users:list",
-      "home-page:visit",
-      "dashboard-page:visit",
+      ...readOnlyStaticRules,
+      ...editorStaticRules,
+      ...adminStaticRules,
+      ...itSupervisorStaticRules,
     ],
   },
 };
 
 export default rules;
+
+// TODO: Restrict routes
+// TODO: Restrict edit logic in crash details view

--- a/atd-vze/src/auth/rbac-rules.js
+++ b/atd-vze/src/auth/rbac-rules.js
@@ -27,12 +27,6 @@ export const rules = {
   readonly: {
     label: "Read-only",
     static: readOnlyStaticRules,
-    // dynamic: {
-    //   "posts:edit": ({ userId, postOwnerId }) => {
-    //     if (!userId || !postOwnerId) return false;
-    //     return userId === postOwnerId;
-    //   },
-    // },
   },
   editor: {
     label: "Editor",

--- a/atd-vze/src/auth/rbac-rules.js
+++ b/atd-vze/src/auth/rbac-rules.js
@@ -1,0 +1,48 @@
+const rules = {
+  readOnly: {
+    static: ["dashboard:visit", "crashes:visit", "locations:visit"],
+    // dynamic: {
+    //   "posts:edit": ({ userId, postOwnerId }) => {
+    //     if (!userId || !postOwnerId) return false;
+    //     return userId === postOwnerId;
+    //   },
+    // },
+  },
+  editor: {
+    static: [
+      "users:get",
+      "user:view",
+      "user:edit",
+      "user:delete",
+      "user:unblock",
+      "home-page:visit",
+      "dashboard-page:visit",
+    ],
+  },
+  admin: {
+    static: [
+      "users:get",
+      "user:view",
+      "user:edit",
+      "user:delete",
+      "user:unblock",
+      "home-page:visit",
+      "dashboard-page:visit",
+    ],
+  },
+  itSupervisor: {
+    static: [
+      "posts:list",
+      "posts:create",
+      "posts:edit",
+      "posts:delete",
+      "users:get",
+      "users:getSelf",
+      "users:list",
+      "home-page:visit",
+      "dashboard-page:visit",
+    ],
+  },
+};
+
+export default rules;

--- a/atd-vze/src/auth/rbac-rules.js
+++ b/atd-vze/src/auth/rbac-rules.js
@@ -11,6 +11,7 @@ const readOnlyStaticRules = [
 const editorStaticRules = ["crash: edit", "location: edit"];
 
 const adminStaticRules = [
+  "users:visit",
   "users:get",
   "user:get",
   "user:create",

--- a/atd-vze/src/auth/rbac-rules.js
+++ b/atd-vze/src/auth/rbac-rules.js
@@ -1,3 +1,5 @@
+// Read-only permissions not enforced by Can component
+// since all authorized users should have accesss
 const readOnlyStaticRules = [
   "dashboard:visit",
   "crashes:visit",

--- a/atd-vze/src/auth/rbac-rules.js
+++ b/atd-vze/src/auth/rbac-rules.js
@@ -51,6 +51,4 @@ const rules = {
 
 export default rules;
 
-// TODO: Restrict routes
-// TODO: Restrict edit logic in crash details view
 // TODO: Restrict giving admin role to itSupervisor

--- a/atd-vze/src/auth/rbac-rules.js
+++ b/atd-vze/src/auth/rbac-rules.js
@@ -22,9 +22,10 @@ const adminStaticRules = [
 
 const itSupervisorStaticRules = ["user:makeAdmin"];
 
-const rules = {
+export const rules = {
   // Changing readonly to camelCase will break Hasura permissions
   readonly: {
+    label: "Read-only",
     static: readOnlyStaticRules,
     // dynamic: {
     //   "posts:edit": ({ userId, postOwnerId }) => {
@@ -34,12 +35,15 @@ const rules = {
     // },
   },
   editor: {
+    label: "Editor",
     static: [...readOnlyStaticRules, ...editorStaticRules],
   },
   admin: {
+    label: "Admin",
     static: [...readOnlyStaticRules, ...editorStaticRules, ...adminStaticRules],
   },
   itSupervisor: {
+    label: "IT Supervisor",
     static: [
       ...readOnlyStaticRules,
       ...editorStaticRules,
@@ -50,5 +54,3 @@ const rules = {
 };
 
 export default rules;
-
-// TODO: Restrict giving admin role to itSupervisor

--- a/atd-vze/src/auth/rbac-rules.js
+++ b/atd-vze/src/auth/rbac-rules.js
@@ -6,19 +6,19 @@ const readOnlyStaticRules = [
   "location:visit",
 ];
 
-const editorStaticRules = [];
+const editorStaticRules = ["crash: edit", "location: edit"];
 
 const adminStaticRules = [
   "users:get",
   "user:view",
+  "user:create",
   "user:edit",
+  "user:editRole",
   "user:delete",
   "user:unblock",
-  "home-page:visit",
-  "dashboard-page:visit",
 ];
 
-const itSupervisorStaticRules = [];
+const itSupervisorStaticRules = ["user:makeAdmin"];
 
 const rules = {
   readOnly: {
@@ -50,3 +50,4 @@ export default rules;
 
 // TODO: Restrict routes
 // TODO: Restrict edit logic in crash details view
+// TODO: Restrict giving admin role to itSupervisor

--- a/atd-vze/src/auth/rbac-rules.js
+++ b/atd-vze/src/auth/rbac-rules.js
@@ -10,7 +10,7 @@ const editorStaticRules = ["crash: edit", "location: edit"];
 
 const adminStaticRules = [
   "users:get",
-  "user:view",
+  "user:get",
   "user:create",
   "user:edit",
   "user:editRole",

--- a/atd-vze/src/containers/DefaultLayout/DefaultHeader.js
+++ b/atd-vze/src/containers/DefaultLayout/DefaultHeader.js
@@ -1,6 +1,7 @@
 import React from "react";
 import { NavLink } from "react-router-dom";
 import { useAuth0 } from "../../auth/authContext";
+import Can from "../../auth/Can";
 import {
   UncontrolledDropdown,
   DropdownItem,
@@ -21,7 +22,7 @@ const propTypes = {
 const defaultProps = {};
 
 const DefaultHeader = props => {
-  const { logout } = useAuth0();
+  const { logout, getRoles } = useAuth0();
   // eslint-disable-next-line
   const { children, ...attributes } = props;
 
@@ -44,11 +45,17 @@ const DefaultHeader = props => {
             Dashboard
           </NavLink>
         </NavItem>
-        <NavItem className="px-3">
-          <NavLink to="/users" className="nav-link">
-            Users
-          </NavLink>
-        </NavItem>
+        <Can
+          roles={getRoles()}
+          perform="users:visit"
+          yes={() => (
+            <NavItem className="px-3">
+              <NavLink to="/users" className="nav-link">
+                Users
+              </NavLink>
+            </NavItem>
+          )}
+        />
       </Nav>
       <Nav className="ml-auto" navbar>
         <UncontrolledDropdown nav direction="down">

--- a/atd-vze/src/containers/DefaultLayout/DefaultLayout.js
+++ b/atd-vze/src/containers/DefaultLayout/DefaultLayout.js
@@ -1,7 +1,8 @@
-import React, { Component, Suspense } from "react";
+import React, { Suspense } from "react";
 import { Redirect, Route, Switch } from "react-router-dom";
 import * as router from "react-router-dom";
 import { Container } from "reactstrap";
+import { useAuth0 } from "../../auth/authContext";
 
 import {
   AppAside,
@@ -24,73 +25,70 @@ const DefaultAside = React.lazy(() => import("./DefaultAside"));
 const DefaultFooter = React.lazy(() => import("./DefaultFooter"));
 const DefaultHeader = React.lazy(() => import("./DefaultHeader"));
 
-class DefaultLayout extends Component {
-  loading = () => (
+const DefaultLayout = props => {
+  const { getRoles } = useAuth0();
+  const roles = getRoles();
+
+  const loading = () => (
     <div className="animated fadeIn pt-1 text-center">Loading...</div>
   );
 
-  signOut(e) {
+  const signOut = e => {
     e.preventDefault();
-    this.props.history.push("/login");
-  }
+    props.history.push("/login");
+  };
 
-  render() {
-    return (
-      <div className="app">
-        <AppHeader fixed>
-          <Suspense fallback={this.loading()}>
-            <DefaultHeader onLogout={e => this.signOut(e)} />
+  return (
+    <div className="app">
+      <AppHeader fixed>
+        <Suspense fallback={loading()}>
+          <DefaultHeader onLogout={e => signOut(e)} />
+        </Suspense>
+      </AppHeader>
+      <div className="app-body">
+        <AppSidebar fixed display="lg">
+          <AppSidebarHeader />
+          <AppSidebarForm />
+          <Suspense>
+            <AppSidebarNav navConfig={navigation} {...props} router={router} />
           </Suspense>
-        </AppHeader>
-        <div className="app-body">
-          <AppSidebar fixed display="lg">
-            <AppSidebarHeader />
-            <AppSidebarForm />
-            <Suspense>
-              <AppSidebarNav
-                navConfig={navigation}
-                {...this.props}
-                router={router}
-              />
+          <AppSidebarFooter />
+          <AppSidebarMinimizer />
+        </AppSidebar>
+        <main className="main">
+          <AppBreadcrumb appRoutes={routes(roles)} router={router} />
+          <Container fluid>
+            <Suspense fallback={loading()}>
+              <Switch>
+                {routes(roles).map((route, idx) => {
+                  return route.component ? (
+                    <Route
+                      key={idx}
+                      path={route.path}
+                      exact={route.exact}
+                      name={route.name}
+                      render={props => <route.component {...props} />}
+                    />
+                  ) : null;
+                })}
+                <Redirect from="/" to="/dashboard" />
+              </Switch>
             </Suspense>
-            <AppSidebarFooter />
-            <AppSidebarMinimizer />
-          </AppSidebar>
-          <main className="main">
-            <AppBreadcrumb appRoutes={routes} router={router} />
-            <Container fluid>
-              <Suspense fallback={this.loading()}>
-                <Switch>
-                  {routes.map((route, idx) => {
-                    return route.component ? (
-                      <Route
-                        key={idx}
-                        path={route.path}
-                        exact={route.exact}
-                        name={route.name}
-                        render={props => <route.component {...props} />}
-                      />
-                    ) : null;
-                  })}
-                  <Redirect from="/" to="/dashboard" />
-                </Switch>
-              </Suspense>
-            </Container>
-          </main>
-          <AppAside fixed>
-            <Suspense fallback={this.loading()}>
-              <DefaultAside />
-            </Suspense>
-          </AppAside>
-        </div>
-        <AppFooter>
-          <Suspense fallback={this.loading()}>
-            <DefaultFooter />
+          </Container>
+        </main>
+        <AppAside fixed>
+          <Suspense fallback={loading()}>
+            <DefaultAside />
           </Suspense>
-        </AppFooter>
+        </AppAside>
       </div>
-    );
-  }
-}
+      <AppFooter>
+        <Suspense fallback={loading()}>
+          <DefaultFooter />
+        </Suspense>
+      </AppFooter>
+    </div>
+  );
+};
 
 export default DefaultLayout;

--- a/atd-vze/src/containers/DefaultLayout/DefaultLayout.js
+++ b/atd-vze/src/containers/DefaultLayout/DefaultLayout.js
@@ -17,7 +17,7 @@ import {
   AppSidebarNav2 as AppSidebarNav,
 } from "@coreui/react";
 // sidebar nav config
-import navigation from "../../_nav";
+import { navigation } from "../../_nav";
 // routes config
 import routes from "../../routes";
 
@@ -50,7 +50,11 @@ const DefaultLayout = props => {
           <AppSidebarHeader />
           <AppSidebarForm />
           <Suspense>
-            <AppSidebarNav navConfig={navigation} {...props} router={router} />
+            <AppSidebarNav
+              navConfig={navigation(roles)}
+              {...props}
+              router={router}
+            />
           </Suspense>
           <AppSidebarFooter />
           <AppSidebarMinimizer />

--- a/atd-vze/src/containers/DefaultLayout/DefaultLayout.js
+++ b/atd-vze/src/containers/DefaultLayout/DefaultLayout.js
@@ -51,6 +51,7 @@ const DefaultLayout = props => {
           <AppSidebarForm />
           <Suspense>
             <AppSidebarNav
+              // Render nav links based on roles
               navConfig={navigation(roles)}
               {...props}
               router={router}
@@ -64,6 +65,7 @@ const DefaultLayout = props => {
           <Container fluid>
             <Suspense fallback={loading()}>
               <Switch>
+                {/* Render routes based on roles */}
                 {routes(roles).map((route, idx) => {
                   return route.component ? (
                     <Route

--- a/atd-vze/src/routes.js
+++ b/atd-vze/src/routes.js
@@ -1,4 +1,5 @@
 import React from "react";
+import { isAdmin, isItSupervisor } from "./auth/authContext";
 
 const Breadcrumbs = React.lazy(() => import("./views/Base/Breadcrumbs"));
 const Cards = React.lazy(() => import("./views/Base/Cards"));
@@ -50,7 +51,8 @@ const AddUser = React.lazy(() => import("./views/Users/AddUser"));
 const EditUser = React.lazy(() => import("./views/Users/EditUser"));
 
 // https://github.com/ReactTraining/react-router/tree/master/packages/react-router-config
-const routes = [
+// Accept roles arg for role-based access to routes
+const routes = roles => [
   { path: "/", exact: true, name: "Home" },
   { path: "/dev/dashboard", name: "Dashboard", component: Dashboard },
   { path: "/dev/theme", exact: true, name: "Theme", component: Colors },
@@ -153,15 +155,30 @@ const routes = [
     name: "Demo UI Components",
     component: Dev,
   },
-  { path: "/users", exact: true, name: "Users", component: Users },
-  { path: "/users/add", exact: true, name: "Add User", component: AddUser },
-  {
+  (isAdmin(roles) || isItSupervisor(roles)) && {
+    path: "/users",
+    exact: true,
+    name: "Users",
+    component: Users,
+  },
+  (isAdmin(roles) || isItSupervisor(roles)) && {
+    path: "/users/add",
+    exact: true,
+    name: "Add User",
+    component: AddUser,
+  },
+  (isAdmin(roles) || isItSupervisor(roles)) && {
     path: "/users/:id/edit",
     exact: true,
     name: "Edit User",
     component: EditUser,
   },
-  { path: "/users/:id", exact: true, name: "User Details", component: User },
+  (isAdmin(roles) || isItSupervisor(roles)) && {
+    path: "/users/:id",
+    exact: true,
+    name: "User Details",
+    component: User,
+  },
 ];
 
 export default routes;

--- a/atd-vze/src/views/Users/User.js
+++ b/atd-vze/src/views/Users/User.js
@@ -12,6 +12,7 @@ import {
   Table,
   Spinner,
 } from "reactstrap";
+import Can from "../../auth/Can";
 
 const User = () => {
   const token = window.localStorage.getItem("id_token");
@@ -114,45 +115,76 @@ const User = () => {
   return isUserDeleted ? (
     <Redirect to="/users" />
   ) : (
-    <div className="animated fadeIn">
-      <Row>
-        <Col xs="12" md="6">
-          <Card>
-            <CardHeader>
-              <strong>
-                <i className="icon-info pr-1"></i>User ID: {id}
-              </strong>
-            </CardHeader>
-            <CardBody>
-              <Row className="align-items-center mb-3">
-                <Col col="6" sm="4" md="2" xl className="mb-xl-0">
-                  <Link to={`/users/${id}/edit`} className="link">
-                    <Button color="primary">
-                      <i className="fa fa-edit"></i> Edit User
-                    </Button>
-                  </Link>{" "}
-                  <Button color="danger" onClick={handleDeleteUserClick}>
-                    <i className="fa fa-user-times"></i> Delete User
-                  </Button>{" "}
-                  {isUserBlocked && (
-                    <Button color="warning" onClick={handleUnblockUserClick}>
-                      <i className="fa fa-key"></i> Unblock User
-                    </Button>
+    <Can
+      role={"admin"}
+      perform="user:get"
+      yes={() => (
+        <div className="animated fadeIn">
+          <Row>
+            <Col xs="12" md="6">
+              <Card>
+                <CardHeader>
+                  <strong>
+                    <i className="icon-info pr-1"></i>User ID: {id}
+                  </strong>
+                </CardHeader>
+                <CardBody>
+                  <Row className="align-items-center mb-3">
+                    <Col col="6" sm="4" md="2" xl className="mb-xl-0">
+                      <Can
+                        role={"admin"}
+                        perform="user:edit"
+                        yes={() => (
+                          <Link to={`/users/${id}/edit`} className="link">
+                            <Button color="primary" className="mr-2">
+                              <i className="fa fa-edit"></i> Edit User
+                            </Button>
+                          </Link>
+                        )}
+                      />
+                      <Can
+                        role={"admin"}
+                        perform="user:delete"
+                        yes={() => (
+                          <Button
+                            color="danger"
+                            onClick={handleDeleteUserClick}
+                            className="mr-2"
+                          >
+                            <i className="fa fa-user-times"></i> Delete User
+                          </Button>
+                        )}
+                      />
+                      <Can
+                        role={"admin"}
+                        perform="user:delete"
+                        yes={() =>
+                          isUserBlocked && (
+                            <Button
+                              color="warning"
+                              onClick={handleUnblockUserClick}
+                            >
+                              <i className="fa fa-key"></i> Unblock User
+                            </Button>
+                          )
+                        }
+                      />
+                    </Col>
+                  </Row>
+                  {!!user ? (
+                    <Table responsive striped hover>
+                      <tbody>{formatUserData(user)}</tbody>
+                    </Table>
+                  ) : (
+                    <Spinner className="mt-2" color="primary" />
                   )}
-                </Col>
-              </Row>
-              {!!user ? (
-                <Table responsive striped hover>
-                  <tbody>{formatUserData(user)}</tbody>
-                </Table>
-              ) : (
-                <Spinner className="mt-2" color="primary" />
-              )}
-            </CardBody>
-          </Card>
-        </Col>
-      </Row>
-    </div>
+                </CardBody>
+              </Card>
+            </Col>
+          </Row>
+        </div>
+      )}
+    />
   );
 };
 

--- a/atd-vze/src/views/Users/User.js
+++ b/atd-vze/src/views/Users/User.js
@@ -124,7 +124,7 @@ const User = () => {
       yes={() => (
         <div className="animated fadeIn">
           <Row>
-            <Col xs="12" md="6">
+            <Col xs="12" lg="8" xl="6">
               <Card>
                 <CardHeader>
                   <strong>
@@ -133,7 +133,7 @@ const User = () => {
                 </CardHeader>
                 <CardBody>
                   <Row className="align-items-center mb-3">
-                    <Col col="6" sm="4" md="2" xl className="mb-xl-0">
+                    <Col col="12" xl className="mb-xl-0">
                       <Can
                         roles={roles}
                         perform="user:edit"

--- a/atd-vze/src/views/Users/User.js
+++ b/atd-vze/src/views/Users/User.js
@@ -68,16 +68,24 @@ const User = () => {
 
       const format = userAttributes[key].format;
 
-      if (format === "string") {
-        formattedValue = user[key];
-      } else if (format === "bool") {
-        formattedValue = !!user[key] ? "Yes" : "No";
-      } else if (format === "time") {
-        formattedValue = moment(user[key]).format("MM/DD/YYYY, h:mm:ss a");
-      } else if (format === "object") {
-        const nestedKey = value.nestedKey;
-        formattedValue = user[key][nestedKey].join(", ");
+      switch (format) {
+        case "string":
+          formattedValue = user[key];
+          break;
+        case "bool":
+          formattedValue = !!user[key] ? "Yes" : "No";
+          break;
+        case "time":
+          formattedValue = moment(user[key]).format("MM/DD/YYYY, h:mm:ss a");
+          break;
+        case "object":
+          const nestedKey = value.nestedKey;
+          formattedValue = user[key][nestedKey].join(", ");
+          break;
+        default:
+          console.log("No User view field format match");
       }
+
       return (
         <tr key={key}>
           <td>{`${label}:`}</td>

--- a/atd-vze/src/views/Users/User.js
+++ b/atd-vze/src/views/Users/User.js
@@ -13,10 +13,12 @@ import {
   Spinner,
 } from "reactstrap";
 import Can from "../../auth/Can";
+import { useAuth0 } from "../../auth/authContext";
 
 const User = () => {
   const token = window.localStorage.getItem("id_token");
   const { id } = useParams();
+  const { getRoles } = useAuth0();
 
   // Define attributes to render in view and their labels and format for handling
   const userAttributes = {
@@ -116,7 +118,7 @@ const User = () => {
     <Redirect to="/users" />
   ) : (
     <Can
-      role={"admin"}
+      roles={getRoles()}
       perform="user:get"
       yes={() => (
         <div className="animated fadeIn">
@@ -132,7 +134,7 @@ const User = () => {
                   <Row className="align-items-center mb-3">
                     <Col col="6" sm="4" md="2" xl className="mb-xl-0">
                       <Can
-                        role={"admin"}
+                        roles={getRoles()}
                         perform="user:edit"
                         yes={() => (
                           <Link to={`/users/${id}/edit`} className="link">
@@ -143,7 +145,7 @@ const User = () => {
                         )}
                       />
                       <Can
-                        role={"admin"}
+                        roles={getRoles()}
                         perform="user:delete"
                         yes={() => (
                           <Button
@@ -156,7 +158,7 @@ const User = () => {
                         )}
                       />
                       <Can
-                        role={"admin"}
+                        roles={getRoles()}
                         perform="user:delete"
                         yes={() =>
                           isUserBlocked && (

--- a/atd-vze/src/views/Users/User.js
+++ b/atd-vze/src/views/Users/User.js
@@ -19,6 +19,7 @@ const User = () => {
   const token = window.localStorage.getItem("id_token");
   const { id } = useParams();
   const { getRoles } = useAuth0();
+  const roles = getRoles();
 
   // Define attributes to render in view and their labels and format for handling
   const userAttributes = {
@@ -118,7 +119,7 @@ const User = () => {
     <Redirect to="/users" />
   ) : (
     <Can
-      roles={getRoles()}
+      roles={roles}
       perform="user:get"
       yes={() => (
         <div className="animated fadeIn">
@@ -134,7 +135,7 @@ const User = () => {
                   <Row className="align-items-center mb-3">
                     <Col col="6" sm="4" md="2" xl className="mb-xl-0">
                       <Can
-                        roles={getRoles()}
+                        roles={roles}
                         perform="user:edit"
                         yes={() => (
                           <Link to={`/users/${id}/edit`} className="link">
@@ -145,7 +146,7 @@ const User = () => {
                         )}
                       />
                       <Can
-                        roles={getRoles()}
+                        roles={roles}
                         perform="user:delete"
                         yes={() => (
                           <Button
@@ -158,7 +159,7 @@ const User = () => {
                         )}
                       />
                       <Can
-                        roles={getRoles()}
+                        roles={roles}
                         perform="user:delete"
                         yes={() =>
                           isUserBlocked && (

--- a/atd-vze/src/views/Users/UserForm.js
+++ b/atd-vze/src/views/Users/UserForm.js
@@ -43,7 +43,8 @@ const UserForm = ({ type, id = null }) => {
     { id: "itSupervisor", label: "IT Supervisor" },
     { id: "admin", label: "Admin" },
     { id: "editor", label: "Editor" },
-    { id: "readOnly", label: "Read-only" },
+    // Changing readonly to camelCase will break Hasura permissions
+    { id: "readonly", label: "Read-only" },
   ];
 
   // Fetch existing user data if editing

--- a/atd-vze/src/views/Users/UserForm.js
+++ b/atd-vze/src/views/Users/UserForm.js
@@ -98,8 +98,9 @@ const UserForm = ({ type, id = null }) => {
     let editFields = ["name", "email", "app_metadata"];
 
     // If resetting password, must include only password and required connection field
-    editFields =
-      userFormData.password !== "" ? ["password", "connection"] : editFields;
+    editFields = !!userFormData.password
+      ? ["password", "connection"]
+      : editFields;
 
     const cleanedFormData = editFields.reduce((acc, field) => {
       return { ...acc, [field]: userFormData[field] };

--- a/atd-vze/src/views/Users/UserForm.js
+++ b/atd-vze/src/views/Users/UserForm.js
@@ -95,12 +95,11 @@ const UserForm = ({ type, id = null }) => {
 
   // Remove fields not needed for edits (so req does not fail)
   const cleanFormDataForEdit = userFormData => {
-    const editFields = ["name", "email", "app_metadata"];
+    let editFields = ["name", "email", "app_metadata"];
 
-    // If resetting password, must include password and required connection field
-    userFormData.password !== "" &&
-      editFields.push("password") &&
-      editFields.push("connection");
+    // If resetting password, must include only password and required connection field
+    editFields =
+      userFormData.password !== "" ? ["password", "connection"] : editFields;
 
     const cleanedFormData = editFields.reduce((acc, field) => {
       return { ...acc, [field]: userFormData[field] };
@@ -149,7 +148,7 @@ const UserForm = ({ type, id = null }) => {
 
   const renderErrorMessage = () => (
     <Alert className="mt-3" color="danger">
-      {submissionErrorMessage} Please try again.
+      {submissionErrorMessage}. Please try again.
     </Alert>
   );
 
@@ -241,7 +240,7 @@ const UserForm = ({ type, id = null }) => {
                       <FormText className="help-block">
                         {type === "Add"
                           ? "Please enter a password"
-                          : "Only enter a password if you need to reset it"}
+                          : "No other fields will update if resetting password."}
                       </FormText>
                     </Col>
                   </FormGroup>

--- a/atd-vze/src/views/Users/UserForm.js
+++ b/atd-vze/src/views/Users/UserForm.js
@@ -110,36 +110,30 @@ const UserForm = ({ type, id = null }) => {
   };
 
   const handleFormSubmit = () => {
+    let submitForm;
+    const headers = {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    };
+
     if (type === "Edit") {
       const endpoint = `${process.env.REACT_APP_CR3_API_DOMAIN}/user/update_user/${id}`;
       const updatedFormData = cleanFormDataForEdit(userFormData);
-      axios
-        .put(endpoint, updatedFormData, {
-          headers: { Authorization: `Bearer ${token}` },
-        })
-        .then(res => {
-          if (res.data.error) {
-            setIsSubmissionError(true);
-            setSubmissionErrorMessage(res.data.message);
-          } else {
-            setIsFormSubmitted(true);
-          }
-        });
+      submitForm = axios.put(endpoint, updatedFormData, headers);
     } else if (type === "Add") {
       const endpoint = `${process.env.REACT_APP_CR3_API_DOMAIN}/user/create_user`;
-      axios
-        .post(endpoint, userFormData, {
-          headers: { Authorization: `Bearer ${token}` },
-        })
-        .then(res => {
-          if (res.data.error) {
-            setIsSubmissionError(true);
-            setSubmissionErrorMessage(res.data.message);
-          } else {
-            setIsFormSubmitted(true);
-          }
-        });
+      submitForm = axios.post(endpoint, userFormData, headers);
     }
+
+    submitForm.then(res => {
+      if (res.data.error) {
+        setIsSubmissionError(true);
+        setSubmissionErrorMessage(res.data.message);
+      } else {
+        setIsFormSubmitted(true);
+      }
+    });
   };
 
   const resetForm = () => {

--- a/atd-vze/src/views/Users/UserForm.js
+++ b/atd-vze/src/views/Users/UserForm.js
@@ -39,6 +39,7 @@ const UserForm = ({ type, id = null }) => {
   const [submissionErrorMessage, setSubmissionErrorMessage] = useState("");
   const [isFormSubmitted, setIsFormSubmitted] = useState(false);
 
+  // TODO: Get from rbac-rules.js
   const roles = [
     { id: "itSupervisor", label: "IT Supervisor" },
     { id: "admin", label: "Admin" },

--- a/atd-vze/src/views/Users/Users.js
+++ b/atd-vze/src/views/Users/Users.js
@@ -13,6 +13,7 @@ import {
   Button,
   Spinner,
 } from "reactstrap";
+import Can from "../../auth/Can";
 
 const UserRow = ({ user }) => {
   const userLink = `/users/${user.user_id}`;
@@ -67,48 +68,54 @@ const Users = () => {
   }, [token]);
 
   return (
-    <div className="animated fadeIn">
-      <Row>
-        <Col>
-          <Card>
-            <CardHeader>
-              <i className="fa fa-align-justify"></i> Users{" "}
-            </CardHeader>
-            <CardBody>
-              <Row className="align-items-center mb-3">
-                <Col col="6" sm="4" md="2" xl className="mb-xl-0">
-                  <Link to="/users/add" className="link">
-                    <Button color="primary">
-                      <i className="fa fa-user-plus"></i> Add User
-                    </Button>
-                  </Link>
-                </Col>
-              </Row>
-              {!!userList ? (
-                <Table responsive striped hover>
-                  <thead>
-                    <tr>
-                      <th scope="col">Name</th>
-                      <th scope="col">Email</th>
-                      <th scope="col">Created</th>
-                      <th scope="col">Role</th>
-                      <th scope="col">Status</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {userList.map((user, index) => (
-                      <UserRow key={index} user={user} />
-                    ))}
-                  </tbody>
-                </Table>
-              ) : (
-                <Spinner className="mt-2" color="primary" />
-              )}
-            </CardBody>
-          </Card>
-        </Col>
-      </Row>
-    </div>
+    <Can
+      role={"admin"}
+      perform="users:get"
+      yes={() => (
+        <div className="animated fadeIn">
+          <Row>
+            <Col>
+              <Card>
+                <CardHeader>
+                  <i className="fa fa-align-justify"></i> Users{" "}
+                </CardHeader>
+                <CardBody>
+                  <Row className="align-items-center mb-3">
+                    <Col col="6" sm="4" md="2" xl className="mb-xl-0">
+                      <Link to="/users/add" className="link">
+                        <Button color="primary">
+                          <i className="fa fa-user-plus"></i> Add User
+                        </Button>
+                      </Link>
+                    </Col>
+                  </Row>
+                  {!!userList ? (
+                    <Table responsive striped hover>
+                      <thead>
+                        <tr>
+                          <th scope="col">Name</th>
+                          <th scope="col">Email</th>
+                          <th scope="col">Created</th>
+                          <th scope="col">Role</th>
+                          <th scope="col">Status</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {userList.map((user, index) => (
+                          <UserRow key={index} user={user} />
+                        ))}
+                      </tbody>
+                    </Table>
+                  ) : (
+                    <Spinner className="mt-2" color="primary" />
+                  )}
+                </CardBody>
+              </Card>
+            </Col>
+          </Row>
+        </div>
+      )}
+    />
   );
 };
 

--- a/atd-vze/src/views/Users/Users.js
+++ b/atd-vze/src/views/Users/Users.js
@@ -14,6 +14,7 @@ import {
   Spinner,
 } from "reactstrap";
 import Can from "../../auth/Can";
+import { useAuth0 } from "../../auth/authContext";
 
 const UserRow = ({ user }) => {
   const userLink = `/users/${user.user_id}`;
@@ -50,6 +51,7 @@ const UserRow = ({ user }) => {
 };
 
 const Users = () => {
+  const { getRoles } = useAuth0();
   const token = window.localStorage.getItem("id_token");
 
   const [userList, setUserList] = useState(null);
@@ -69,7 +71,7 @@ const Users = () => {
 
   return (
     <Can
-      role={"admin"}
+      roles={getRoles()}
       perform="users:get"
       yes={() => (
         <div className="animated fadeIn">


### PR DESCRIPTION
Closes part of https://github.com/cityofaustin/atd-data-tech/issues/1820

This PR closes out the changes to the UI for the admin and read-only enhancements. It is a little large because I added the `Can` component wrapper around some components to control access (lots of lines didn't actually change). This component and the rules that feed it were set up with [this guide](https://auth0.com/blog/role-based-access-control-rbac-and-react-apps/).

I'd love feedback on how this is documented. Not every action defined in `rbac-rules.js` is present in the app, but I thought it documents what each role is able to do pretty well. Happy to screen share and talk through any questions.