### PR TITLE
Replace Unit Description column with Est Comprehensive Cost

### DIFF
--- a/atd-vze/src/Components/GridTable.js
+++ b/atd-vze/src/Components/GridTable.js
@@ -396,19 +396,26 @@ const GridTable = ({
     data[query.table].map((row, index) =>
       dataEntries.push(
         <tr key={index}>
-          {query.columns.map((column, ci) => (
-            <td key={ci}>
-              {query.isPK(column) ? (
-                <Link to={`/${query.singleItem}/${row[column]}`}>
-                  {row[column]}
-                </Link>
-              ) : isAlphanumeric(column) ? (
-                query.getFormattedValue(column, row[column])
-              ) : (
-                query.getFormattedValue(column, getSummary(row, column.trim()))
-              )}
-            </td>
-          ))}
+          {query.columns.map(
+            (column, ci) =>
+              // If column is hidden, don't render <td>
+              !query.isHidden(column) && (
+                <td key={ci}>
+                  {query.isPK(column) ? (
+                    <Link to={`/${query.singleItem}/${row[column]}`}>
+                      {row[column]}
+                    </Link>
+                  ) : isAlphanumeric(column) ? (
+                    query.getFormattedValue(column, row[column])
+                  ) : (
+                    query.getFormattedValue(
+                      column,
+                      getSummary(row, column.trim())
+                    )
+                  )}
+                </td>
+              )
+          )}
         </tr>
       )
     );

--- a/atd-vze/src/Components/GridTable.js
+++ b/atd-vze/src/Components/GridTable.js
@@ -308,7 +308,10 @@ const GridTable = ({
    **/
 
   // Allow for Date Range to be configured from the queryConf/gqlAbstract query props
-  const hasDateRange = typeof query.config.showDateRange !== "undefined" ? query.config.showDateRange : true; 
+  const hasDateRange =
+    typeof query.config.showDateRange !== "undefined"
+      ? query.config.showDateRange
+      : true;
   const dateField = query.table === "atd_apd_blueform" ? "date" : "crash_date";
   // Handle Date Range (only if available)
   if (

--- a/atd-vze/src/Components/GridTable.js
+++ b/atd-vze/src/Components/GridTable.js
@@ -523,22 +523,19 @@ const GridTable = ({
                   )}
                 </ButtonGroup>
               </ButtonToolbar>
-              <Table responsive>
-                <GridTableHeader
-                  query={query}
-                  handleTableHeaderClick={handleTableHeaderClick}
-                  sortColumn={sortColumn}
-                  sortOrder={sortOrder}
-                />
-
-                <tbody>
-                  {loading ? (
-                    <Spinner className="mt-2" color="primary" />
-                  ) : (
-                    data && dataEntries
-                  )}
-                </tbody>
-              </Table>
+              {loading ? (
+                <Spinner className="mt-2" color="primary" />
+              ) : (
+                <Table responsive>
+                  <GridTableHeader
+                    query={query}
+                    handleTableHeaderClick={handleTableHeaderClick}
+                    sortColumn={sortColumn}
+                    sortOrder={sortOrder}
+                  />
+                  <tbody>{data && dataEntries}</tbody>
+                </Table>
+              )}
             </CardBody>
           </Card>
         </Col>

--- a/atd-vze/src/Components/GridTableHeader.js
+++ b/atd-vze/src/Components/GridTableHeader.js
@@ -19,7 +19,13 @@ const GridTableHeader = ({
    * @param {boolean} ascending - true if ordering in ascending mode
    * @returns {object} jsx component
    */
-  const renderLabel = (col, sortable = false, ascending = false) => {
+  const renderLabel = (
+    col,
+    sortable = false,
+    ascending = false,
+    hidden = false
+  ) => {
+    if (hidden) return false;
     if (sortable) {
       return (
         <StyledArrow>
@@ -35,25 +41,28 @@ const GridTableHeader = ({
   return (
     <thead>
       <tr>
-        {query.columns.map((column, index) => (
-          <th
-            onClick={
-              query.isSortable(column)
-                ? e => handleTableHeaderClick(column)
-                : null
-            }
-            key={`th-${index}`}
-          >
-            {renderLabel(
-              // Get a human-readable label string
-              query.getLabel(column, "table"),
-              // If it is sortable, render as such
-              query.isSortable(column),
-              // If sort column is defined, use sort order, or false as default
-              sortColumn === column ? sortOrder === "asc" : false
-            )}
-          </th>
-        ))}
+        {query.columns.map(
+          (column, index) =>
+            !query.isHidden(column) && ( // If column is hidden, don't render <th>
+              <th
+                onClick={
+                  query.isSortable(column)
+                    ? e => handleTableHeaderClick(column)
+                    : null
+                }
+                key={`th-${index}`}
+              >
+                {renderLabel(
+                  // Get a human-readable label string
+                  query.getLabel(column, "table"),
+                  // If it is sortable, render as such
+                  query.isSortable(column),
+                  // If sort column is defined, use sort order, or false as default
+                  sortColumn === column ? sortOrder === "asc" : false
+                )}
+              </th>
+            )
+        )}
       </tr>
     </thead>
   );

--- a/atd-vze/src/queries/gqlAbstract.js
+++ b/atd-vze/src/queries/gqlAbstract.js
@@ -219,6 +219,15 @@ gqlAbstractTableAggregateName (
   }
 
   /**
+   * Returns true if a column is defined as hidden in the config, assumes false if not found.
+   * @param {string} columnName - The name of the column in the config
+   * @returns {boolean}
+   */
+  isHidden(columnName) {
+    return this.config["columns"][columnName]["hidden"] || false;
+  }
+
+  /**
    * Returns true if a column is defined as searchable in the config, assumes false if not found.
    * @param {string} columnName - The name of the column in the config
    * @returns {boolean}

--- a/atd-vze/src/views/Crashes/crashGridTableParameters.js
+++ b/atd-vze/src/views/Crashes/crashGridTableParameters.js
@@ -46,6 +46,12 @@ export const crashGridTableColumns = {
     label_table: "CRIS Death Count",
     type: "Date",
   },
+  est_comp_cost: {
+    searchable: false,
+    sortable: true,
+    label_table: "Est Comprehensive Cost",
+    type: "Currency",
+  },
   "collision { collsn_desc } ": {
     searchable: false,
     sortable: false,
@@ -57,6 +63,7 @@ export const crashGridTableColumns = {
     sortable: false,
     label_table: "Unit Description",
     type: "String",
+    hidden: true,
   },
   "geocode_method { name }": {
     searchable: false,


### PR DESCRIPTION
Closes https://github.com/cityofaustin/atd-data-tech/issues/2239

This seemed like it would be a simple fix but I hit a little bit of a blocker when I realized that if we remove the "Unit Description" column, our Locations detail page bombs because it needs that column to build the "Types of Vehicles - Count Distribution" dataviz widget.

So, I decided to add a hidden option for columns in the gqlAbstract. With the new `hidden: true` option, we still have access to the data for a column in the query (for the purpose of building dataviz widgets, etc) but we skip rendering it in the `<th>` & `<td>`  of the actual `<Table>` component.

Also fixed a console warning related to the Spinner rendering inside `<tbody>` and a few lines of prettier formatting.

![Screen Shot 2020-04-02 at 1 24 30 PM](https://user-images.githubusercontent.com/5697474/78284633-56c05700-74e5-11ea-94f4-6f17508add79.png)
