### PR TITLE
adjust sizing so by month and by mode charts equal height

### DIFF
--- a/atd-vzv/src/views/summary/CrashesByMode.js
+++ b/atd-vzv/src/views/summary/CrashesByMode.js
@@ -226,7 +226,7 @@ const CrashesByMode = () => {
                 width={null}
                 options={{
                   responsive: true,
-                  aspectRatio: 1,
+                  aspectRatio: 1.8,
                   maintainAspectRatio: false,
                   scales: {
                     xAxes: [

--- a/atd-vzv/src/views/summary/CrashesByMonth.js
+++ b/atd-vzv/src/views/summary/CrashesByMonth.js
@@ -192,7 +192,7 @@ const CrashesByMonth = () => {
                 width={null}
                 options={{
                   responsive: true,
-                  aspectRatio: 1,
+                  aspectRatio: 1.16,
                   maintainAspectRatio: false,
                   tooltips: {
                     mode: "x",


### PR DESCRIPTION
Fixes https://github.com/cityofaustin/atd-data-tech/issues/2549

Adjusts heights of By Mode and By Month components so they are both the same.

<img width="1280" alt="Screen Shot 2020-05-05 at 3 28 03 PM" src="https://user-images.githubusercontent.com/35410637/81112915-032a9a00-8ee5-11ea-9616-1c2944d9ca18.png">
