### PR TITLE
Hide "Reports" from non-admins in nav & routing

### DIFF
--- a/atd-vze/package.json
+++ b/atd-vze/package.json
@@ -1,6 +1,6 @@
 {
   "name": "atd-vz-data",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "homepage": "./",
   "description": "ATD Vision Zero Editor",
   "author": "ATD Data & Technology Services",

--- a/atd-vze/src/_nav.js
+++ b/atd-vze/src/_nav.js
@@ -33,18 +33,6 @@ export const navigation = roles => {
       {
         divider: true,
       },
-      {
-        name: 'Reports',
-        url: '#',
-        icon: 'icon-chart',
-        children: [
-          {
-            name: "Inconsistent KSI Counts",
-            url: "/reports/inconsistent_ksi_counts",
-            icon: "icon-graph",
-          },
-        ],
-      },
     ],
   };
 
@@ -55,10 +43,22 @@ export const navigation = roles => {
       url: "/users",
       icon: "icon-people",
     },
+    {
+      name: "Reports",
+      url: "#",
+      icon: "icon-chart",
+      children: [
+        {
+          name: "Inconsistent KSI Counts",
+          url: "/reports/inconsistent_ksi_counts",
+          icon: "icon-graph",
+        },
+      ],
+    },
   ];
 
   if (isAdmin(roles) || isItSupervisor(roles)) {
-    adminNavItems.forEach(item => nav.items.splice(1, 0, item));
+    adminNavItems.forEach(item => nav.items.splice(-1, 0, item));
   }
 
   return nav;

--- a/atd-vze/src/routes.js
+++ b/atd-vze/src/routes.js
@@ -41,7 +41,9 @@ const Typography = React.lazy(() => import("./views/Theme/Typography"));
 const Widgets = React.lazy(() => import("./views/Widgets/Widgets"));
 const Dev = React.lazy(() => import("./views/Dev/Dev"));
 const Crashes = React.lazy(() => import("./views/Crashes/Crashes"));
-const ReportsInconsistentKSI = React.lazy(() => import("./views/Reports/ReportsInconsistentKSI"));
+const ReportsInconsistentKSI = React.lazy(() =>
+  import("./views/Reports/ReportsInconsistentKSI")
+);
 const Crash = React.lazy(() => import("./views/Crashes/Crash"));
 const Profile = React.lazy(() => import("./views/Profile/Profile"));
 const Locations = React.lazy(() => import("./views/Locations/Locations"));
@@ -150,7 +152,7 @@ const routes = roles => [
     name: "Crash Details",
     component: Crash,
   },
-  {
+  (isAdmin(roles) || isItSupervisor(roles)) && {
     path: "/reports/inconsistent_ksi_counts",
     exact: true,
     name: "Crashes with Inconsistent KSI Counts",


### PR DESCRIPTION
Also update v.1.6.0 in footer

## Admin
<img width="1552" alt="Screen Shot 2020-04-21 at 4 51 25 PM" src="https://user-images.githubusercontent.com/5697474/79917600-65b56d80-83f0-11ea-8e12-998133bae29b.png">


## Editor (can't see)
<img width="1552" alt="Screen Shot 2020-04-21 at 4 51 03 PM" src="https://user-images.githubusercontent.com/5697474/79917605-68b05e00-83f0-11ea-91ba-36ed45b6d4ab.png">
