### PR TITLE
updated reaviz and reintegrated custom tooltip

### DIFF
--- a/atd-vzv/package-lock.json
+++ b/atd-vzv/package-lock.json
@@ -7627,9 +7627,9 @@
       }
     },
     "framer-motion": {
-      "version": "1.6.7",
-      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-1.6.7.tgz",
-      "integrity": "sha512-1tAqvyf70jj1b7ue86iDYEQ5ShwH4Ge6y+slAmkGrxPn9y+BgdZDP3pG10Gs6GgpNalNglKH9hRb8Uw75SwHog==",
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-1.10.3.tgz",
+      "integrity": "sha512-VooCzGWg7brSO4Gc0YwpY5AadJe4OPS74ZyOlOHWll5rMXCoOc6Ia3uDQ6RfOJlwCP/D9TQuRGtboyJiVXjVcw==",
       "requires": {
         "@emotion/is-prop-valid": "^0.8.2",
         "@popmotion/easing": "^1.0.2",
@@ -7638,7 +7638,7 @@
         "hey-listen": "^1.0.8",
         "popmotion": "9.0.0-beta-8",
         "style-value-types": "^3.1.6",
-        "stylefire": "^6.0.10",
+        "stylefire": "^7.0.2",
         "tslib": "^1.10.0"
       }
     },
@@ -12825,49 +12825,20 @@
       }
     },
     "rdk": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/rdk/-/rdk-3.0.4.tgz",
-      "integrity": "sha512-xXCs6gCGk1AHgMoAoSek6HGCeka2zriUPzCKLx9FTtFkBflpxqWXtIzTNym0JZXjmrN5dDzzYrw5VUq7S05Vpg==",
+      "version": "4.0.17",
+      "resolved": "https://registry.npmjs.org/rdk/-/rdk-4.0.17.tgz",
+      "integrity": "sha512-ATXsZzw1PlDrZ11aEQxMO4s2czoo5n20MmCDOo5baedKmwlZRIbYJbeoQy7NqqgpI5pZf5WnbO5/G7kClTghLQ==",
       "requires": {
         "classnames": "^2.2.6",
-        "framer-motion": "1.8.4",
-        "memoize-bind": "^1.0.3",
+        "framer-motion": "^1.10.3",
         "popper.js": "^1.16.1",
-        "react-scrolllock": "^5.0.0"
+        "react-scrolllock": "^5.0.1"
       },
       "dependencies": {
-        "framer-motion": {
-          "version": "1.8.4",
-          "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-1.8.4.tgz",
-          "integrity": "sha512-MMtJ3m0UpSb+val+aL8snz57p47LJS8lBSzvybhXjJgQHpufTZEzbp62eXNVdBlCHnC02J5+NmHRz4AAN6J9Qg==",
-          "requires": {
-            "@emotion/is-prop-valid": "^0.8.2",
-            "@popmotion/easing": "^1.0.2",
-            "@popmotion/popcorn": "^0.4.2",
-            "framesync": "^4.0.4",
-            "hey-listen": "^1.0.8",
-            "popmotion": "9.0.0-beta-8",
-            "style-value-types": "^3.1.6",
-            "stylefire": "^7.0.2",
-            "tslib": "^1.10.0"
-          }
-        },
         "popper.js": {
           "version": "1.16.1",
           "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
           "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ=="
-        },
-        "stylefire": {
-          "version": "7.0.3",
-          "resolved": "https://registry.npmjs.org/stylefire/-/stylefire-7.0.3.tgz",
-          "integrity": "sha512-Q0l7NSeFz/OkX+o6/7Zg3VZxSAZeQzQpYomWmIpOehFM/rJNMSLVX5fgg6Q48ut2ETNKwdhm97mPNU643EBCoQ==",
-          "requires": {
-            "@popmotion/popcorn": "^0.4.4",
-            "framesync": "^4.0.0",
-            "hey-listen": "^1.0.8",
-            "style-value-types": "^3.1.7",
-            "tslib": "^1.10.0"
-          }
         }
       }
     },
@@ -13393,9 +13364,9 @@
       }
     },
     "reaviz": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/reaviz/-/reaviz-7.2.3.tgz",
