### PR TITLE
2097 update by mode component

### DIFF
--- a/atd-vzv/src/views/summary/CrashesByMode.js
+++ b/atd-vzv/src/views/summary/CrashesByMode.js
@@ -218,7 +218,7 @@ const CrashesByMode = () => {
         <Col>
           {chartLegend}
           {
-            <div>
+            <Container>
               <Bar
                 ref={(ref) => (chartRef.current = ref)}
                 data={data}
@@ -252,11 +252,9 @@ const CrashesByMode = () => {
                               <h6 className="text-center pt-2">{"\u00A0"}</h6>
                             </div>
                             {chart.data.datasets.map((dataset, i) => {
-                              const legendColor = legendColors[i];
-
                               const updateLegendColors = () => {
                                 const legendColorsClone = [...legendColors];
-                                legendColor !== "dimgray"
+                                legendColors[i] !== "dimgray"
                                   ? legendColorsClone.splice(i, 1, "dimgray")
                                   : legendColorsClone.splice(
                                       i,
@@ -267,10 +265,7 @@ const CrashesByMode = () => {
                               };
 
                               const customLegendClickHandler = () => {
-                                const legendItems = [
-                                  ...chart.legend.legendItems,
-                                ];
-                                const legendItem = legendItems[i];
+                                const legendItem = chart.legend.legendItems[i];
                                 const index = legendItem.datasetIndex;
                                 const ci = chartRef.current.chartInstance.chart;
                                 const meta = ci.getDatasetMeta(index);
@@ -281,11 +276,9 @@ const CrashesByMode = () => {
                                     ? !ci.data.datasets[index].hidden
                                     : null;
 
-                                // We hid a dataset ... rerender the chart
-                                ci.update();
-
-                                // Update legend colors to show data has been hidden
-                                updateLegendColors();
+                                // We hid a dataset ... rerender the chart,
+                                // then update the legend colors
+                                updateLegendColors(ci.update());
                               };
 
                               return (
@@ -296,14 +289,16 @@ const CrashesByMode = () => {
                                   onClick={customLegendClickHandler}
                                 >
                                   <hr className="my-0"></hr>
-                                  <h6 className="text-center my-0 pt-1 pb-1">
+                                  <h6 className="text-center my-0 py-1">
                                     <FontAwesomeIcon
                                       aria-hidden="true"
                                       className="block-icon"
                                       icon={dataset.icon}
-                                      color={legendColor}
+                                      color={legendColors[i]}
                                     />
-                                    <span className="sr-only">{dataset.label}</span>
+                                    <span className="sr-only">
+                                      {dataset.label}
+                                    </span>
                                     <p className="mode-label-text">
                                       {" "}
                                       {dataset.label}
@@ -315,7 +310,8 @@ const CrashesByMode = () => {
                           </StyledDiv>
                         </Col>
                         {chart.data.labels.map((year, yearIterator) => {
-                          let paddingRight = yearIterator === 4 ? null : "pr-1";
+                          let paddingRight =
+                            yearIterator === 4 ? "null" : "pr-1";
                           return (
                             <Col
                               key={yearIterator}
@@ -354,7 +350,7 @@ const CrashesByMode = () => {
                   },
                 }}
               />
-            </div>
+            </Container>
           }
         </Col>
       </Row>

--- a/atd-vzv/src/views/summary/CrashesByMode.js
+++ b/atd-vzv/src/views/summary/CrashesByMode.js
@@ -303,7 +303,7 @@ const CrashesByMode = () => {
                                       icon={dataset.icon}
                                       color={legendColor}
                                     />
-                                    <span class="sr-only">{dataset.label}</span>
+                                    <span className="sr-only">{dataset.label}</span>
                                     <p className="mode-label-text">
                                       {" "}
                                       {dataset.label}

--- a/atd-vzv/src/views/summary/CrashesByMode.js
+++ b/atd-vzv/src/views/summary/CrashesByMode.js
@@ -184,7 +184,7 @@ const CrashesByMode = () => {
       </Row>
       <Row>
         <Col>
-          <hr />
+          <hr className="mb-2" />
         </Col>
       </Row>
       <Row className="mt-1">
@@ -219,10 +219,10 @@ const CrashesByMode = () => {
                   legendCallback: function (chart) {
                     return (
                       <Row className="pb-2">
-                        <Col className="px-2">
+                        <Col className="pr-1">
                           <StyledDiv>
                             <div>
-                              <h6 className="text-center my-1 pt-2">
+                              <h6 className="text-center pt-2">
                                 {"\u00A0"}
                               </h6>
                             </div>
@@ -244,7 +244,7 @@ const CrashesByMode = () => {
                                     );
                                 setLegendColors(legendColorsClone);
                               };
-  
+
                               const customLegendClickHandler = () => {
                                 const legendItems = [
                                   ...chart.legend.legendItems,
@@ -253,16 +253,16 @@ const CrashesByMode = () => {
                                 const index = legendItem.datasetIndex;
                                 const ci = chartRef.current.chartInstance.chart;
                                 const meta = ci.getDatasetMeta(index);
-  
+
                                 // See controller.isDatasetVisible comment
                                 meta.hidden =
                                   meta.hidden === null
                                     ? !ci.data.datasets[index].hidden
                                     : null;
-  
+
                                 // We hid a dataset ... rerender the chart
                                 ci.update();
-  
+
                                 // Update legend colors to show data has been hidden
                                 updateLegendColors();
                               };
@@ -277,7 +277,7 @@ const CrashesByMode = () => {
                                   onClick={customLegendClickHandler}
                                 >
                                   <hr className="my-0"></hr>
-                                  <h6 className="text-center mx-2 my-0 pt-1 pb-1">
+                                  <h6 className="text-center mx-1 my-0 pt-1 pb-1">
                                     {mode.label}
                                   </h6>
                                 </div>
@@ -286,8 +286,10 @@ const CrashesByMode = () => {
                           </StyledDiv>
                         </Col>
                         {chart.data.labels.map((year, yearIterator) => {
+                          let paddingRight =
+                          yearIterator === 4 ? null : "pr-1";                          
                           return (
-                            <Col className="px-2" key={yearIterator}>
+                            <Col key={yearIterator} className={`pl-0 ${paddingRight}`}>
                               <StyledDiv>
                                 <div className="year-total-div">
                                   <div>

--- a/atd-vzv/src/views/summary/CrashesByMode.js
+++ b/atd-vzv/src/views/summary/CrashesByMode.js
@@ -6,6 +6,14 @@ import styled from "styled-components";
 
 import CrashTypeSelector from "../nav/CrashTypeSelector";
 import { colors } from "../../constants/colors";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import {
+  faWalking,
+  faBiking,
+  faCar,
+  faMotorcycle,
+  faEllipsisH,
+} from "@fortawesome/free-solid-svg-icons";
 import {
   dataEndDate,
   yearsArray,
@@ -14,44 +22,6 @@ import {
 import { crashEndpointUrl } from "./queries/socrataQueries";
 
 const CrashesByMode = () => {
-  const modes = [
-    {
-      label: "Motorist",
-      fields: {
-        fatal: `motor_vehicle_death_count`,
-        injury: `motor_vehicle_serious_injury_count`,
-      },
-    },
-    {
-      label: "Pedestrian",
-      fields: {
-        fatal: `pedestrian_death_count`,
-        injury: `pedestrian_serious_injury_count`,
-      },
-    },
-    {
-      label: "Motorcyclist",
-      fields: {
-        fatal: `motorcycle_death_count`,
-        injury: `motorcycle_serious_injury_count`,
-      },
-    },
-    {
-      label: "Bicyclist",
-      fields: {
-        fatal: `bicycle_death_count`,
-        injury: `bicycle_serious_injury_count`,
-      },
-    },
-    {
-      label: "Other",
-      fields: {
-        fatal: `other_death_count`,
-        injury: `other_serious_injury_count`,
-      },
-    },
-  ];
-
   const chartColors = [
     colors.viridis1Of6Highest,
     colors.viridis2Of6,
@@ -66,6 +36,49 @@ const CrashesByMode = () => {
   const [legendColors, setLegendColors] = useState([...chartColors]);
 
   const chartRef = useRef();
+
+  const modes = [
+    {
+      label: "Motorist",
+      icon: faCar,
+      fields: {
+        fatal: `motor_vehicle_death_count`,
+        injury: `motor_vehicle_serious_injury_count`,
+      },
+    },
+    {
+      label: "Pedestrian",
+      icon: faWalking,
+      fields: {
+        fatal: `pedestrian_death_count`,
+        injury: `pedestrian_serious_injury_count`,
+      },
+    },
+    {
+      label: "Motorcyclist",
+      icon: faMotorcycle,
+      fields: {
+        fatal: `motorcycle_death_count`,
+        injury: `motorcycle_serious_injury_count`,
+      },
+    },
+    {
+      label: "Bicyclist",
+      icon: faBiking,
+      fields: {
+        fatal: `bicycle_death_count`,
+        injury: `bicycle_serious_injury_count`,
+      },
+    },
+    {
+      label: "Other",
+      icon: faEllipsisH,
+      fields: {
+        fatal: `other_death_count`,
+        injury: `other_serious_injury_count`,
+      },
+    },
+  ];
 
   // Fetch data and set in state by years in yearsArray
   useEffect(() => {
@@ -143,6 +156,7 @@ const CrashesByMode = () => {
     const modeData = modes.map((mode) => ({
       borderWidth: 2,
       label: mode.label,
+      icon: mode.icon,
       data: getModeData(mode.fields),
     }));
     // Determine order of modes in each year stack and color appropriately
@@ -167,6 +181,19 @@ const CrashesByMode = () => {
       cursor: pointer;
       color: ${colors.buttonBackground};
       background: dimgray 0% 0% no-repeat padding-box;
+      border-radius: 4px;
+      border-style: none;
+    }
+
+    .mode-label-text {
+      display: none;
+      @media (min-width: 576px) {
+        display: inline;
+      }
+    }
+
+    .sr-only {
+      display: hidden;
     }
   `;
 
@@ -219,24 +246,18 @@ const CrashesByMode = () => {
                   legendCallback: function (chart) {
                     return (
                       <Row className="pb-2">
-                        <Col className="pr-1">
+                        <Col className="pr-1 col-sm-4">
                           <StyledDiv>
                             <div>
-                              <h6 className="text-center pt-2">
-                                {"\u00A0"}
-                              </h6>
+                              <h6 className="text-center pt-2">{"\u00A0"}</h6>
                             </div>
-                            {modes.map((mode, i) => {
+                            {chart.data.datasets.map((dataset, i) => {
                               const legendColor = legendColors[i];
 
                               const updateLegendColors = () => {
                                 const legendColorsClone = [...legendColors];
-                                legendColor !== colors.buttonBackground
-                                  ? legendColorsClone.splice(
-                                      i,
-                                      1,
-                                      colors.buttonBackground
-                                    )
+                                legendColor !== "dimgray"
+                                  ? legendColorsClone.splice(i, 1, "dimgray")
                                   : legendColorsClone.splice(
                                       i,
                                       1,
@@ -271,14 +292,22 @@ const CrashesByMode = () => {
                                 <div
                                   key={i}
                                   className="mode-label-div"
-                                  style={{
-                                    borderRight: `8px solid ${legendColor}`,
-                                  }}
+                                  title={dataset.label}
                                   onClick={customLegendClickHandler}
                                 >
                                   <hr className="my-0"></hr>
-                                  <h6 className="text-center mx-1 my-0 pt-1 pb-1">
-                                    {mode.label}
+                                  <h6 className="text-center my-0 pt-1 pb-1">
+                                    <FontAwesomeIcon
+                                      aria-hidden="true"
+                                      className="block-icon"
+                                      icon={dataset.icon}
+                                      color={legendColor}
+                                    />
+                                    <span class="sr-only">{dataset.label}</span>
+                                    <p className="mode-label-text">
+                                      {" "}
+                                      {dataset.label}
+                                    </p>
                                   </h6>
                                 </div>
                               );
@@ -286,10 +315,12 @@ const CrashesByMode = () => {
                           </StyledDiv>
                         </Col>
                         {chart.data.labels.map((year, yearIterator) => {
-                          let paddingRight =
-                          yearIterator === 4 ? null : "pr-1";                          
+                          let paddingRight = yearIterator === 4 ? null : "pr-1";
                           return (
-                            <Col key={yearIterator} className={`pl-0 ${paddingRight}`}>
+                            <Col
+                              key={yearIterator}
+                              className={`pl-0 ${paddingRight}`}
+                            >
                               <StyledDiv>
                                 <div className="year-total-div">
                                   <div>

--- a/atd-vzv/src/views/summary/CrashesByMonth.js
+++ b/atd-vzv/src/views/summary/CrashesByMonth.js
@@ -194,7 +194,7 @@ const CrashesByMonth = () => {
           {chartLegend}
           {
             // Wrapping the chart in a div prevents it from getting caught in a rerendering loop
-            <div>
+            <Container>
               <Line
                 ref={(ref) => (chartRef.current = ref)}
                 data={data}
@@ -202,7 +202,7 @@ const CrashesByMonth = () => {
                 width={null}
                 options={{
                   responsive: true,
-                  aspectRatio: 1,
+                  aspectRatio: .8,
                   maintainAspectRatio: false,
                   tooltips: {
                     mode: "x",
@@ -305,7 +305,7 @@ const CrashesByMonth = () => {
                   },
                 }}
               />
-            </div>
+            </Container>
           }
         </Col>
       </Row>

--- a/atd-vzv/src/views/summary/CrashesByMonth.js
+++ b/atd-vzv/src/views/summary/CrashesByMonth.js
@@ -15,7 +15,6 @@ import {
 import { colors } from "../../constants/colors";
 
 const CrashesByMonth = () => {
-  const chartRef = useRef();
 
   // Set years order ascending
   const chartYearsArray = yearsArray().sort((a, b) => b - a);
@@ -32,6 +31,8 @@ const CrashesByMonth = () => {
   const [crashType, setCrashType] = useState([]);
   const [chartLegend, setChartLegend] = useState(null);
   const [legendColors, setLegendColors] = useState([...chartColors].reverse());
+
+  const chartRef = useRef();
 
   useEffect(() => {
     const calculateYearMonthlyTotals = (data) => {
@@ -281,7 +282,6 @@ const CrashesByMonth = () => {
                                     onClick={customLegendClickHandler}
                                   >
                                     <hr
-                                      id={`bar-${year}`}
                                       className="my-1"
                                       style={{
                                         border: `4px solid ${legendColor}`,

--- a/atd-vzv/src/views/summary/CrashesByMonth.js
+++ b/atd-vzv/src/views/summary/CrashesByMonth.js
@@ -202,7 +202,7 @@ const CrashesByMonth = () => {
                 width={null}
                 options={{
                   responsive: true,
-                  aspectRatio: .8,
+                  aspectRatio: 1,
                   maintainAspectRatio: false,
                   tooltips: {
                     mode: "x",


### PR DESCRIPTION
Fixes https://github.com/cityofaustin/atd-data-tech/issues/2097

- Adds custom legend that displays mode data for all years in grid format
- Adds clickable mode labels using colored symbols for user to turn on or off modes in chart display
- Adds mobile responsiveness: Displays words and symbols for labels on larger screens and symbols only on smaller screens
- Adds tooltips and screen reader text describing symbols for accessibility
- Adds new "Other" FontAwesome symbol: faEllipsisH

I showed this to @JaceDeloney and he thinks it's ready for primetime. I asked if he thinks the ellipsis symbol is sufficient to represent "Other" on small screens and he thinks so. I'm open to discussing reverting back to the word "Other" but hoping we can consider this new symbol.

![desktopgif](https://user-images.githubusercontent.com/35410637/80543174-fd2c3a80-8973-11ea-9f95-29c5bf14e157.gif)
![mobilegif](https://user-images.githubusercontent.com/35410637/80543186-03bab200-8974-11ea-8604-f6dee86a5318.gif)

