### PR TITLE
2098 update time of day scale logic

### DIFF
--- a/atd-vzv/package-lock.json
+++ b/atd-vzv/package-lock.json
@@ -5344,9 +5344,9 @@
       },
       "dependencies": {
         "cross-spawn": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.1.tgz",
-          "integrity": "sha512-u7v4o84SwFpD32Z8IIcPZ6z1/ie24O6RU3RbtL5Y316l3KuHVPx9ItBgWQ6VlfAFnRnTtMUrsQ9MUUTuEZjogg==",
+          "version": "7.0.2",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.2.tgz",
+          "integrity": "sha512-PD6G8QG3S4FK/XCGFbEQrDqO2AnMMsy0meR7lerlIOHAAbkuavGU/pOqprrlvfTNjvowivTeBsjebAL0NSoMxw==",
           "requires": {
             "path-key": "^3.1.0",
             "shebang-command": "^2.0.0",
@@ -5736,9 +5736,9 @@
       "integrity": "sha512-TzNPeJy2+iEepfiL92LAAB7fvnp/dV2YwANPVHdDWmYMm23qIJBYww3qT8I8C1wXrmrg4UWs7BKc2tKIgyjzHg=="
     },
     "d3-format": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.4.2.tgz",
-      "integrity": "sha512-gco1Ih54PgMsyIXgttLxEhNy/mXxq8+rLnCb5shQk+P5TsiySrwWU5gpB4zen626J4LIwBxHvDChyA8qDm57ww=="
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.4.4.tgz",
+      "integrity": "sha512-TWks25e7t8/cqctxCmxpUuzZN11QxIA7YrMbram94zMQ0PXjE4LVIMe/f6a4+xxL8HQ3OsAFULOINQi1pE62Aw=="
     },
     "d3-geo": {
       "version": "1.11.9",
@@ -5803,9 +5803,9 @@
       "integrity": "sha512-Xh0isrZ5rPYYdqhAVk8VLnMEidhz5aP7htAADH6MfzgmmicPkTo8LhkLxci61/lCB7n7UmE3bN0leRt+qvkLxA=="
     },
     "d3-time-format": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.2.2.tgz",
-      "integrity": "sha512-pweL2Ri2wqMY+wlW/wpkl8T3CUzKAha8S9nmiQlMABab8r5MJN0PD1V4YyRNVaKQfeh4Z0+VO70TLw6ESVOYzw==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.2.3.tgz",
+      "integrity": "sha512-RAHNnD8+XvC4Zc4d2A56Uw0yJoM7bsvOlJR33bclxq399Rak/b9bhvu/InjxdWhPtkgU53JJcleJTGkNRnN6IA==",
       "requires": {
         "d3-time": "1"
       }
@@ -6252,11 +6252,11 @@
       "integrity": "sha512-Tc8JQEfGQ1MzfSzI/bTlSr7btJv/FFO7Yh6tanqVmIWOuNCu6/D1MilIEgLtmWqIrsv+o4IjpLAhgMBr/ncNAA=="
     },
     "element-resize-detector": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/element-resize-detector/-/element-resize-detector-1.1.15.tgz",
-      "integrity": "sha512-16/5avDegXlUxytGgaumhjyQoM6hpp5j3+L79sYq5hlXfTNRy5WMMuTVWkZU3egp/CokCmTmvf18P3KeB57Iog==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/element-resize-detector/-/element-resize-detector-1.2.1.tgz",
+      "integrity": "sha512-BdFsPepnQr9fznNPF9nF4vQ457U/ZJXQDSNF1zBe7yaga8v9AdZf3/NElYxFdUh7SitSGt040QygiTo6dtatIw==",
       "requires": {
-        "batch-processor": "^1.0.0"
+        "batch-processor": "1.0.0"
       }
     },
     "ellipsize": {
@@ -8421,9 +8421,9 @@
       }
     },
     "is-boolean-object": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.0.0.tgz",
-      "integrity": "sha1-mPiygDBoQhmpXzdc+9iM40Bd/5M="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.0.1.tgz",
+      "integrity": "sha512-TqZuVwa/sppcrhUCAYkGBk7w0yxfQQnxq28fjkO53tnK9FQXmdwz2JS5+GjsWQ6RByES1K40nI+yDic5c9/aAQ=="
     },
     "is-buffer": {
       "version": "1.1.6",
@@ -8557,9 +8557,9 @@
       }
     },
     "is-number-object": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.3.tgz",
