### PR TITLE
VZV | Additional Roles rules

### DIFF
--- a/atd-vze/src/views/Users/User.js
+++ b/atd-vze/src/views/Users/User.js
@@ -14,6 +14,7 @@ import {
 } from "reactstrap";
 import Can from "../../auth/Can";
 import { useAuth0 } from "../../auth/authContext";
+import { rules } from "../../auth/rbac-rules";
 
 const User = () => {
   const token = window.localStorage.getItem("id_token");
@@ -26,7 +27,7 @@ const User = () => {
     user_id: { label: "User ID", format: "string" },
     name: { label: "Name", format: "string" },
     email: { label: "Email", format: "string" },
-    app_metadata: { label: "Roles", format: "object", nestedKey: "roles" },
+    app_metadata: { label: "Roles", format: "roleObject", nestedKey: "roles" },
     created_at: { label: "Created", format: "time" },
     blocked: { label: "Blocked", format: "bool" },
     last_login: { label: "Last login", format: "time" },
@@ -78,9 +79,11 @@ const User = () => {
         case "time":
           formattedValue = moment(user[key]).format("MM/DD/YYYY, h:mm:ss a");
           break;
-        case "object":
+        case "roleObject":
           const nestedKey = value.nestedKey;
-          formattedValue = user[key][nestedKey].join(", ");
+          const roleArray = user[key][nestedKey];
+          const readableRoleArray = roleArray.map(role => rules[role].label);
+          formattedValue = readableRoleArray.join(", ");
           break;
         default:
           console.log("No User view field format match");

--- a/atd-vze/src/views/Users/UserForm.js
+++ b/atd-vze/src/views/Users/UserForm.js
@@ -44,7 +44,7 @@ const UserForm = ({ type, id = null }) => {
   const [submissionErrorMessage, setSubmissionErrorMessage] = useState("");
   const [isFormSubmitted, setIsFormSubmitted] = useState(false);
 
-  // Disable giving admin or IT Supervisor role unless user is IT Supervisor
+  // Roles that admin is not allowed to set
   const adminRoleExceptions = ["itSupervisor"];
 
   const radioButtonRoles = roles =>

--- a/atd-vze/src/views/Users/UserForm.js
+++ b/atd-vze/src/views/Users/UserForm.js
@@ -52,14 +52,17 @@ const UserForm = ({ type, id = null }) => {
       acc.push({
         id: role,
         label: roleConfig.label,
+        // Disable radio buttons based on role
         disabled:
-          // Non-supervisor cannot edit supervisor role
+          // Non-supervisors cannot edit other supervisor's role
           (!isItSupervisor(roles) &&
             userFormData.app_metadata.roles.includes("itSupervisor")) ||
-          // No one can edit their own roles
+          // Prevent editing own role
           user.email === userFormData.email ||
           // Admin can give all roles except supervisor
-          (isAdmin(roles) && adminRoleExceptions.includes(role)),
+          (isAdmin(roles) &&
+            !isItSupervisor(roles) &&
+            adminRoleExceptions.includes(role)),
       });
       return acc;
     }, []);

--- a/atd-vze/src/views/Users/UserForm.js
+++ b/atd-vze/src/views/Users/UserForm.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from "react";
-import { useAuth0, isItSupervisor } from "../../auth/authContext";
+import { useAuth0, isItSupervisor, isAdmin } from "../../auth/authContext";
 import { rules } from "../../auth/rbac-rules";
 import axios from "axios";
 import { Redirect } from "react-router-dom";
@@ -23,7 +23,7 @@ import {
 const UserForm = ({ type, id = null }) => {
   const token = window.localStorage.getItem("id_token");
 
-  const { getRoles } = useAuth0();
+  const { getRoles, user } = useAuth0();
   const roles = getRoles();
 
   const defaultFormData = {
@@ -45,16 +45,22 @@ const UserForm = ({ type, id = null }) => {
   const [isFormSubmitted, setIsFormSubmitted] = useState(false);
 
   // Disable giving admin or IT Supervisor role unless user is IT Supervisor
-  const roleExceptions = ["admin", "itSupervisor"];
+  const adminRoleExceptions = ["itSupervisor"];
 
   const radioButtonRoles = roles =>
     Object.entries(rules).reduce((acc, [role, roleConfig]) => {
-      if (isItSupervisor(roles)) {
-        acc.push({ id: role, label: roleConfig.label });
-      } else {
-        !roleExceptions.includes(role) &&
-          acc.push({ id: role, label: roleConfig.label });
-      }
+      acc.push({
+        id: role,
+        label: roleConfig.label,
+        disabled:
+          // Non-supervisor cannot edit supervisor role
+          (!isItSupervisor(roles) &&
+            userFormData.app_metadata.roles.includes("itSupervisor")) ||
+          // No one can edit their own roles
+          user.email === userFormData.email ||
+          // Admin can give all roles except supervisor
+          (isAdmin(roles) && adminRoleExceptions.includes(role)),
+      });
       return acc;
     }, []);
 
@@ -258,6 +264,7 @@ const UserForm = ({ type, id = null }) => {
                               checked={
                                 userFormData.app_metadata.roles[0] === role.id
                               }
+                              disabled={role.disabled}
                               onChange={handleRoleRadioInputChange}
                             />
                             <Label

--- a/atd-vze/src/views/Users/Users.js
+++ b/atd-vze/src/views/Users/Users.js
@@ -15,6 +15,7 @@ import {
 } from "reactstrap";
 import Can from "../../auth/Can";
 import { useAuth0 } from "../../auth/authContext";
+import { rules } from "../../auth/rbac-rules";
 
 const UserRow = ({ user }) => {
   const userLink = `/users/${user.user_id}`;
@@ -38,7 +39,7 @@ const UserRow = ({ user }) => {
         <Link to={userLink}>{user.email}</Link>
       </td>
       <td>{moment(user.created_at).format("MM/DD/YYYY")}</td>
-      <td>{user.app_metadata.roles[0]}</td>
+      <td>{rules[user.app_metadata.roles[0]].label}</td>
       <td>
         <Link to={userLink}>
           <Badge color={getBadge(user.blocked)}>


### PR DESCRIPTION
Closes https://github.com/cityofaustin/atd-data-tech/issues/2184

This PR adds the rules outlined in #2184 to enhance the existing role editing in the admin UI.

I also snuck in an enhancement to display roles as the labels defined in `rbac-rules.js` in the User and Users views ("IT Supervisor" instead of "itSupervisor", etc.) just like they are in the Edit view.

### IT Supervisor

#### Editing own role
<img width="335" alt="itSupervisorSelf" src="https://user-images.githubusercontent.com/37249039/77985737-db8b5500-72da-11ea-9df6-8ed32e883241.png">

#### Editing other IT Supervisor
<img width="335" alt="itSupervisorOtherItSupervisor" src="https://user-images.githubusercontent.com/37249039/77985824-0e354d80-72db-11ea-8357-2d848fe04a5e.png">

### Admin

#### Editing own role
<img width="335" alt="adminSelf" src="https://user-images.githubusercontent.com/37249039/77985854-22794a80-72db-11ea-91a9-728e5f442e62.png">

#### Editing IT Supervisor
<img width="335" alt="adminOtherItSupervisor" src="https://user-images.githubusercontent.com/37249039/77985861-2c9b4900-72db-11ea-8cd0-eb8c54b7c033.png">

#### Editing other admin/editor/read-only
<img width="335" alt="adminOtherAdmin" src="https://user-images.githubusercontent.com/37249039/77985867-32912a00-72db-11ea-8ba5-52c1c6a3482c.png">

