### PR TITLE
VZ Events: PRs for SQS

### DIFF
--- a/.circleci/aws-helper.sh
+++ b/.circleci/aws-helper.sh
@@ -4,33 +4,44 @@
 case "${CIRCLE_BRANCH}" in
   "production")
     export WORKING_STAGE="production";
-    ;;
+  ;;
+
+  "master")
+    export WORKING_STAGE="staging";
+  ;;
 
   *)
-    export WORKING_STAGE="staging";
-    ;;
+    export WORKING_STAGE="pr";
+  ;;
 esac
 
 # Deploys API to AWS
 function deploy_aws_lambda {
-    if [[ "${WORKING_STAGE}" == "" ]]; then
-        echo "No working stage could be determined."
-        exit 1;
+    if [[ "${WORKING_STAGE}" == "pr" ]]; then
+        echo "PRs are not currently being deployed to the API";
+        exit 0;
     fi;
 
-    if [[ "${AWS_ACCESS_KEY_ID}" == "" ]] || [[ "${AWS_SECRET_ACCESS_KEY}" = "" ]]; then
-        echo "The AWS keys are not set"
-        exit 1;
-    fi;
+    echo "It should not reach this point";
 
-    # Check ATD CR3 API
-    cd "atd-cr3-api";
-
-    python3 -m venv venv;
-    source venv/bin/activate;
-    pip install -r requirements.txt
-
-    # Run zappa
-    echo $ZAPPA_SETTINGS > zappa_settings.json;
-    zappa update $WORKING_STAGE;
+#    if [[ "${WORKING_STAGE}" == "" ]]; then
+#        echo "No working stage could be determined."
+#        exit 1;
+#    fi;
+#
+#    if [[ "${AWS_ACCESS_KEY_ID}" == "" ]] || [[ "${AWS_SECRET_ACCESS_KEY}" = "" ]]; then
+#        echo "The AWS keys are not set"
+#        exit 1;
+#    fi;
+#
+#    # Check ATD CR3 API
+#    cd "atd-cr3-api";
+#
+#    python3 -m venv venv;
+#    source venv/bin/activate;
+#    pip install -r requirements.txt
+#
+#    # Run zappa
+#    echo $ZAPPA_SETTINGS > zappa_settings.json;
+#    zappa update $WORKING_STAGE;
 }

--- a/.circleci/aws-lambda-helper.sh
+++ b/.circleci/aws-lambda-helper.sh
@@ -88,7 +88,7 @@ function deploy_event_function {
   # Set environment variables for the function
   echo "Resetting environment variables: ${FUNCTION_NAME} @ ${PWD}";
   aws lambda update-function-configuration \
-        --function-name "atd-vz-data-events-crash_update_jurisdiction_staging" \
+        --function-name "${FUNCTION_NAME}" \
         --cli-input-json file://$PWD/handler_config.json | jq -r ".LastUpdateStatus";
   echo "Finished Lambda Update/Deployment";
 }

--- a/.circleci/aws-lambda-helper.sh
+++ b/.circleci/aws-lambda-helper.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# CIRCLE_PR_NUMBER only works on forked PRs
+export ATD_PR_NUMBER="${CIRCLE_PULL_REQUEST##*/}";
+
 case "${CIRCLE_BRANCH}" in
   "production")
     export WORKING_STAGE="production";
@@ -9,7 +12,7 @@ case "${CIRCLE_BRANCH}" in
   ;;
   *)
     echo "PR Detected, resetting working stage";
-    export WORKING_STAGE="pr_${CIRCLE_PR_NUMBER}";
+    export WORKING_STAGE="pr_${ATD_PR_NUMBER}";
     echo "New working stage: ${WORKING_STAGE}...";
   ;;
 esac

--- a/.circleci/aws-lambda-helper.sh
+++ b/.circleci/aws-lambda-helper.sh
@@ -8,7 +8,9 @@ case "${CIRCLE_BRANCH}" in
     export WORKING_STAGE="staging";
   ;;
   *)
+    echo "PR Detected, resetting working stage";
     export WORKING_STAGE="pr_${CIRCLE_PR_NUMBER}";