-      "integrity": "sha1-8mWrian0RQNO9q/xWo8AsA9VF5k="
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.4.tgz",
+      "integrity": "sha512-zohwelOAur+5uXtk8O3GPQ1eAcu4ZX3UwxQhUlfFFMNpUd83gXgjbhJh6HmB6LUNV/ieOLQuDwJO3dWJosUeMw=="
     },
     "is-obj": {
       "version": "1.0.1",
@@ -8634,9 +8634,9 @@
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
     },
     "is-string": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.4.tgz",
-      "integrity": "sha1-zDqbaYV9Yh6WNyWiTK7shzuCbmQ="
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.5.tgz",
+      "integrity": "sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ=="
     },
     "is-svg": {
       "version": "3.0.0",
@@ -12714,15 +12714,50 @@
       }
     },
     "rdk": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/rdk/-/rdk-3.0.3.tgz",
-      "integrity": "sha512-/3jDBhKzQGIVMVjFDlGDCRRs7kf6Q3XvaCVVN12TpicrFNfUL/sdodgXa1NsoZDKEjpQ623+z9USuziujZiVIA==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/rdk/-/rdk-3.0.4.tgz",
+      "integrity": "sha512-xXCs6gCGk1AHgMoAoSek6HGCeka2zriUPzCKLx9FTtFkBflpxqWXtIzTNym0JZXjmrN5dDzzYrw5VUq7S05Vpg==",
       "requires": {
         "classnames": "^2.2.6",
-        "framer-motion": "1.6.7",
+        "framer-motion": "1.8.4",
         "memoize-bind": "^1.0.3",
-        "popper.js": "^1.15.0",
-        "react-scrolllock": "^4.0.1"
+        "popper.js": "^1.16.1",
+        "react-scrolllock": "^5.0.0"
+      },
+      "dependencies": {
+        "framer-motion": {
+          "version": "1.8.4",
+          "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-1.8.4.tgz",
+          "integrity": "sha512-MMtJ3m0UpSb+val+aL8snz57p47LJS8lBSzvybhXjJgQHpufTZEzbp62eXNVdBlCHnC02J5+NmHRz4AAN6J9Qg==",
+          "requires": {
+            "@emotion/is-prop-valid": "^0.8.2",
+            "@popmotion/easing": "^1.0.2",
+            "@popmotion/popcorn": "^0.4.2",
+            "framesync": "^4.0.4",
+            "hey-listen": "^1.0.8",
+            "popmotion": "9.0.0-beta-8",
+            "style-value-types": "^3.1.6",
+            "stylefire": "^7.0.2",
+            "tslib": "^1.10.0"
+          }
+        },
+        "popper.js": {
+          "version": "1.16.1",
+          "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
+          "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ=="
+        },
+        "stylefire": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/stylefire/-/stylefire-7.0.3.tgz",
+          "integrity": "sha512-Q0l7NSeFz/OkX+o6/7Zg3VZxSAZeQzQpYomWmIpOehFM/rJNMSLVX5fgg6Q48ut2ETNKwdhm97mPNU643EBCoQ==",
+          "requires": {
+            "@popmotion/popcorn": "^0.4.4",
+            "framesync": "^4.0.0",
+            "hey-listen": "^1.0.8",
+            "style-value-types": "^3.1.7",
+            "tslib": "^1.10.0"
+          }
+        }
       }
     },
     "react": {
@@ -12758,9 +12793,9 @@
       }
     },
     "react-countup": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/react-countup/-/react-countup-4.3.2.tgz",
-      "integrity": "sha512-3zkN1XXQgRC1b2L97e47m7D2BKQoYEw0ZiBsbrfqp4w7YA/GtOXwJWgA/2XcYh0TQyHqp47ZCCjradCK8iSGEw==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/react-countup/-/react-countup-4.3.3.tgz",
+      "integrity": "sha512-pWnxpwdPNRyJFha/YKKbyc4RLAw8PzmULdgCziGIgw6vxhT1VdccrvQgj38HBSoM2qF/MoLmn4M2klvDWVIdaw==",
       "requires": {
         "countup.js": "^1.9.3",
         "prop-types": "^15.7.2",
@@ -12992,11 +13027,6 @@
         }
       }
     },
