### PR TITLE
Added Index to city_id in crashes

### DIFF
--- a/atd-vzd/migrations/migration_crashes_2020_03_15--1648.sql
+++ b/atd-vzd/migrations/migration_crashes_2020_03_15--1648.sql
@@ -1,0 +1,3 @@
+-- Added index for city_id on crashes table
+create index atd_txdot_crashes_city_id_index
+	on atd_txdot_crashes (city_id);


### PR DESCRIPTION
This has been already implemented in staging and production, just added a migration file to keep track of structure.