### PR TITLE
2096 viz components update

### DIFF
--- a/atd-vzv/src/constants/colors.js
+++ b/atd-vzv/src/constants/colors.js
@@ -16,6 +16,7 @@ export const colors = {
   intensity3Of5: '#ff8b8f',
   intensity4Of5: '#ff343b',
   intensity5Of5Highest: '#990428',
+  buttonBackground: '#f6f6f6',
   info: "#18A2B8",
   infoDark: "#257A8B",
   dark: "#343A41",

--- a/atd-vzv/src/views/nav/CrashTypeSelector.js
+++ b/atd-vzv/src/views/nav/CrashTypeSelector.js
@@ -1,14 +1,19 @@
 import React, { useState, useEffect } from "react";
 import { Button } from "reactstrap";
 import styled from "styled-components";
+import classnames from "classnames";
 import { colors } from "../../constants/colors";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import {
-  faHeartbeat,
-  faMedkit
-} from "@fortawesome/free-solid-svg-icons";
+import { faHeartbeat, faMedkit } from "@fortawesome/free-solid-svg-icons";
 
 const CrashTypeSelector = ({ setCrashType }) => {
+  const fatalitiesAndSeriousInjuries = {
+    name: "fatalitiesAndSeriousInjuries",
+    textString: "Fatalities and Serious Injuries",
+    queryStringCrash: "(death_cnt > 0 OR sus_serious_injry_cnt > 0)",
+    queryStringPerson: "(prsn_injry_sev_id = 4 OR prsn_injry_sev_id = 1)"
+  };
+
   const fatalities = {
     name: "fatalities",
     textString: "Fatalities",
@@ -23,77 +28,23 @@ const CrashTypeSelector = ({ setCrashType }) => {
     queryStringPerson: "(prsn_injry_sev_id = 1)"
   };
 
-  const [activeTab, setActiveTab] = useState([fatalities, seriousInjuries]);
-  const [previousTabClicked, setPreviousTabClicked] = useState([]);
+  const [activeTab, setActiveTab] = useState(fatalitiesAndSeriousInjuries);
 
   const toggle = tab => {
-    // Make a copy of the activeTab array that exists in state in order to mutate it
-    let placeHolder = [...activeTab];
-    // Attempt to filter out the object in the activeTab copy that matches the clicked tab
-    let filteredObject = placeHolder.filter(
-      objectChild => objectChild.name === tab.name
-    );
-    // Store the previous object filtered out to default back to if user clicks same tab twice
-    setPreviousTabClicked(filteredObject);
-    // If the clicked tab object is filtered out of the activeTab copy,
-    // find any remaining objects and place them into a new array
-    if (filteredObject.length) {
-      let placeHolderChild = [];
-      placeHolder.forEach(item => {
-        if (item.name !== tab.name) {
-          placeHolderChild.push(item);
-        }
-      });
-      // If there are remaining objects, set them to replace the activeTab copy, clearing out the clicked tab,
-      // else if there are no remaining objects, set the previous tab to replace the activeTab copy
-      // (toggling back to previous state rather than emptying activeTab completely and returning no results)
-      placeHolder = placeHolderChild.length
-        ? placeHolderChild
-        : previousTabClicked;
-      // If the clicked tab object was not found in the activeTab copy,
-      // add it back into the activeTab copy
-    } else {
-      placeHolder.push(tab);
+    if (activeTab.name !== tab.name) {
+      setActiveTab(tab);
     }
-    // Set the activeTab copy to replace activeTab in state
-    setActiveTab(placeHolder);
-  };
-
-  // Check to see whether a tab is unselected, return true if unselected
-  const isUnselected = tab => {
-    let filteredObject = activeTab.find(element => element.name === tab.name);
-    let unselected = filteredObject ? false : true;
-    return unselected;
-  };
-
-  // Set hover class based on whether button is unselected
-  const setHoverClass = unselected => {
-    return unselected ? "unselected" : "selected";
   };
 
   useEffect(() => {
-    const fatalitiesAndSeriousInjuries = {
-      name: "fatalitiesAndSeriousInjuries",
-      textString: "Fatalities and Serious Injuries",
-      queryStringCrash: "(death_cnt > 0 OR sus_serious_injry_cnt > 0)",
-      queryStringPerson:
-        "(prsn_injry_sev_id = 4 OR prsn_injry_sev_id = 1)"
-    };
-
-    const handleCrashType = () => {
-      let selectedCrashType =
-        activeTab.length > 1 ? fatalitiesAndSeriousInjuries : activeTab[0];
-      return selectedCrashType;
-    };
-
-    setCrashType(handleCrashType());
+    setCrashType(activeTab);
   }, [setCrashType, activeTab]);
 
-  // Set styles to override Bootstrap hover behavior based on whether button is selected
+  // Set styles to override Bootstrap default styling
   const StyledButton = styled.div`
     .crash-type {
       color: #171717;
-      background: #F6F6F6 0% 0% no-repeat padding-box;
+      background: #f6f6f6 0% 0% no-repeat padding-box;
       border-style: none;
       border-radius: 18px;
       opacity: 1;
@@ -115,48 +66,49 @@ const CrashTypeSelector = ({ setCrashType }) => {
       icon={faMedkit}
       color={colors.seriousInjuries}
     />
-  )
+  );
 
   return (
     <StyledButton>
-      {/* <ButtonGroup className="d-flex"> */}
       <Button
-          id="all-btn"
-          type="button"
-          // color="#171717"
-          className="crash-type"
-          // onClick={() => {
-          //   toggle(fatalities);
-          // }}
-          // outline={isUnselected(fatalities)}
-        >
-          All
-        </Button>      
-        <Button
-          id="fatalities-btn"
-          type="button"
-          // color="#171717"
-          className="crash-type"
-          // onClick={() => {
-          //   toggle(fatalities);
-          // }}
-          // outline={isUnselected(fatalities)}
-        >       
-          {fatalitiesIcon} Fatalities
-        </Button>
-        <Button
-          id="serious-injuries-btn"
-          type="button"
-          // color="#171717"
-          className="crash-type"
-          // onClick={() => {
-          //   toggle(seriousInjuries);
-          // }}
-          // outline={isUnselected(seriousInjuries)}
-        >
-          {seriousInjuriesIcon} Serious Injuries
-        </Button>
-      {/* </ButtonGroup> */}
+        id="all-btn"
+        type="button"
+        className={classnames(
+          { active: activeTab.name === "fatalitiesAndSeriousInjuries" },
+          "crash-type"
+        )}
+        onClick={() => {
+          toggle(fatalitiesAndSeriousInjuries);
+        }}
+      >
+        All
+      </Button>
+      <Button
+        id="fatalities-btn"
+        type="button"
+        className={classnames(
+          { active: activeTab.name === "fatalities" },
+          "crash-type"
+        )}
+        onClick={() => {
+          toggle(fatalities);
+        }}
+      >
+        {fatalitiesIcon} Fatalities
+      </Button>
+      <Button
+        id="serious-injuries-btn"
+        type="button"
+        className={classnames(
+          { active: activeTab.name === "seriousInjuries" },
+          "crash-type"
+        )}
+        onClick={() => {
+          toggle(seriousInjuries);
+        }}
+      >
+        {seriousInjuriesIcon} Serious Injuries
+      </Button>
     </StyledButton>
   );
 };

--- a/atd-vzv/src/views/nav/CrashTypeSelector.js
+++ b/atd-vzv/src/views/nav/CrashTypeSelector.js
@@ -1,7 +1,12 @@
 import React, { useState, useEffect } from "react";
-import { Button, ButtonGroup } from "reactstrap";
+import { Button } from "reactstrap";
 import styled from "styled-components";
 import { colors } from "../../constants/colors";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import {
+  faHeartbeat,
+  faMedkit
+} from "@fortawesome/free-solid-svg-icons";
 
 const CrashTypeSelector = ({ setCrashType }) => {
   const fatalities = {
@@ -86,50 +91,72 @@ const CrashTypeSelector = ({ setCrashType }) => {
 
   // Set styles to override Bootstrap hover behavior based on whether button is selected
   const StyledButton = styled.div`
-    .selected:hover {
-      background-color: ${colors.info};
-      border: 1px solid ${colors.info};
-      color: ${colors.white};
-    }
-    .unselected:hover {
-      background-color: ${colors.white};
-      border: 1px solid ${colors.info};
-      color: ${colors.info};
+    .crash-type {
+      color: #171717;
+      background: #F6F6F6 0% 0% no-repeat padding-box;
+      border-style: none;
+      border-radius: 18px;
+      opacity: 1;
+      margin-right: 10px;
     }
   `;
 
+  const fatalitiesIcon = (
+    <FontAwesomeIcon
+      className="block-icon"
+      icon={faHeartbeat}
+      color={colors.fatalities}
+    />
+  );
+
+  const seriousInjuriesIcon = (
+    <FontAwesomeIcon
+      className="block-icon"
+      icon={faMedkit}
+      color={colors.seriousInjuries}
+    />
+  )
+
   return (
     <StyledButton>
-      <ButtonGroup className="mb-3 d-flex">
+      {/* <ButtonGroup className="d-flex"> */}
+      <Button
+          id="all-btn"
+          type="button"
+          // color="#171717"
+          className="crash-type"
+          // onClick={() => {
+          //   toggle(fatalities);
+          // }}
+          // outline={isUnselected(fatalities)}
+        >
+          All
+        </Button>      
         <Button
           id="fatalities-btn"
           type="button"
-          color="info"
-          className={`${setHoverClass(
-            isUnselected(fatalities)
-          )} w-100 pt-1 pb-1 pl-0 pr-0`}
-          onClick={() => {
-            toggle(fatalities);
-          }}
-          outline={isUnselected(fatalities)}
-        >
-          Fatalities
+          // color="#171717"
+          className="crash-type"
+          // onClick={() => {
+          //   toggle(fatalities);
+          // }}
+          // outline={isUnselected(fatalities)}
+        >       
+          {fatalitiesIcon} Fatalities
         </Button>
         <Button
           id="serious-injuries-btn"
           type="button"
-          color="info"
-          className={`${setHoverClass(
-            isUnselected(seriousInjuries)
-          )} w-100 pt-1 pb-1 pl-0 pr-0`}
-          onClick={() => {
-            toggle(seriousInjuries);
-          }}
-          outline={isUnselected(seriousInjuries)}
+          // color="#171717"
+          className="crash-type"
+          // onClick={() => {
+          //   toggle(seriousInjuries);
+          // }}
+          // outline={isUnselected(seriousInjuries)}
         >
-          Serious Injuries
+          {seriousInjuriesIcon} Serious Injuries
         </Button>
-      </ButtonGroup>
+      {/* </ButtonGroup> */}
     </StyledButton>
   );
 };

--- a/atd-vzv/src/views/nav/CrashTypeSelector.js
+++ b/atd-vzv/src/views/nav/CrashTypeSelector.js
@@ -43,8 +43,8 @@ const CrashTypeSelector = ({ setCrashType }) => {
   // Set styles to override Bootstrap default styling
   const StyledButton = styled.div`
     .crash-type {
-      color: #171717;
-      background: #f6f6f6 0% 0% no-repeat padding-box;
+      color: ${colors.dark};
+      background: ${colors.buttonBackground} 0% 0% no-repeat padding-box;
       border-style: none;
       border-radius: 18px;
       opacity: 1;

--- a/atd-vzv/src/views/summary/CrashesByMode.js
+++ b/atd-vzv/src/views/summary/CrashesByMode.js
@@ -145,9 +145,19 @@ const CrashesByMode = () => {
 
   return (
     <Container>
-      <Row className="pb-3">
+      <Row>
         <Col>
-          <h3 className="text-center">{crashType.textString} by Mode</h3>
+          <h1 className="text-left, font-weight-bold">By Mode</h1>
+        </Col>
+      </Row>
+      <Row>
+        <Col>
+          <CrashTypeSelector setCrashType={setCrashType} />
+        </Col>
+      </Row>
+      <Row>
+        <Col>
+          <hr/>
         </Col>
       </Row>
       <Row>
@@ -177,11 +187,6 @@ const CrashesByMode = () => {
           <p className="text-center">
             Data Through: {dataEndDate.format("MMMM YYYY")}
           </p>
-        </Col>
-      </Row>
-      <Row className="pt-3">
-        <Col>
-          <CrashTypeSelector setCrashType={setCrashType} />
         </Col>
       </Row>
     </Container>

--- a/atd-vzv/src/views/summary/CrashesByMode.js
+++ b/atd-vzv/src/views/summary/CrashesByMode.js
@@ -105,7 +105,7 @@ const CrashesByMode = () => {
 
         accumulator += isFatalQuery && parseInt(record[fields.fatal]);
         accumulator += isInjuryQuery && parseInt(record[fields.injury]);
-        
+
         return accumulator;
       }, 0);
     });
@@ -157,7 +157,7 @@ const CrashesByMode = () => {
       </Row>
       <Row>
         <Col>
-          <hr/>
+          <hr />
         </Col>
       </Row>
       <Row>

--- a/atd-vzv/src/views/summary/CrashesByMonth.js
+++ b/atd-vzv/src/views/summary/CrashesByMonth.js
@@ -180,7 +180,7 @@ const CrashesByMonth = () => {
       </Row>
       <Row>
         <Col>
-          <hr style={{ marginTop: 3 }} />
+          <hr className="mt-1"/>
         </Col>
       </Row>
       <Row style={{ paddingBottom: 20 }}>

--- a/atd-vzv/src/views/summary/CrashesByMonth.js
+++ b/atd-vzv/src/views/summary/CrashesByMonth.js
@@ -160,9 +160,19 @@ const CrashesByMonth = () => {
 
   return (
     <Container>
-      <Row className="pb-3">
+      <Row>
         <Col>
-          <h3 className="text-center">{crashType.textString} by Year</h3>
+          <h1 className="text-left, font-weight-bold">By Year</h1>
+        </Col>
+      </Row>
+      <Row>
+        <Col>
+          <CrashTypeSelector setCrashType={setCrashType} />
+        </Col>
+      </Row>
+      <Row>
+        <Col>
+          <hr/>
         </Col>
       </Row>
       <Row style={{ paddingBottom: 20 }}>
@@ -198,11 +208,6 @@ const CrashesByMonth = () => {
               }
             }}
           />
-        </Col>
-      </Row>
-      <Row className="pt-3">
-        <Col>
-          <CrashTypeSelector setCrashType={setCrashType} />
         </Col>
       </Row>
     </Container>

--- a/atd-vzv/src/views/summary/CrashesByMonth.js
+++ b/atd-vzv/src/views/summary/CrashesByMonth.js
@@ -172,11 +172,16 @@ const CrashesByMonth = () => {
       </Row>
       <Row>
         <Col>
-          <hr/>
+          <hr />
         </Col>
       </Row>
-      <Row style={{ paddingBottom: 20 }}>
+      <Row>
         <Col>{!!chartData && renderHeader()}</Col>
+      </Row>
+      <Row>
+        <Col>
+          <hr style={{ marginTop: 3 }} />
+        </Col>
       </Row>
       <Row style={{ paddingBottom: 20 }}>
         <Col>

--- a/atd-vzv/src/views/summary/CrashesBySystem.js
+++ b/atd-vzv/src/views/summary/CrashesBySystem.js
@@ -105,11 +105,19 @@ const CrashesBySystem = () => {
 
   return (
     <Container>
-      <Row className="pb-3">
+      <Row>
         <Col>
-          <h3 className="text-center">
-            {crashType.textString} by Jurisdiction
-          </h3>
+          <h1 className="text-left, font-weight-bold">By Jurisdiction</h1>
+        </Col>
+      </Row>
+      <Row>
+        <Col>
+          <CrashTypeSelector setCrashType={setCrashType} />
+        </Col>
+      </Row>
+      <Row>
+        <Col>
+          <hr/>
         </Col>
       </Row>
       <Row>
@@ -132,11 +140,6 @@ const CrashesBySystem = () => {
               }
             }}
           />
-        </Col>
-      </Row>
-      <Row className="pt-3">
-        <Col>
-          <CrashTypeSelector setCrashType={setCrashType} />
         </Col>
       </Row>
     </Container>

--- a/atd-vzv/src/views/summary/CrashesBySystem.js
+++ b/atd-vzv/src/views/summary/CrashesBySystem.js
@@ -117,7 +117,7 @@ const CrashesBySystem = () => {
       </Row>
       <Row>
         <Col>
-          <hr/>
+          <hr />
         </Col>
       </Row>
       <Row>

--- a/atd-vzv/src/views/summary/CrashesByTimeOfDay.js
+++ b/atd-vzv/src/views/summary/CrashesByTimeOfDay.js
@@ -123,9 +123,19 @@ const CrashesByTimeOfDay = () => {
 
   return (
     <Container>
-      <Row className="pb-3">
+      <Row>
         <Col>
-          <h3 className="text-center">{crashType.textString} by Time of Day</h3>
+          <h1 className="text-left, font-weight-bold">By Time of Day</h1>
+        </Col>
+      </Row>
+      <Row>
+        <Col>
+          <CrashTypeSelector setCrashType={setCrashType} />
+        </Col>
+      </Row>
+      <Row>
+        <Col>
+          <hr/>
         </Col>
       </Row>
       <Row>
@@ -169,11 +179,6 @@ const CrashesByTimeOfDay = () => {
               />
             }
           />
-        </Col>
-      </Row>
-      <Row className="pt-3">
-        <Col>
-          <CrashTypeSelector setCrashType={setCrashType} />
         </Col>
       </Row>
     </Container>

--- a/atd-vzv/src/views/summary/CrashesByTimeOfDay.js
+++ b/atd-vzv/src/views/summary/CrashesByTimeOfDay.js
@@ -125,8 +125,8 @@ const CrashesByTimeOfDay = () => {
   // Set styles to override Bootstrap default styling
   const StyledButton = styled.div`
     .year-selector {
-      color: #171717;
-      background: #f6f6f6 0% 0% no-repeat padding-box;
+      color: ${colors.dark};
+      background: ${colors.buttonBackground} 0% 0% no-repeat padding-box;
       border-style: none;
       opacity: 1;
       margin-left: 5px;

--- a/atd-vzv/src/views/summary/CrashesByTimeOfDay.js
+++ b/atd-vzv/src/views/summary/CrashesByTimeOfDay.js
@@ -3,7 +3,8 @@ import axios from "axios";
 import moment from "moment";
 
 import CrashTypeSelector from "../nav/CrashTypeSelector";
-import { Nav, NavItem, NavLink, Row, Col, Container } from "reactstrap";
+import { Row, Col, Container, Button } from "reactstrap";
+import styled from "styled-components";
 import classnames from "classnames";
 import { Heatmap, HeatmapSeries } from "reaviz";
 import {
@@ -121,6 +122,18 @@ const CrashesByTimeOfDay = () => {
       });
   }, [activeTab, crashType]);
 
+  // Set styles to override Bootstrap default styling
+  const StyledButton = styled.div`
+    .year-selector {
+      color: #171717;
+      background: #f6f6f6 0% 0% no-repeat padding-box;
+      border-style: none;
+      opacity: 1;
+      margin-left: 5px;
+      margin-right: 5px;
+    }
+  `;
+
   return (
     <Container>
       <Row>
@@ -135,31 +148,32 @@ const CrashesByTimeOfDay = () => {
       </Row>
       <Row>
         <Col>
-          <hr/>
+          <hr />
         </Col>
       </Row>
-      <Row>
-        <Col>
-          <Nav tabs className="justify-content-center">
+      <Row className="text-center">
+        <Col className="pb-2">
+          <StyledButton>
             {yearsArray() // Calculate years ago for each year in data window
               .map(year => {
                 const currentYear = parseInt(dataEndDate.format("YYYY"));
                 return currentYear - year;
               })
               .map(yearsAgo => (
-                <NavItem key={yearsAgo}>
-                  <NavLink
-                    key={yearsAgo}
-                    className={classnames({ active: activeTab === yearsAgo })}
-                    onClick={() => {
-                      toggle(yearsAgo);
-                    }}
-                  >
-                    {getYearsAgoLabel(yearsAgo)}
-                  </NavLink>
-                </NavItem>
+                <Button
+                  key={yearsAgo}
+                  className={classnames(
+                    { active: activeTab === yearsAgo },
+                    "year-selector"
+                  )}
+                  onClick={() => {
+                    toggle(yearsAgo);
+                  }}
+                >
+                  {getYearsAgoLabel(yearsAgo)}
+                </Button>
               ))}
-          </Nav>
+          </StyledButton>
         </Col>
       </Row>
       <Row>

--- a/atd-vzv/src/views/summary/PeopleByDemographics.js
+++ b/atd-vzv/src/views/summary/PeopleByDemographics.js
@@ -203,7 +203,7 @@ const PeopleByDemographics = () => {
   const sortAndColorData = data => {
     const averageCrashes = dataArray =>
       dataArray.reduce((a, b) => a + b) / dataArray.length;
-    const dataSorted = data.sort(
+    const dataSorted = [...data].sort(
       (a, b) => averageCrashes(b.data) - averageCrashes(a.data)
     );
     // If age is selected, keep original sorting to make chart more readable
@@ -251,9 +251,19 @@ const PeopleByDemographics = () => {
 
   return (
     <Container>
-      <Row className="pb-3">
+      <Row>
         <Col>
-          <h3 className="text-center">{crashType.textString} Demographics</h3>
+          <h1 className="text-left, font-weight-bold">Demographics</h1>
+        </Col>
+      </Row>
+      <Row>
+        <Col>
+          <CrashTypeSelector setCrashType={setCrashType} />
+        </Col>
+      </Row>
+      <Row>
+        <Col>
+          <hr/>
         </Col>
       </Row>
       <Row>
@@ -331,11 +341,6 @@ const PeopleByDemographics = () => {
               }
             }}
           />
-        </Col>
-      </Row>
-      <Row className="pt-3">
-        <Col>
-          <CrashTypeSelector setCrashType={setCrashType} />
         </Col>
       </Row>
     </Container>

--- a/atd-vzv/src/views/summary/PeopleByDemographics.js
+++ b/atd-vzv/src/views/summary/PeopleByDemographics.js
@@ -253,8 +253,8 @@ const PeopleByDemographics = () => {
   // Set styles to override Bootstrap default styling
   const StyledButton = styled.div`
     .demographic-type {
-      color: #171717;
-      background: #f6f6f6 0% 0% no-repeat padding-box;
+      color: ${colors.dark};
+      background: ${colors.buttonBackground} 0% 0% no-repeat padding-box;
       border-style: none;
       opacity: 1;
       margin-left: 5px;

--- a/atd-vzv/src/views/summary/PeopleByDemographics.js
+++ b/atd-vzv/src/views/summary/PeopleByDemographics.js
@@ -1,7 +1,8 @@
 import React, { useEffect, useState } from "react";
 import axios from "axios";
 import { HorizontalBar } from "react-chartjs-2";
-import { Container, Row, Col, Nav, NavItem, NavLink } from "reactstrap";
+import { Container, Row, Col, Button } from "reactstrap";
+import styled from "styled-components";
 import classnames from "classnames";
 
 import CrashTypeSelector from "../nav/CrashTypeSelector";
@@ -249,6 +250,18 @@ const PeopleByDemographics = () => {
     datasets: !!chartData && createTypeDatasets()
   };
 
+  // Set styles to override Bootstrap default styling
+  const StyledButton = styled.div`
+    .demographic-type {
+      color: #171717;
+      background: #f6f6f6 0% 0% no-repeat padding-box;
+      border-style: none;
+      opacity: 1;
+      margin-left: 5px;
+      margin-right: 5px;
+    }
+  `;
+
   return (
     <Container>
       <Row>
@@ -263,45 +276,48 @@ const PeopleByDemographics = () => {
       </Row>
       <Row>
         <Col>
-          <hr/>
+          <hr />
         </Col>
       </Row>
-      <Row>
-        <Col>
-          <Nav tabs className="justify-content-center">
-            <NavItem>
-              <NavLink
-                className={classnames({ active: activeTab === "prsn_age" })}
-                onClick={() => {
-                  toggle("prsn_age");
-                }}
-              >
-                Age
-              </NavLink>
-            </NavItem>
-            <NavItem>
-              <NavLink
-                className={classnames({ active: activeTab === "prsn_gndr_id" })}
-                onClick={() => {
-                  toggle("prsn_gndr_id");
-                }}
-              >
-                Sex
-              </NavLink>
-            </NavItem>
-            <NavItem>
-              <NavLink
-                className={classnames({
+      <Row className="text-center">
+        <Col className="pb-2">
+          <StyledButton>
+            <Button
+              className={classnames(
+                { active: activeTab === "prsn_age" },
+                "demographic-type"
+              )}
+              onClick={() => {
+                toggle("prsn_age");
+              }}
+            >
+              Age
+            </Button>
+            <Button
+              className={classnames(
+                { active: activeTab === "prsn_gndr_id" },
+                "demographic-type"
+              )}
+              onClick={() => {
+                toggle("prsn_gndr_id");
+              }}
+            >
+              Sex
+            </Button>
+            <Button
+              className={classnames(
+                {
                   active: activeTab === "prsn_ethnicity_id"
-                })}
-                onClick={() => {
-                  toggle("prsn_ethnicity_id");
-                }}
-              >
-                Race/Ethnicity
-              </NavLink>
-            </NavItem>
-          </Nav>
+                },
+                "demographic-type"
+              )}
+              onClick={() => {
+                toggle("prsn_ethnicity_id");
+              }}
+            >
+              Race/Ethnicity
+            </Button>
+          </StyledButton>
         </Col>
       </Row>
       <Row>


### PR DESCRIPTION
Fixes https://github.com/cityofaustin/atd-data-tech/issues/2096

Updates crash type selector to be simple buttons rather than toggles, updates headers, adds line breaks after buttons, and redesigns secondary selectors (year, demographic type) to match crash type buttons etc.

<img width="436" alt="Screen Shot 2020-04-06 at 5 39 46 PM" src="https://user-images.githubusercontent.com/35410637/78611939-b6906800-782d-11ea-9bf7-9b6a85c8400d.png">
<img width="436" alt="Screen Shot 2020-04-06 at 5 39 46 PM" src="https://user-images.githubusercontent.com/35410637/78611946-babc8580-782d-11ea-9c20-9b53a0c7a378.png">
<img width="424" alt="Screen Shot 2020-04-06 at 5 40 00 PM" src="https://user-images.githubusercontent.com/35410637/78611959-bf813980-782d-11ea-9295-4036b5f03ab5.png">
<img width="428" alt="Screen Shot 2020-04-06 at 5 40 10 PM" src="https://user-images.githubusercontent.com/35410637/78611968-c4de8400-782d-11ea-8b73-e9b2d1125d75.png">