-      "integrity": "sha512-9DcL1JiDAqzboGGiPjVJBTQPl6WrSlXJHuIWTKjqzswX2aAMTaugTBA/K+zkCjJVnoe4TX2h42MVJ7JtUqSJIA==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/reaviz/-/reaviz-8.1.0.tgz",
+      "integrity": "sha512-+7S6O3LRQibSMhL9MsgMgIm0liPUwOPPd0KKIf9bRGOguPfRfIUn9Ep30LtKRmqQFK/HL1SbRXHn6su48kFcVA==",
       "requires": {
         "big-integer": "1.6.48",
         "calculate-size": "^1.1.1",
@@ -13410,13 +13381,13 @@
         "d3-shape": "^1.3.7",
         "d3-time": "^1.1.0",
         "ellipsize": "^0.1.0",
-        "framer-motion": "1.6.7",
+        "framer-motion": "1.10.3",
         "human-format": "^0.10.1",
         "is-equal": "1.6.0",
         "memoize-bind": "^1.0.3",
         "memoize-one": "^5.1.1",
-        "rdk": "^3.0.3",
-        "react-countup": "^4.3.2",
+        "rdk": "4.0.17",
+        "react-countup": "^4.3.3",
         "react-sizeme": "^2.6.12",
         "transformation-matrix": "^2.2.0"
       }
@@ -14862,14 +14833,15 @@
       }
     },
     "stylefire": {
-      "version": "6.0.12",
-      "resolved": "https://registry.npmjs.org/stylefire/-/stylefire-6.0.12.tgz",
-      "integrity": "sha512-cE7pGHZpA1DZ6yIYFbrLpF13e98jRu0vWwU4oK/En1PKpAo6IrEdWo8rDd5qzQkUQ+Jl8ioDhK4yzj9UEHDOwQ==",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/stylefire/-/stylefire-7.0.3.tgz",
+      "integrity": "sha512-Q0l7NSeFz/OkX+o6/7Zg3VZxSAZeQzQpYomWmIpOehFM/rJNMSLVX5fgg6Q48ut2ETNKwdhm97mPNU643EBCoQ==",
       "requires": {
-        "@popmotion/popcorn": "^0.4.2",
+        "@popmotion/popcorn": "^0.4.4",
         "framesync": "^4.0.0",
         "hey-listen": "^1.0.8",
-        "style-value-types": "^3.1.6"
+        "style-value-types": "^3.1.7",
+        "tslib": "^1.10.0"
       }
     },
     "stylehacks": {

--- a/atd-vzv/package.json
+++ b/atd-vzv/package.json
@@ -29,7 +29,7 @@
     "react-scripts": "^3.3.0",
     "react-with-styles-interface-aphrodite": "^6.0.1",
     "reactstrap": "^8.1.1",
-    "reaviz": "^7.2.3",
+    "reaviz": "^8.1.0",
     "serialize-javascript": ">=2.1.1",
     "styled-components": "^4.4.0"
   },

--- a/atd-vzv/src/views/summary/CrashesByTimeOfDay.js
+++ b/atd-vzv/src/views/summary/CrashesByTimeOfDay.js
@@ -195,10 +195,10 @@ const CrashesByTimeOfDay = () => {
           </StyledButton>
         </Col>
       </Row>
-      <Row>
+      <Row className="h-auto">
         <Col>
           <Heatmap
-            height={200}
+            height={267}
             data={heatmapData}
             series={
               <HeatmapSeries

--- a/atd-vzv/src/views/summary/CrashesByTimeOfDay.js
+++ b/atd-vzv/src/views/summary/CrashesByTimeOfDay.js
@@ -136,6 +136,11 @@ const CrashesByTimeOfDay = () => {
       });
   }, [activeTab, crashType]);
 
+  const formatValue = (d) => {
+    const value = d.data.value ? d.data.value : 0;
+    return value;
+  };
+
   // Set styles to override Bootstrap default styling
   const StyledButton = styled.div`
     .year-selector {
@@ -204,6 +209,18 @@ const CrashesByTimeOfDay = () => {
                   colors.viridis1Of6Highest,
                 ]}
                 emptyColor={colors.intensity1Of5Lowest}
+                cell={
+                  <HeatmapCell
+                    tooltip={
+                      <ChartTooltip
+                        content={(d) =>
+                          `${d.x} ∙
+                          ${formatValue(d)}`
+                        }
+                      />
+                    }
+                  />
+                }                
               />
             }
           />


### PR DESCRIPTION
Fixes https://github.com/cityofaustin/atd-data-tech/issues/2367

Fixes issue with persistent tooltip (thanks @mddilley for uncovering the solution), reintroduces custom tooltip that shows 0 for times when there are no crashes as opposed to no value at all, and resizes viz to match height of demographics chart (adjacent chart).

<img width="1158" alt="Screen Shot 2020-04-16 at 10 48 12 AM" src="https://user-images.githubusercontent.com/35410637/79477600-fc88c100-7fcf-11ea-8005-5fdc0bb88ade.png">