+    echo "New working stage: ${WORKING_STAGE}...";
   ;;
 esac
 
@@ -38,7 +40,7 @@ function bundle_function {
 #
 function generate_env_vars {
       echo $ZAPPA_SETTINGS > zappa_settings.json;
-      echo "Generating environment variables for environment '${WORKKING_STAGE}'...";
+      echo "Generating environment variables for environment '${WORKING_STAGE}'...";
       if [[ "${WORKING_STAGE}" != "pr_" ]] && [[ "${WORKING_STAGE}" == pr_* ]]; then
         echo "Detected PR, adjusting environment to Staging...";
         LOCAL_STAGE="staging"

--- a/.circleci/aws-lambda-helper.sh
+++ b/.circleci/aws-lambda-helper.sh
@@ -37,8 +37,9 @@ function bundle_function {
 # Generates environment variables for deployment
 #
 function generate_env_vars {
-      echo $ZAPPA_SETTINGS > zappa_settings.json
-      if [[ "${WORKING_STAGE}" == "pr_*" ]]; then
+      echo $ZAPPA_SETTINGS > zappa_settings.json;
+      echo "Generating environment variables for environment '${WORKKING_STAGE}'...";
+      if [[ "${WORKING_STAGE}" != "pr_" ]] && [[ "${WORKING_STAGE}" == pr_* ]]; then
         echo "Detected PR, adjusting environment to Staging...";
         LOCAL_STAGE="staging"
       else

--- a/.circleci/aws-lambda-helper.sh
+++ b/.circleci/aws-lambda-helper.sh
@@ -3,11 +3,13 @@
 case "${CIRCLE_BRANCH}" in
   "production")
     export WORKING_STAGE="production";
-    ;;
-
-  *)
+  ;;
+  "master")
     export WORKING_STAGE="staging";
-    ;;
+  ;;
+  *)
+    export WORKING_STAGE="pr_${CIRCLE_PR_NUMBER}";
+  ;;
 esac
 
 #
@@ -126,6 +128,9 @@ function deploy_sqs {
     deploy_event_source_mapping $QUEUE_NAME $QUEUE_ARN;
 }
 
+function clean_up {
+    python aws-lambda-sqs-clean.py;
+}
 #
 # Deploys all functions in the events directory
 #

--- a/.circleci/aws-lambda-helper.sh
+++ b/.circleci/aws-lambda-helper.sh
@@ -52,8 +52,8 @@ function generate_env_vars {
         echo "No PR detected, using '${WORKING_STAGE}' as environment..."
         LOCAL_STAGE="${WORKING_STAGE}";
       fi;
-      echo "Using stage: ${LOCAL_STAGE} (Current working stage: '${WORKING_STAGE}')...";
-      STAGE_ENV_VARS=$(cat zappa_settings.json | jq -r ".${WORKING_STAGE}.aws_environment_variables");
+      echo "Using stage: '${LOCAL_STAGE}' (Current working stage: '${WORKING_STAGE}')...";
+      STAGE_ENV_VARS=$(cat zappa_settings.json | jq -r ".${LOCAL_STAGE}.aws_environment_variables");
       echo -e "{\"Description\": \"ATD VisionZero Events Handler\", \"Environment\": { \"Variables\": ${STAGE_ENV_VARS}}}" | jq -rc > handler_config.json;
 }
 

