### PR TITLE
VZV | Summary | "By Month" visualization doesn't plot if month total is 0

### DIFF
--- a/atd-vzv/src/views/map/CrashPointCard.js
+++ b/atd-vzv/src/views/map/CrashPointCard.js
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { PureComponent } from "react";
-import { Card, CardBody, CardText, Table } from "reactstrap";
+import { Card, Table } from "reactstrap";
 import moment from "moment";
 
 export default class CrashPointCard extends PureComponent {

--- a/atd-vzv/src/views/summary/CrashesByMonth.js
+++ b/atd-vzv/src/views/summary/CrashesByMonth.js
@@ -35,7 +35,7 @@ const CrashesByMonth = () => {
 
   useEffect(() => {
     const calculateYearMonthlyTotals = (data) => {
-      // Data query is ordered by crash_date ASC so truncate dataset by month of latest record
+      // Determine if the data is a complete year or not and which records to process
       const isCurrentYear =
         data.length > 0 &&
         data[0].crash_date.includes(dataEndDate.format("YYYY"));
@@ -47,6 +47,7 @@ const CrashesByMonth = () => {
         monthTotalArray.push(0);
       }
 
+      // Calculate totals for each month in data
       const monthTotals = data.reduce((acc, record) => {
         const recordMonth = moment(record.crash_date).format("MM");
         const monthIndex = parseInt(recordMonth) - 1;
@@ -63,12 +64,19 @@ const CrashesByMonth = () => {
               acc[monthIndex] +=
                 parseInt(record.death_cnt) +
                 parseInt(record.sus_serious_injry_cnt);
-              // debugger;
               break;
           }
         }
         return acc;
       }, monthTotalArray);
+
+      // Accumulate the monthly totals over the year of data
+      const accumulatedTotals = monthTotals.reduce((acc, month, i) => {
+        acc.push((month += acc[i - 1] || 0));
+        return acc;
+      }, []);
+
+      return accumulatedTotals;
     };
 
     // Wait for crashType to be passed up from setCrashType component

--- a/atd-vzv/src/views/summary/CrashesByMonth.js
+++ b/atd-vzv/src/views/summary/CrashesByMonth.js
@@ -42,53 +42,33 @@ const CrashesByMonth = () => {
 
       const monthLimit = isCurrentYear ? dataEndDate.format("MM") : "12";
 
-      // TODO: Refactor without monthIntegerArray
-      const monthIntegerArray = [
-        "01",
-        "02",
-        "03",
-        "04",
-        "05",
-        "06",
-        "07",
-        "08",
-        "09",
-        "10",
-        "11",
-        "12",
-      ];
+      let monthTotalArray = [];
+      for (let i = 1; i <= parseInt(monthLimit); i++) {
+        monthTotalArray.push(0);
+      }
 
-      const truncatedMonthIntegerArray = monthIntegerArray.slice(
-        0,
-        monthIntegerArray.indexOf(monthLimit) + 1
-      );
-      let cumulativeMonthTotal = 0;
-      const monthTotalArray = truncatedMonthIntegerArray.map((month) => {
-        let monthTotal = 0;
-        data.forEach((record) => {
-          // If the crash date is in the current month, compile data
-          if (moment(record.crash_date).format("MM") === month) {
-            // Compile data based on the selected crash type
-            switch (crashType.name) {
-              case "fatalities":
-                monthTotal += parseInt(record.death_cnt);
-                break;
-              case "seriousInjuries":
-                monthTotal += parseInt(record.sus_serious_injry_cnt);
-                break;
-              default:
-                monthTotal +=
-                  parseInt(record.death_cnt) +
-                  parseInt(record.sus_serious_injry_cnt);
-                break;
-            }
+      const monthTotals = data.reduce((acc, record) => {
+        const recordMonth = moment(record.crash_date).format("MM");
+        const monthIndex = parseInt(recordMonth) - 1;
+
+        if (monthIndex < monthTotalArray.length) {
+          switch (crashType.name) {
+            case "fatalities":
+              acc[monthIndex] += parseInt(record.death_cnt);
+              break;
+            case "seriousInjuries":
+              acc[monthIndex] += parseInt(record.sus_serious_injry_cnt);
+              break;
+            default:
+              acc[monthIndex] +=
+                parseInt(record.death_cnt) +
+                parseInt(record.sus_serious_injry_cnt);
+              // debugger;
+              break;
           }
-        });
-        cumulativeMonthTotal += monthTotal;
-        return cumulativeMonthTotal;
-      });
-
-      return monthTotalArray;
+        }
+        return acc;
+      }, monthTotalArray);
     };
 
     // Wait for crashType to be passed up from setCrashType component

--- a/atd-vzv/src/views/summary/CrashesByMonth.js
+++ b/atd-vzv/src/views/summary/CrashesByMonth.js
@@ -36,11 +36,13 @@ const CrashesByMonth = () => {
   useEffect(() => {
     const calculateYearMonthlyTotals = (data) => {
       // Data query is ordered by crash_date ASC so truncate dataset by month of latest record
-      const monthLimit =
-        data.length > 0
-          ? moment(data[data.length - 1].crash_date).format("MM")
-          : "12";
+      const isCurrentYear =
+        data.length > 0 &&
+        data[0].crash_date.includes(dataEndDate.format("YYYY"));
 
+      const monthLimit = isCurrentYear ? dataEndDate.format("MM") : "12";
+
+      // TODO: Refactor without monthIntegerArray
       const monthIntegerArray = [
         "01",
         "02",


### PR DESCRIPTION
Closes https://github.com/cityofaustin/atd-data-tech/issues/2249

This PR fixes a bug where the VZV By Month chart presented its time range of data based on the latest record pulled from Socrata. This caused a scenario where a month's total is not represented until the number of records with serious injuries, fatalities, or both pulled for a month surpasses 0. The code was updated to start each month's total at zero and then increment up. I also refactored the existing code to use `reduce` and avoid nested iteration.

#### Before
<img width="703" alt="Screen Shot 2020-04-30 at 1 54 35 PM" src="https://user-images.githubusercontent.com/37249039/80748226-34bcf300-8aea-11ea-9ace-c93b32e9ea7e.png">

#### After
<img width="703" alt="Screen Shot 2020-04-30 at 1 54 23 PM" src="https://user-images.githubusercontent.com/37249039/80748238-3981a700-8aea-11ea-80a6-7119e47c0527.png">
