### PR TITLE
VZD: Adds indexing to crash_date

### DIFF
--- a/atd-vzd/migrations/migration_crashes_2020_05_21--0354.sql
+++ b/atd-vzd/migrations/migration_crashes_2020_05_21--0354.sql
@@ -1,5 +1,7 @@
 -- ADDS INDEXING TO crash_date
-
 create index atd_txdot_crashes_crash_date_index
 	on atd_txdot_crashes (crash_date);
 
+-- ADDS INDEXING TO AGENCY ID
+create index atd_txdot_crashes_investigat_agency_id_index
+	on atd_txdot_crashes (investigat_agency_id);

--- a/atd-vzd/migrations/migration_crashes_2020_05_21--0354.sql
+++ b/atd-vzd/migrations/migration_crashes_2020_05_21--0354.sql
@@ -1,0 +1,5 @@
+-- ADDS INDEXING TO crash_date
+
+create index atd_txdot_crashes_crash_date_index
+	on atd_txdot_crashes (crash_date);
+


### PR DESCRIPTION
I realized we don't have indexing for crash_date, which can degrade performance, especially on date searches in VZE and ETL.

This has been already applied to prod and staging. Ready to merge.

Closes https://github.com/cityofaustin/atd-data-tech/issues/2779