### PR TITLE
Exclude non CoA Locations

### DIFF
--- a/atd-vze/src/views/Locations/Locations.js
+++ b/atd-vze/src/views/Locations/Locations.js
@@ -60,7 +60,10 @@ let queryConf = {
     },
   },
   order_by: {},
-  where: {},
+  where: {
+    // Only show Locations inside CoA Limits.
+    council_district: "_gt: 0",
+  },
   limit: 25,
   offset: 0,
 };


### PR DESCRIPTION
Closes https://github.com/cityofaustin/atd-data-tech/issues/2146

This turned out to be way more simple than I was originally thinking. Based on Frank's previous work in creating the Location polygons and adding a council districts attribute, we can assume that any Location that has a `council_district` value has already been processed with the `ST_Contains` method comparing the Council District polygons to each Location polygon. Of the 89,930 Location records, 62,971 have a `council_district` value >= 1 & <= 10 . The rest are `NULL`.

So if we just filter our Location query for records where the council_district > 0, we get the same 62,971 total.