### PR TITLE
Update warning banner and version number

### DIFF
--- a/atd-vze/package.json
+++ b/atd-vze/package.json
@@ -1,6 +1,6 @@
 {
   "name": "atd-vz-data",
-  "version": "1.6.0",
+  "version": "1.8.1",
   "homepage": "./",
   "description": "ATD Vision Zero Editor",
   "author": "ATD Data & Technology Services",

--- a/atd-vzv/src/views/nav/SideDrawer.js
+++ b/atd-vzv/src/views/nav/SideDrawer.js
@@ -2,16 +2,19 @@ import React from "react";
 import { StoreContext } from "../../utils/store";
 import { usePath } from "hookrouter";
 
-import SideMapControl from "./SideMapControl";
 import { Container, Alert } from "reactstrap";
 import CssBaseline from "@material-ui/core/CssBaseline";
 import Drawer from "@material-ui/core/Drawer";
 import { makeStyles, useTheme } from "@material-ui/core/styles";
 import styled from "styled-components";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faExclamationTriangle } from "@fortawesome/free-solid-svg-icons";
+
+import SideMapControl from "./SideMapControl";
+import SideDrawerMobileNav from "./SideDrawerMobileNav";
 import { drawer } from "../../constants/drawer";
 import { colors } from "../../constants/colors";
 import { responsive } from "../../constants/responsive";
-import SideDrawerMobileNav from "./SideDrawerMobileNav";
 
 const drawerWidth = drawer.width;
 
@@ -110,11 +113,12 @@ const SideDrawer = () => {
         <SideDrawerMobileNav />
         {/* TODO: Remove disclaimer when going live */}
         <Alert color="danger" className="mt-2">
-          <strong>This site is a work in progress.</strong>
-          <br />
-          <span>
-            The information displayed may be outdated or incorrect. Check back
-            later for live Vision Zero data.
+          <FontAwesomeIcon icon={faExclamationTriangle} />
+          <span className="ml-2">
+            This is a beta version of the Vision Zero Viewer, published to
+            gather user feedback. Crash data displayed may be outdated or
+            inaccurate, and will be updated for the first public release
+            version.
           </span>
         </Alert>
         {currentPath === "/map" && <SideMapControl />}

--- a/atd-vzv/src/views/summary/Summary.js
+++ b/atd-vzv/src/views/summary/Summary.js
@@ -10,6 +10,8 @@ import { dataEndDate } from "../../constants/time";
 import InfoPopover from "../../Components/Popover/InfoPopover";
 import { popoverConfig } from "../../Components/Popover/popoverConfig";
 import DataModal from "./DataModal";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faExclamationTriangle } from "@fortawesome/free-solid-svg-icons";
 
 import { Container, Row, Col, Alert } from "reactstrap";
 
@@ -40,15 +42,14 @@ const Summary = () => {
       {/* Create whitespace on sides of view until mobile */}
       <Row className="px-xs-0 mx-xs-0 px-lg-3 mx-lg-4 mt-4 mb-0">
         <Col>
-          <Alert
-            style={{
-              backgroundColor: colors.customAlert,
-              color: colors.dark,
-              borderStyle: "none",
-            }}
-          >
-            This site is a work in progress. The information displayed may be
-            outdated or incorrect. Check back later for live Vision Zero data.
+          <Alert color="danger">
+            <FontAwesomeIcon icon={faExclamationTriangle} />
+            <span className="ml-2">
+              This is a beta version of the Vision Zero Viewer, published to
+              gather user feedback. Crash data displayed may be outdated or
+              inaccurate, and will be updated for the first public release
+              version.
+            </span>
           </Alert>
           <Alert
             style={{


### PR DESCRIPTION
Closes https://github.com/cityofaustin/atd-data-tech/issues/2777

I've used `git cherry-pick` to commit these changes directly to the production branch already per request from @JaceDeloney.

### Updates to banner on both Summary & Map pages. Change text and color. Add icon.

![Screen Shot 2020-05-26 at 10 25 15 AM](https://user-images.githubusercontent.com/5697474/82919267-6b482b00-9f3b-11ea-99de-4fe5d6121faa.png)

![Screen Shot 2020-05-26 at 10 25 41 AM](https://user-images.githubusercontent.com/5697474/82919254-65eae080-9f3b-11ea-8f00-f3ff93d45bea.png)

### Update version number (we forgot to update that since v1.6)

![Screen Shot 2020-05-26 at 10 29 08 AM](https://user-images.githubusercontent.com/5697474/82919537-cbd76800-9f3b-11ea-83b2-8eacbc3bae27.png)