-    "react-node-resolver": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/react-node-resolver/-/react-node-resolver-2.0.1.tgz",
-      "integrity": "sha512-+PPy/FtAAo5wsLQYMlHkxJ3AMUGL33gpEIx/HBzS8OrcIfacRhGaNVWUJ8bhEbc64en+/bbCNTVZR+pkhqXEbA=="
-    },
     "react-popper": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-1.3.4.tgz",
@@ -13071,20 +13101,19 @@
       }
     },
     "react-scrolllock": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/react-scrolllock/-/react-scrolllock-4.0.1.tgz",
-      "integrity": "sha512-XWtRucd411402AfwnUyR0cZqN/beJy0NAygX92APzgeAhkHzpfWrsiakqKVIVqMNkgM8s2lIku/hzaFoTgw7Gw==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/react-scrolllock/-/react-scrolllock-5.0.1.tgz",
+      "integrity": "sha512-poeEsjnZAlpA6fJlaNo4rZtcip2j6l5mUGU/SJe1FFlicEudS943++u7ZSdA7lk10hoyYK3grOD02/qqt5Lxhw==",
       "requires": {
-        "exenv": "^1.2.2",
-        "react-node-resolver": "^2.0.1"
+        "exenv": "^1.2.2"
       }
     },
     "react-sizeme": {
-      "version": "2.6.10",
-      "resolved": "https://registry.npmjs.org/react-sizeme/-/react-sizeme-2.6.10.tgz",
-      "integrity": "sha512-OJAPQxSqbcpbsXFD+fr5ARw4hNSAOimWcaTOLcRkIqnTp9+IFWY0w3Qdw1sMez6Ao378aimVL/sW6TTsgigdOA==",
+      "version": "2.6.12",
+      "resolved": "https://registry.npmjs.org/react-sizeme/-/react-sizeme-2.6.12.tgz",
+      "integrity": "sha512-tL4sCgfmvapYRZ1FO2VmBmjPVzzqgHA7kI8lSJ6JS6L78jXFNRdOZFpXyK6P1NBZvKPPCZxReNgzZNUajAerZw==",
       "requires": {
-        "element-resize-detector": "^1.1.15",
+        "element-resize-detector": "^1.2.1",
         "invariant": "^2.2.4",
         "shallowequal": "^1.1.0",
         "throttle-debounce": "^2.1.0"
@@ -13231,16 +13260,16 @@
       }
     },
     "reaviz": {
-      "version": "7.2.2",
-      "resolved": "https://registry.npmjs.org/reaviz/-/reaviz-7.2.2.tgz",
-      "integrity": "sha512-khfJkNG/JhLuwHpIidNVzqMvmwYVerYTCevXCK+SUxNXEqnDw+UiqDpBXUA9aysVVpsCyjgN95yLN4dwOOok5g==",
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/reaviz/-/reaviz-7.2.3.tgz",
+      "integrity": "sha512-9DcL1JiDAqzboGGiPjVJBTQPl6WrSlXJHuIWTKjqzswX2aAMTaugTBA/K+zkCjJVnoe4TX2h42MVJ7JtUqSJIA==",
       "requires": {
         "big-integer": "1.6.48",
         "calculate-size": "^1.1.1",
         "chroma-js": "^2.1.0",
         "classnames": "^2.2.6",
         "d3-array": "^2.4.0",
-        "d3-format": "^1.4.2",
+        "d3-format": "^1.4.3",
         "d3-geo": "^1.11.9",
         "d3-interpolate": "^1.4.0",
         "d3-sankey": "^0.12.3",
@@ -13254,9 +13283,9 @@
         "memoize-bind": "^1.0.3",
         "memoize-one": "^5.1.1",
         "rdk": "^3.0.3",
-        "react-countup": "^4.2.3",
-        "react-sizeme": "^2.6.10",
-        "transformation-matrix": "^2.1.1"
+        "react-countup": "^4.3.2",
+        "react-sizeme": "^2.6.12",
+        "transformation-matrix": "^2.2.0"
       }
     },
     "recompose": {
@@ -15092,9 +15121,9 @@
       }
     },
     "transformation-matrix": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/transformation-matrix/-/transformation-matrix-2.2.0.tgz",
