### PR TITLE
Update Locations summary counts view table

### DIFF
--- a/atd-vzd/views/view_location_injry_count_cost_summary-schema.sql
+++ b/atd-vzd/views/view_location_injry_count_cost_summary-schema.sql
@@ -27,10 +27,10 @@ CREATE VIEW public.view_location_injry_count_cost_summary AS
 
 SELECT
 	(atcloc.location_id)::character varying (32) AS location_id,
-	COALESCE(ccs.total_crashes, (0)::bigint) AS total_crashes,
+	COALESCE(ccs.total_crashes + blueform_ccs.total_crashes, (0)::bigint) AS total_crashes,
 	COALESCE(ccs.total_deaths, (0)::bigint) AS total_deaths,
 	COALESCE(ccs.total_serious_injuries, (0)::bigint) AS total_serious_injuries,
-	COALESCE(ccs.est_comp_cost, (0)::numeric) AS est_comp_cost
+	COALESCE(ccs.est_comp_cost + blueform_ccs.est_comp_cost, (0)::numeric) AS est_comp_cost
 FROM (atd_txdot_locations atcloc
 	LEFT JOIN (
 		SELECT
@@ -39,12 +39,27 @@ FROM (atd_txdot_locations atcloc
 			sum(atc.death_cnt) AS total_deaths,
 			sum(atc.sus_serious_injry_cnt) AS total_serious_injuries,
 			sum(atc.est_comp_cost) AS est_comp_cost
-		FROM atd_txdot_crashes AS atc
+		FROM 
+			atd_txdot_crashes AS atc
 	WHERE ((1 = 1)
+		AND atc.crash_date > now() - '5 years'::interval
 		AND(atc.location_id IS NOT NULL)
 		AND((atc.location_id)::text <> 'None'::text))
-GROUP BY
-	atc.location_id) ccs ON (((ccs.location_id)::text = (atcloc.location_id)::text)));
+	GROUP BY
+		atc.location_id) ccs ON (((ccs.location_id)::text = (atcloc.location_id)::text)))
+	LEFT JOIN(
+		SELECT
+			aab.location_id,
+			sum(aab.est_comp_cost) AS est_comp_cost,
+			count(1) AS total_crashes
+		FROM
+			atd_apd_blueform AS aab
+		WHERE ((1 = 1)
+			AND aab.date > now() - '5 years'::interval
+			AND(aab.location_id IS NOT NULL)
+			AND((aab.location_id)::text <> 'None'::text))
+		GROUP BY
+			aab.location_id) blueform_ccs ON (blueform_ccs.location_id = atcloc.location_id)
 
 
 ALTER TABLE public.view_location_injry_count_cost_summary OWNER TO atd_vz_data;

--- a/atd-vze/src/views/Locations/Locations.js
+++ b/atd-vze/src/views/Locations/Locations.js
@@ -54,7 +54,7 @@ let queryConf = {
       searchable: false,
       sortable: true,
       label_search: null,
-      label_table: "Comp. Cost (CR3s)",
+      label_table: "Total Est Comp. Cost", // Both CR3 + Blueform
       default: 0,
       type: "Currency",
     },


### PR DESCRIPTION
Closes https://github.com/cityofaustin/atd-data-tech/issues/2140

Updates the SQL View Table that powers the GridTable component on the `/locations` page.

We now use CR3 + Blueform crash data to sum the total crash and total comprehensive cost. And we limit those calculations for the past 5 years of data.

![Screen Shot 2020-04-16 at 6 26 04 PM](https://user-images.githubusercontent.com/5697474/79516389-dc2d2680-8010-11ea-8243-ef4dc9692dd4.png)

Notice that the values highlighted in the red rectangle should match the values highlighted below for any Crash Details page (when you apply the same 5 year time range):

![Screen Shot 2020-04-16 at 6 26 16 PM](https://user-images.githubusercontent.com/5697474/79516419-fa932200-8010-11ea-9d5c-4ea23eb50823.png)

![Screen Shot 2020-04-16 at 6 30 02 PM](https://user-images.githubusercontent.com/5697474/79516454-0da5f200-8011-11ea-9114-1ab88c6d3658.png)

**TODO: Apply the view table update to `atd-vzd/views/view_location_injry_count_cost_summary-schema.sql` on the production DB on deployment.**
