### PR TITLE
VZV | Map | Make default date range for map YTD

### DIFF
--- a/atd-vzv/src/constants/time.js
+++ b/atd-vzv/src/constants/time.js
@@ -1,8 +1,10 @@
 import moment from "moment";
 
+// Set the sliding window of data that feeds VZV
 // Number of past years data to fetch
-// 4 full years of data, plus data up to the last complete month of the current year
 export const ROLLING_YEARS_OF_DATA = 4;
+// Number of months window slides in the past (to display most accurate data)
+export const MONTHS_AGO = 2;
 
 // Create array of ints of last n years
 export const yearsArray = () => {
@@ -16,12 +18,14 @@ export const yearsArray = () => {
 
 // First date of records that should be referenced in VZV (start of first year in rolling window)
 export const dataStartDate = moment()
-  .subtract(1, "month")
+  .subtract(MONTHS_AGO, "month")
   .subtract(ROLLING_YEARS_OF_DATA, "year")
   .startOf("year");
 
-// Last date of records that should be referenced in VZV (the last day of the month that is two months ago)
-export const dataEndDate = moment().subtract(2, "month").endOf("month");
+// Last date of records that should be referenced in VZV (the last day of the month that is MONTHS_AGO months ago)
+export const dataEndDate = moment()
+  .subtract(MONTHS_AGO, "month")
+  .endOf("month");
 
 // Summary time data
 export const summaryCurrentYearStartDate = dataEndDate
@@ -44,6 +48,9 @@ export const currentYearString = summaryCurrentYearStartDate.slice(0, 4);
 export const prevYearString = summaryLastYearStartDate.slice(0, 4);
 
 // Map time data
-export const mapStartDate = moment().subtract(1, "month").startOf("year");
+// To decrease initial load time and focus map data to recent crashes, limit to current year of sliding window
+export const mapStartDate = moment()
+  .subtract(MONTHS_AGO, "month")
+  .startOf("year");
 
 export const mapEndDate = dataEndDate.clone();

--- a/atd-vzv/src/constants/time.js
+++ b/atd-vzv/src/constants/time.js
@@ -42,3 +42,8 @@ export const summaryLastYearEndDate = dataEndDate
 
 export const currentYearString = summaryCurrentYearStartDate.slice(0, 4);
 export const prevYearString = summaryLastYearStartDate.slice(0, 4);
+
+// Map time data
+export const mapStartDate = moment().subtract(1, "month").startOf("year");
+
+export const mapEndDate = dataEndDate.clone();

--- a/atd-vzv/src/utils/store.js
+++ b/atd-vzv/src/utils/store.js
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { dataStartDate, dataEndDate } from "../constants/time";
+import { mapStartDate, mapEndDate } from "../constants/time";
 
 export const StoreContext = React.createContext(null);
 
@@ -11,8 +11,8 @@ export default ({ children }) => {
     injury: true,
   });
   const [mapDateRange, setMapDateRange] = useState({
-    start: dataStartDate,
-    end: dataEndDate,
+    start: mapStartDate,
+    end: mapEndDate,
   });
   const [mapTimeWindow, setMapTimeWindow] = useState("");
   const [mapOverlay, setMapOverlay] = useState({

--- a/atd-vzv/src/views/nav/SideMapControlDateRange.js
+++ b/atd-vzv/src/views/nav/SideMapControlDateRange.js
@@ -6,7 +6,12 @@ import DefaultTheme from "react-dates/lib/theme/DefaultTheme";
 import styled from "styled-components";
 import { DateRangePicker } from "react-dates";
 import { Input, FormGroup, Form, Col } from "reactstrap";
-import { dataStartDate, dataEndDate } from "../../constants/time";
+import {
+  dataStartDate,
+  dataEndDate,
+  mapStartDate,
+  mapEndDate,
+} from "../../constants/time";
 import { colors } from "../../constants/colors";
 import { responsive } from "../../constants/responsive";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -14,8 +19,8 @@ import { faTimesCircle } from "@fortawesome/free-solid-svg-icons";
 
 const SideMapControlDateRange = () => {
   const [focused, setFocused] = useState(null);
-  const [start, setStart] = useState(dataStartDate);
-  const [end, setEnd] = useState(dataEndDate);
+  const [start, setStart] = useState(mapStartDate);
+  const [end, setEnd] = useState(mapEndDate);
 
   // Override defaultTheme https://github.com/airbnb/react-dates/blob/master/src/theme/DefaultTheme.js
   const vzTheme = {


### PR DESCRIPTION
Closes https://github.com/cityofaustin/atd-data-tech/issues/2546

This PR updates the default date range for the Map date range picker to the full year preceding the end date of global VZV data date range.

#### Updated map date range
<img width="1155" alt="Screen Shot 2020-05-06 at 6 00 33 PM" src="https://user-images.githubusercontent.com/37249039/81236749-83273180-8fc3-11ea-859b-5c343c027286.png">