--- a/.circleci/aws-lambda-helper.sh
+++ b/.circleci/aws-lambda-helper.sh
@@ -38,7 +38,7 @@ function bundle_function {
 #
 function generate_env_vars {
       echo $ZAPPA_SETTINGS > zappa_settings.json
-      if [[ "${WORKING_STAGE}" == "other" ]]; then
+      if [[ "${WORKING_STAGE}" == "pr_*" ]]; then
         echo "Detected PR, adjusting environment to Staging...";
         LOCAL_STAGE="staging"
       else

--- a/.circleci/aws-lambda-sqs-clean.py
+++ b/.circleci/aws-lambda-sqs-clean.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+
+import pdb
+import boto3
+
+# First initialize the client
+client = boto3.client('sqs')
+
+
+def is_removable(queue_url) -> bool:
+    """
+    Returns True if the queue url does not end with staging or production
+    :param str queue_url: The queue url
+    :return bool:
+    """
+    if str(queue_url).endswith("staging") == True \
+        or str(queue_url).endswith("production") == True:
+        return False
+    return True
+
+
+def get_queue_list() -> [str]:
+    """
+    Returns an array of strings containing a list of queue urls
+    :return Array[str]:
+    """
+    # We need to get a list of all of our queues
+    response = client.list_queues(
+        QueueNamePrefix="atd-vz-data-events-"
+    )
+    # Return our list
+    return response.get("QueueUrls", [])
+
+
+def get_queue_name_from_url(queue_url) -> str:
+    """
+    Returns a string with the name of the queue
+    :param str queue_url:
+    :return str:
+    """
+    return queue_url[41:]
+
+
+def get_function_name_from_url(queue_url) -> str:
+    """
+    Returns a string with the name of the lambda function
+    :param str queue_url:
+    :return str:
+    """
+    return queue_url[41:]
+
+
+def delete_queue(queue_url) -> dict:
+    """
+    Returns a dictionary with the deletion response
+    :param str queue_url:
+    :return dict:
+    """
+    return client.delete_queue(
+        QueueUrl=queue_url
+    )
+
+
+#
+# Main Function
+#
+def main():
+    queues = get_queue_list()
+
+    for queue_url in queues:
+        removable = is_removable(queue_url)
+        queue_name = get_queue_name_from_url(queue_url)
+        function_name = get_function_name_from_url(queue_url)
+        if removable:
+            print(f"Removing: {removable} : {queue_name} : {function_name}")
+            print(delete_queue(queue_url))
+        else:
+            print(f"Skipping: {removable} : {queue_name} : {function_name}")
+
+
+if __name__ == "__main__":
+    main()
+    print("Done")

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,16 +13,19 @@ jobs:
       - setup_remote_docker:
           version: 18.09.3
       - run:
+          # Builds master and production branches only
           name: "Building Docker"
           command: |
             source .circleci/docker-helper.sh
             build_containers
       - run:
+          # Builds master and production branches only
           name: "Build VZE API"
           command: |
             source .circleci/aws-helper.sh
             deploy_aws_lambda
       - run:
+          # Builds master, production and PR branches
           name: "Build VZ SQS Functions"
           command: |
             source .circleci/aws-lambda-helper.sh
@@ -37,3 +40,4 @@ workflows:
               only:
                 - master
                 - production
+                - /^(?!pull\/).*$/

--- a/.circleci/docker-helper.sh
+++ b/.circleci/docker-helper.sh
@@ -1,32 +1,54 @@
 #!/usr/bin/env bash
 
+# Determine work branch
+case "${CIRCLE_BRANCH}" in
+  "production")
+    export WORKING_STAGE="production";
+  ;;
+
+  "master")
+    export WORKING_STAGE="staging";
+  ;;
+
+  *)
+    export WORKING_STAGE="pr";
+  ;;
+esac
+
 export ATD_IMAGE="atddocker/atd-vz-etl";
 export ATD_IMAGE_AGOL="atddocker/atd-vz-etl-agol"
 #
 # We need to assign the name of the branch as the tag to be deployed
 #
