### PR TITLE
Fixes Crash Upserts

### DIFF
--- a/atd-etl/app/process/config.py
+++ b/atd-etl/app/process/config.py
@@ -23,6 +23,7 @@ ATD_ETL_CONFIG = {
     "MAX_THREADS": int(os.getenv("MAX_THREADS", "20")),
     "MAX_ATTEMPTS": int(os.getenv("MAX_ATTEMPTS", "5")),
     "RETRY_WAIT_TIME": int(os.getenv("RETRY_WAIT_TIME", "5")),
+    "HASURA_FORCE_UPSERT": os.getenv("HASURA_FORCE_UPSERT", "DISABLED") == "ENABLED",
 
     # CRIS
     "ATD_CRIS_WEBSITE": "https://cris.dot.state.tx.us/",

--- a/atd-etl/app/process/helpers_import_fields.py
+++ b/atd-etl/app/process/helpers_import_fields.py
@@ -7,6 +7,10 @@ CRIS_TXDOT_FIELDS = {
         "function_name": "insert_atd_txdot_crashes",
         "filters": [
             [
+              filter_remove_field,
+              []
+            ],
+            [
                 filter_numeric_field,
                 [
                     "crash_id",

--- a/atd-etl/app/process_hasura_import.py
+++ b/atd-etl/app/process_hasura_import.py
@@ -141,7 +141,8 @@ def process_line(file_type, line, fieldnames, current_line, dryrun=False):
         # that this record needs to be updated (upsert).
         upsert_enabled = True
     else:
-        upsert_enabled = False
+        # To force upserts, set 'HASURA_FORCE_UPSERT' to 'ENABLED'
+        upsert_enabled = ATD_ETL_CONFIG["HASURA_FORCE_UPSERT"]
 
     #
     # Follow Normal Process


### PR DESCRIPTION
The upserts for crashes were not working 100%, some of the fields were being removed from upsertion in the on_conflict clause in the GraphQL query.
- [x] Fixes the upserts for crashes
- [x] Adds functionality to allow for manual upserts (forced upserts)

Closes https://github.com/cityofaustin/atd-data-tech/issues/2468