-      "integrity": "sha512-cxs7k1YT05BgY03PZg8P4MJUcLCqYdG+web+rXdTpyCYfyu6u6CS+X0hSMkHHdFrWpe5gsIQwwPAik+K6UnuMw=="
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/transformation-matrix/-/transformation-matrix-2.3.0.tgz",
+      "integrity": "sha512-iXgfTkswsqHyG3SzL04mfniI4z6/XUDBiWmMv/+YSDFIjoF4Ugy3AwkoL8ed+cCak1uLfb70wQbIkATNS6fgPA=="
     },
     "ts-pnp": {
       "version": "1.1.5",

--- a/atd-vzv/package.json
+++ b/atd-vzv/package.json
@@ -28,7 +28,7 @@
     "react-scripts": "^3.3.0",
     "react-virtualized": "^9.21.2",
     "reactstrap": "^8.1.1",
-    "reaviz": "^7.2.2",
+    "reaviz": "^7.2.3",
     "serialize-javascript": ">=2.1.1",
     "styled-components": "^4.4.0"
   },

--- a/atd-vzv/src/App.css
+++ b/atd-vzv/src/App.css
@@ -18,5 +18,6 @@ a:focus {
 }
 
 div.Tooltip-module_tooltip__omIxd {
+  color: #e4e5e6;
   background: rgb(54, 51, 51);
 }

--- a/atd-vzv/src/views/summary/CrashesByMonth.js
+++ b/atd-vzv/src/views/summary/CrashesByMonth.js
@@ -141,7 +141,7 @@ const CrashesByMonth = () => {
 
   // Build data objects
   const data = {
-    labels: moment.months(),
+    labels: moment.monthsShort(),
     datasets: !!chartData && createDatasets(),
   };
 

--- a/atd-vzv/src/views/summary/CrashesByTimeOfDay.js
+++ b/atd-vzv/src/views/summary/CrashesByTimeOfDay.js
@@ -6,7 +6,14 @@ import CrashTypeSelector from "../nav/CrashTypeSelector";
 import { Row, Col, Container, Button } from "reactstrap";
 import styled from "styled-components";
 import classnames from "classnames";
-import { Heatmap, HeatmapSeries } from "reaviz";
+import {
+  Heatmap,
+  HeatmapSeries,
+  HeatmapCell,
+  ChartTooltip,
+  SequentialLegend,
+  TooltipArea,
+} from "reaviz";
 import {
   summaryCurrentYearStartDate,
   summaryCurrentYearEndDate,
@@ -100,6 +107,13 @@ const CrashesByTimeOfDay = () => {
             break;
         }
       });
+      dataArray.forEach((hour) => {
+        hour.data.forEach((day) => {
+          if (day.data === 0) {
+            day.data = null;
+          }
+        });
+      });
       return dataArray;
     };
 
@@ -119,6 +133,14 @@ const CrashesByTimeOfDay = () => {
         setHeatmapData(calculateHourBlockTotals(res));
       });
   }, [activeTab, crashType]);