-export ATD_TAG="${CIRCLE_BRANCH}";
+export ATD_TAG="${WORKING_STAGE}";
+
 
 function build_containers {
-    echo "Logging in to Docker hub"
-    docker login -u $ATD_DOCKER_USER -p $ATD_DOCKER_PASS
 
-    # First build, tag and push the regular ETL image
-    echo "docker build -f Dockerfile -t $ATD_IMAGE:$ATD_TAG .";
-    docker build -f atd-etl/Dockerfile -t $ATD_IMAGE:$ATD_TAG ./atd-etl
-
-    echo "docker tag $ATD_IMAGE:$ATD_TAG $ATD_IMAGE:$ATD_TAG;";
-    docker tag $ATD_IMAGE:$ATD_TAG $ATD_IMAGE:$ATD_TAG;
-
-    echo "docker push $ATD_IMAGE:$ATD_TAG";
-    docker push $ATD_IMAGE:$ATD_TAG;
-
-    # Then build, tag and push the Agol-containing Image
-    echo "docker build -f Dockerfile.agol -t $ATD_IMAGE_AGOL:$ATD_TAG .";
-    docker build -f atd-etl/Dockerfile.agol -t $ATD_IMAGE_AGOL:$ATD_TAG ./atd-etl
-
-    echo "docker tag $ATD_IMAGE_AGOL:$ATD_TAG $ATD_IMAGE_AGOL:$ATD_TAG;";
-    docker tag $ATD_IMAGE_AGOL:$ATD_TAG $ATD_IMAGE_AGOL:$ATD_TAG;
+    if [[ "${WORKING_STAGE}" == "pr" ]]; then
+        echo "PRs are not currently deployed to the docker-hub.";
+        exit 0;
+    fi;
+    echo "It should not reach this point";
+#    echo "Logging in to Docker hub"
+#    docker login -u $ATD_DOCKER_USER -p $ATD_DOCKER_PASS
+#
+#    # First build, tag and push the regular ETL image
+#    echo "docker build -f Dockerfile -t $ATD_IMAGE:$ATD_TAG .";
+#    docker build -f atd-etl/Dockerfile -t $ATD_IMAGE:$ATD_TAG ./atd-etl
+#
+#    echo "docker tag $ATD_IMAGE:$ATD_TAG $ATD_IMAGE:$ATD_TAG;";
+#    docker tag $ATD_IMAGE:$ATD_TAG $ATD_IMAGE:$ATD_TAG;
+#
+#    echo "docker push $ATD_IMAGE:$ATD_TAG";
+#    docker push $ATD_IMAGE:$ATD_TAG;
+#
+#    # Then build, tag and push the Agol-containing Image
+#    echo "docker build -f Dockerfile.agol -t $ATD_IMAGE_AGOL:$ATD_TAG .";
+#    docker build -f atd-etl/Dockerfile.agol -t $ATD_IMAGE_AGOL:$ATD_TAG ./atd-etl
+#
+#    echo "docker tag $ATD_IMAGE_AGOL:$ATD_TAG $ATD_IMAGE_AGOL:$ATD_TAG;";
+#    docker tag $ATD_IMAGE_AGOL:$ATD_TAG $ATD_IMAGE_AGOL:$ATD_TAG;
 
     echo "docker push $ATD_IMAGE_AGOL:$ATD_TAG";
     docker push $ATD_IMAGE_AGOL:$ATD_TAG;


### PR DESCRIPTION
This deployment script aims to implement PRs for SQS using CircleCI and Python.

Current deployments follow this nomenclature pattern:

**{project}-{name of the queue}_{environment}**

Right now we only have two environments: production and staging (master). **The main idea is that we could switch {environment} for {branch}** which should allow us to list all queues in AWS by name, and _remove only the queues whose name do not end with production or staging_. This would protect production, and allow for testing of multiple PRs in SQS.

This presents one problem, how do we clean up after a PR has been merged to master or production? If we keep creating branches, we are going to have hundreds of sqs queues and lambda functions for branches that aren't even related.

To address this, every time a PR (any PR) is merged to master (or production) we are going to wipe out any SQS queues and accompanying Lambda functions that are not staging or production.

Unfortunately this does mean that if anyone merges a PR to master (even if unrelated). So we have a few options:

1. Remove only the PR that has been merged to master. This could work, but if the deletion process does not work all the time, we can end up with some SQS functions that somehow remain there. Cleanup may be required every now and then.

2. Remove all PRs at once from SQS, but check with GitHub first, if the PR status is closed then remove the PR in question.

3. Remove all PRs regardless. This is probably the most effective, but it will force the developers to re-deploy the SQS by making a dummy commit, or running CircleCI manually by re-running their PR process.


#### CircleCI vs GitHub Actions
It would be nice to keep things in CircleCI, but if managing PRs becomes difficult it may be possible to use GitHub Actions instead for SQS deployments only.