### PR TITLE
VZV | Map controls bug

### DIFF
--- a/atd-vzv/src/App.css
+++ b/atd-vzv/src/App.css
@@ -1,6 +1,7 @@
 .App {
   display: flex;
   width: 100%;
+  height: 100vh;
   align-items: stretch;
 }
 

--- a/atd-vzv/src/App.css
+++ b/atd-vzv/src/App.css
@@ -1,8 +1,10 @@
 .App {
   display: flex;
   width: 100%;
-  height: 100vh;
   align-items: stretch;
+  min-height: 100vh;
+  /* Mobile viewport iOS Safari bug fix for Content component (Map) */
+  min-height: -webkit-fill-available;
 }
 
 body {

--- a/atd-vzv/src/App.css
+++ b/atd-vzv/src/App.css
@@ -4,6 +4,7 @@
   align-items: stretch;
   min-height: 100vh;
   /* Mobile viewport iOS Safari bug fix for Content component (Map) */
+  /* https://allthingssmitty.com/2020/05/11/css-fix-for-100vh-in-mobile-webkit/ */
   min-height: -webkit-fill-available;
 }
 

--- a/atd-vzv/src/views/content/Content.js
+++ b/atd-vzv/src/views/content/Content.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React from "react";
 import { usePath } from "hookrouter";
 import { useTrackedRoutes } from "../../constants/nav";
 import { routes } from "../../routes/routes";

--- a/atd-vzv/src/views/content/Content.js
+++ b/atd-vzv/src/views/content/Content.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 import { usePath } from "hookrouter";
 import { useTrackedRoutes } from "../../constants/nav";
 import { routes } from "../../routes/routes";
@@ -23,7 +23,8 @@ const Content = () => {
   // Map view needs to consider header height and have no overflow scroll to fill view
   // Summary view needs to scroll to show all content
   const mapStyles = `
-    height: calc(100vh - ${responsive.headerHeight}px);
+    position: fixed;
+    height: calc(100% - ${responsive.headerHeight}px);
     width: calc(100vw - ${responsive.drawerWidth}px);
   `;
 
@@ -38,9 +39,6 @@ const Content = () => {
     @media only screen and (max-width: ${responsive.bootstrapMedium}px) {
       .content {
         width: 100vw;
-        height: 100%;
-        height: -webkit-calc(100% - ${responsive.headerHeightMobile}px);
-        height: -moz-calc(100% - ${responsive.headerHeightMobile}px);
         height: calc(100% - ${responsive.headerHeightMobile}px);
         top: ${responsive.headerHeightMobile}px;
       }

--- a/atd-vzv/src/views/content/Content.js
+++ b/atd-vzv/src/views/content/Content.js
@@ -44,8 +44,12 @@ const Content = () => {
     @media only screen and (max-width: ${responsive.bootstrapMedium}px) {
       .content {
         width: 100vw;
-        height: calc(100vh - ${responsive.headerHeightMobile}px);
+        position: fixed;
         top: ${responsive.headerHeightMobile}px;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        height: unset;
       }
     }
   `;

--- a/atd-vzv/src/views/content/Content.js
+++ b/atd-vzv/src/views/content/Content.js
@@ -27,16 +27,10 @@ const Content = () => {
     width: calc(100vw - ${responsive.drawerWidth}px);
   `;
 
-  const summaryStyles = `
-    width: 100vw;
-    height: 100vh;
-  `;
-
   const StyledContent = styled.div`
     .content {
       position: relative;
       top: ${responsive.headerHeight}px;
-      ${currentPath === "/" && summaryStyles}
       ${isMapPath && mapStyles}
     }
 
@@ -44,17 +38,11 @@ const Content = () => {
     @media only screen and (max-width: ${responsive.bootstrapMedium}px) {
       .content {
         width: 100vw;
-        height: calc(100vh - ${responsive.headerHeightMobile}px);
-
-        /* Fix position to fill all space below the header without scrolling */
-        /* while avoiding iOS bug with how vh is handled */
-        ${isMapPath &&
-        `position: fixed;
+        height: 100%;
+        height: -webkit-calc(100% - ${responsive.headerHeightMobile}px);
+        height: -moz-calc(100% - ${responsive.headerHeightMobile}px);
+        height: calc(100% - ${responsive.headerHeightMobile}px);
         top: ${responsive.headerHeightMobile}px;
-        left: 0;
-        right: 0;
-        bottom: 0;
-        height: unset;`}
       }
     }
   `;

--- a/atd-vzv/src/views/content/Content.js
+++ b/atd-vzv/src/views/content/Content.js
@@ -44,12 +44,17 @@ const Content = () => {
     @media only screen and (max-width: ${responsive.bootstrapMedium}px) {
       .content {
         width: 100vw;
-        position: fixed;
+        height: calc(100vh - ${responsive.headerHeightMobile}px);
+
+        /* Fix position to fill all space below the header without scrolling */
+        /* while avoiding iOS bug with how vh is handled */
+        ${isMapPath &&
+        `position: fixed;
         top: ${responsive.headerHeightMobile}px;
         left: 0;
         right: 0;
         bottom: 0;
-        height: unset;
+        height: unset;`}
       }
     }
   `;


### PR DESCRIPTION
Closes https://github.com/cityofaustin/atd-data-tech/issues/2795

This PR addresses a bug in iOS Safari and other mobile browsers where a scroll bar would appear on the Map view and allow the controls to scroll out of view. 

After some trial and error, the fix described in [this post](https://allthingssmitty.com/2020/05/11/css-fix-for-100vh-in-mobile-webkit/) works as a solution for consistently filling the space below the header with the map (without a scrollbar).

#### On my iPhone X (with bottom controls)
![Image from iOS](https://user-images.githubusercontent.com/37249039/84178020-6316e200-aa49-11ea-85c5-412edbe0d125.jpg)

#### On my iPhone X (without bottom controls)
![Image from iOS (1)](https://user-images.githubusercontent.com/37249039/84178328-d4ef2b80-aa49-11ea-9c32-6393c4ef728e.jpg)

#### Galaxy S10 in Chrome
<img width="164" alt="s10" src="https://user-images.githubusercontent.com/37249039/84184801-9cece600-aa53-11ea-9097-b19da53f7c35.png">

#### Galaxy S4 in Chrome
<img width="179" alt="s4" src="https://user-images.githubusercontent.com/37249039/84184847-aece8900-aa53-11ea-9bc5-3ab6aa21386d.png">


