### PR TITLE
2577 time of day firefox styling

### DIFF
--- a/atd-vzv/src/views/summary/CrashesByTimeOfDay.js
+++ b/atd-vzv/src/views/summary/CrashesByTimeOfDay.js
@@ -139,36 +139,6 @@ const CrashesByTimeOfDay = () => {
       });
   }, [activeTab, crashType]);
 
-  // useLayoutEffect(() => {
-  //   !!heatmapData[0] &&
-  //     // !!document.querySelector(
-  //     //   "div.m-0.p-0.container > div.h-auto.row > div > div > svg > g > g:nth-child(1)"
-  //     // ) &&
-  //     navigator.userAgent.includes("Firefox") &&
-  //     fixFirefoxStyling();
-  // }, [heatmapData]);
-
-  // const fixFirefoxStyling = () => {
-  //   console.log(
-  //     document.querySelector(
-  //       "div.m-0.p-0.container > div.h-auto.row > div > div > svg > g > g:nth-child(1)"
-  //     )
-  //   );
-  //   console.log(chartRef.current);
-  //   try {
-  //     // debugger;
-  //     document
-  //       .querySelector(
-  //         "div.m-0.p-0.container > div.h-auto.row > div > div > svg > g > g:nth-child(1)"
-  //       )
-  //       .setAttribute("transform", "translate(0, 250)");
-  //     // debugger;
-  //     console.log("test");
-  //   } catch (err) {
-  //     console.log("Could not change attribute: ", err);
-  //   }
-  // };
-
   const formatValue = (d) => {
     const value = d.data.value ? d.data.value : 0;
     return value;
@@ -231,7 +201,6 @@ const CrashesByTimeOfDay = () => {
       <Row className="h-auto">
         <Col>
           <Heatmap
-            // ref={(ref) => (chartRef.current = ref)}
             height={267}
             data={heatmapData}
             series={

--- a/atd-vzv/src/views/summary/CrashesByTimeOfDay.js
+++ b/atd-vzv/src/views/summary/CrashesByTimeOfDay.js
@@ -12,6 +12,9 @@ import {
   HeatmapCell,
   ChartTooltip,
   SequentialLegend,
+  LinearXAxis,
+  LinearXAxisTickSeries,
+  LinearXAxisTickLabel
 } from "reaviz";
 import {
   summaryCurrentYearStartDate,
@@ -136,6 +139,36 @@ const CrashesByTimeOfDay = () => {
       });
   }, [activeTab, crashType]);
 
+  // useLayoutEffect(() => {
+  //   !!heatmapData[0] &&
+  //     // !!document.querySelector(
+  //     //   "div.m-0.p-0.container > div.h-auto.row > div > div > svg > g > g:nth-child(1)"
+  //     // ) &&
+  //     navigator.userAgent.includes("Firefox") &&
+  //     fixFirefoxStyling();
+  // }, [heatmapData]);
+
+  // const fixFirefoxStyling = () => {
+  //   console.log(
+  //     document.querySelector(
+  //       "div.m-0.p-0.container > div.h-auto.row > div > div > svg > g > g:nth-child(1)"
+  //     )
+  //   );
+  //   console.log(chartRef.current);
+  //   try {
+  //     // debugger;
+  //     document
+  //       .querySelector(
+  //         "div.m-0.p-0.container > div.h-auto.row > div > div > svg > g > g:nth-child(1)"
+  //       )
+  //       .setAttribute("transform", "translate(0, 250)");
+  //     // debugger;
+  //     console.log("test");
+  //   } catch (err) {
+  //     console.log("Could not change attribute: ", err);
+  //   }
+  // };
+
   const formatValue = (d) => {
     const value = d.data.value ? d.data.value : 0;
     return value;
@@ -198,6 +231,7 @@ const CrashesByTimeOfDay = () => {
       <Row className="h-auto">
         <Col>
           <Heatmap
+            // ref={(ref) => (chartRef.current = ref)}
             height={267}
             data={heatmapData}
             series={
@@ -219,6 +253,18 @@ const CrashesByTimeOfDay = () => {
                         }
                       />
                     }
+                  />
+                }
+              />
+            }
+            xAxis={
+              <LinearXAxis
+                type="category"
+                axisLine={null}
+                tickSeries={
+                  <LinearXAxisTickSeries
+                    line={null}
+                    label={<LinearXAxisTickLabel padding={navigator.userAgent.includes("Firefox") ? 15 : 5} />}
                   />
                 }
               />


### PR DESCRIPTION
Fixes https://github.com/cityofaustin/atd-data-tech/issues/2577

Thanks to @mddilley for delving deep into the Reaviz code and discovering this solution! Thanks to @sergiogcx for teaching me a thing or two about DOM manipulation!

Firefox:
<img width="573" alt="Screen Shot 2020-05-29 at 11 44 07 AM" src="https://user-images.githubusercontent.com/35410637/83284363-325dbf80-a1a2-11ea-82d9-603a1bfbbc4e.png">