### PR TITLE
VZV | Change VZV data refresh timing

### DIFF
--- a/atd-vzv/src/constants/time.js
+++ b/atd-vzv/src/constants/time.js
@@ -20,8 +20,8 @@ export const dataStartDate = moment()
   .subtract(ROLLING_YEARS_OF_DATA, "year")
   .startOf("year");
 
-// Last date of records that should be referenced in VZV (through last complete month of data)
-export const dataEndDate = moment().subtract(1, "month").endOf("month");
+// Last date of records that should be referenced in VZV (the last day of the month that is two months ago)
+export const dataEndDate = moment().subtract(2, "month").endOf("month");
 
 // Summary time data
 export const summaryCurrentYearStartDate = dataEndDate


### PR DESCRIPTION
Closes https://github.com/cityofaustin/atd-data-tech/issues/2568

This PR updates the end date of the global VZV date range to the last day of the month that is two months ago. Open to rephrasing that in the comment in the PR since it is hard to describe!

### Date range in app on 5/7/2020
<img width="1155" alt="Screen Shot 2020-05-07 at 5 13 12 PM" src="https://user-images.githubusercontent.com/37249039/81349713-2c366080-9086-11ea-9709-dd19cb5ad1cf.png">