+
+  const formatOutput = (d) => {
+    const value = d.data.value ? d.data.value : 0;
+    const output = `${d.x} ${
+      value
+    }`;
+    return output;
+  };
 
   // Set styles to override Bootstrap default styling
   const StyledButton = styled.div`
@@ -182,14 +204,37 @@ const CrashesByTimeOfDay = () => {
             series={
               <HeatmapSeries
                 colorScheme={[
-                  colors.intensity1Of5Lowest,
                   colors.intensity2Of5,
                   colors.intensity3Of5,
                   colors.intensity4Of5,
                   colors.viridis1Of6Highest,
                 ]}
+                emptyColor={colors.intensity1Of5Lowest}
+                cell={
+                  <HeatmapCell
+                    tooltip={
+                      <ChartTooltip
+                        content={(d) => formatOutput(d)}
+                      />
+                    }
+                  />
+                }
               />
             }
+          />
+        </Col>
+      </Row>
+      <Row>
+        <Col className="pb-2">
+          <SequentialLegend
+            data={heatmapData}
+            orientation="horizontal"
+            colorScheme={[
+              colors.intensity2Of5,
+              colors.intensity3Of5,
+              colors.intensity4Of5,
+              colors.viridis1Of6Highest,
+            ]}
           />
         </Col>
       </Row>

--- a/atd-vzv/src/views/summary/CrashesByTimeOfDay.js
+++ b/atd-vzv/src/views/summary/CrashesByTimeOfDay.js
@@ -106,6 +106,8 @@ const CrashesByTimeOfDay = () => {
             break;
         }
       });
+      // Set any 0 values to null so that the reaviz library
+      // recognizes them as "blank cells" and fills them accordingly
       dataArray.forEach((hour) => {
         hour.data.forEach((day) => {
           if (day.data === 0) {

--- a/atd-vzv/src/views/summary/CrashesByTimeOfDay.js
+++ b/atd-vzv/src/views/summary/CrashesByTimeOfDay.js
@@ -33,9 +33,8 @@ const CrashesByTimeOfDay = () => {
   };
 
   useEffect(() => {
-    const dayOfWeekArray = moment.weekdays();
-    // const dayOfWeekArrayFormatted = dayOfWeekArray.format("dd");
-    // console.log(dayOfWeekArrayFormatted);
+    const dayOfWeekArray = moment.weekdaysShort();
+
     const hourBlockArray = [
       "12AM",
       "01AM",
@@ -155,7 +154,7 @@ const CrashesByTimeOfDay = () => {
   `;
 
   return (
-    <Container>
+    <Container className="m-0 p-0">
       <Row>
         <Col>
           <h2 className="text-left, font-weight-bold">By Time of Day</h2>
@@ -228,7 +227,7 @@ const CrashesByTimeOfDay = () => {
         </Col>
       </Row>
       <Row>
-        <Col className="pb-2">
+        <Col className="py-2">
           <SequentialLegend
             data={heatmapData}
             orientation="horizontal"

--- a/atd-vzv/src/views/summary/CrashesByTimeOfDay.js
+++ b/atd-vzv/src/views/summary/CrashesByTimeOfDay.js
@@ -34,6 +34,8 @@ const CrashesByTimeOfDay = () => {
 
   useEffect(() => {
     const dayOfWeekArray = moment.weekdays();
+    // const dayOfWeekArrayFormatted = dayOfWeekArray.format("dd");
+    // console.log(dayOfWeekArrayFormatted);
     const hourBlockArray = [
       "12AM",
       "01AM",

--- a/atd-vzv/src/views/summary/CrashesByTimeOfDay.js
+++ b/atd-vzv/src/views/summary/CrashesByTimeOfDay.js
@@ -12,7 +12,6 @@ import {
   HeatmapCell,
   ChartTooltip,
   SequentialLegend,
-  TooltipArea,
 } from "reaviz";
 import {
   summaryCurrentYearStartDate,
@@ -134,12 +133,9 @@ const CrashesByTimeOfDay = () => {
       });
   }, [activeTab, crashType]);
 
-  const formatOutput = (d) => {
+  const formatValue = (d) => {
     const value = d.data.value ? d.data.value : 0;
-    const output = `${d.x} ${
-      value
-    }`;
-    return output;
+    return value;
   };
 
   // Set styles to override Bootstrap default styling
@@ -214,7 +210,10 @@ const CrashesByTimeOfDay = () => {
                   <HeatmapCell
                     tooltip={
                       <ChartTooltip
-                        content={(d) => formatOutput(d)}
+                        content={(d) =>
+                          `${d.x} ∙
+                          ${formatValue(d)}`
+                        }
                       />
                     }
                   />


### PR DESCRIPTION
Fixes https://github.com/cityofaustin/atd-data-tech/issues/2098

- Updates scale so that 0 is always represented by the lowest color in the intensity range. The rest of the values are split up dynamically and represented by the remaining four colors in the color scheme.
- Adds a legend for better context

<img width="482" alt="Screen Shot 2020-04-13 at 6 11 01 PM" src="https://user-images.githubusercontent.com/35410637/79169501-3bd9c680-7db2-11ea-87d9-19ac4c0a0a7a.png">

<img width="480" alt="Screen Shot 2020-04-13 at 6 11 14 PM" src="https://user-images.githubusercontent.com/35410637/79169505-3f6d4d80-7db2-11ea-8c54-a4724ec2aa2d.png">
