### PR TITLE
ETL | Update global filters

### DIFF
--- a/atd-etl/app/process/socrata_queries.py
+++ b/atd-etl/app/process/socrata_queries.py
@@ -14,7 +14,7 @@ from string import Template
 crashes_query_template = Template(
     """
     query getCrashesSocrata {
-        atd_txdot_crashes (limit: $limit, offset: $offset, order_by: {crash_id: asc}, where: {_or: [{city_id: {_eq: 22}}, {austin_full_purpose: {_eq: "Y"}}]}) {
+        atd_txdot_crashes (limit: $limit, offset: $offset, order_by: {crash_id: asc}, where: {_and: {_or: [{austin_full_purpose: {_eq: "Y"}}, {_and: [{city_id: {_eq: 22}}, {position: {_is_null: true}}]}]}}) {
             apd_confirmed_fatality
             apd_confirmed_death_count
             crash_id
@@ -61,7 +61,7 @@ crashes_query_template = Template(
 people_query_template = Template(
     """
     query getPeopleSocrata {
-        atd_txdot_person(limit: $limit, offset: $offset, order_by: {person_id: asc}, where: {_or: [{prsn_injry_sev_id: {_eq: 1}}, {prsn_injry_sev_id: {_eq: 4}}], _and: {_or: [{crash: {city_id: {_eq: 22}}}, {crash: {austin_full_purpose: {_eq: "Y"}}}]}}) {
+        atd_txdot_person(limit: $limit, offset: $offset, order_by: {person_id: asc}, where: {_or: [{prsn_injry_sev_id: {_eq: 1}}, {prsn_injry_sev_id: {_eq: 4}}], _and: {_or: [{crash: {austin_full_purpose: {_eq: "Y"}}}, {_and: [{crash: {city_id: {_eq: 22}}}, {crash: {position: {_is_null: true}}} ]}]}}) {
             person_id
             prsn_injry_sev_id
             prsn_age
@@ -77,7 +77,7 @@ people_query_template = Template(
                 }
             }
         }
-        atd_txdot_primaryperson(limit: $limit, offset: $offset, order_by: {primaryperson_id: asc}, where: {_or: [{prsn_injry_sev_id: {_eq: 1}}, {prsn_injry_sev_id: {_eq: 4}}], _and: {_or: [{crash: {city_id: {_eq: 22}}}, {crash: {austin_full_purpose: {_eq: "Y"}}}]}}) {
+        atd_txdot_primaryperson(limit: $limit, offset: $offset, order_by: {primaryperson_id: asc}, where: {_or: [{prsn_injry_sev_id: {_eq: 1}}, {prsn_injry_sev_id: {_eq: 4}}], _and: {_or: [{crash: {austin_full_purpose: {_eq: "Y"}}}, {_and: [{crash: {city_id: {_eq: 22}}}, {crash: {position: {_is_null: true}}} ]}]}}) {
             primaryperson_id
             prsn_injry_sev_id
             prsn_age

--- a/atd-etl/app/process/socrata_queries.py
+++ b/atd-etl/app/process/socrata_queries.py
@@ -14,7 +14,7 @@ from string import Template
 crashes_query_template = Template(
     """
     query getCrashesSocrata {
-        atd_txdot_crashes (limit: $limit, offset: $offset, order_by: {crash_id: asc}, where: {_and: {_or: [{austin_full_purpose: {_eq: "Y"}}, {_and: [{city_id: {_eq: 22}}, {position: {_is_null: true}}]}]}}) {
+        atd_txdot_crashes (limit: $limit, offset: $offset, order_by: {crash_id: asc}, where: {_or: [{austin_full_purpose: {_eq: "Y"}}, {_and: [{city_id: {_eq: 22}}, {position: {_is_null: true}}]}]}) {
             apd_confirmed_fatality
             apd_confirmed_death_count
             crash_id

--- a/atd-etl/app/process/socrata_queries.py
+++ b/atd-etl/app/process/socrata_queries.py
@@ -14,7 +14,7 @@ from string import Template
 crashes_query_template = Template(
     """
     query getCrashesSocrata {
-        atd_txdot_crashes (limit: $limit, offset: $offset, order_by: {crash_id: asc}, where: {city_id: {_eq: 22}}) {
+        atd_txdot_crashes (limit: $limit, offset: $offset, order_by: {crash_id: asc}, where: {_or: [{city_id: {_eq: 22}}, {austin_full_purpose: {_eq: "Y"}}]}) {
             apd_confirmed_fatality
             apd_confirmed_death_count
             crash_id
@@ -61,7 +61,7 @@ crashes_query_template = Template(
 people_query_template = Template(
     """
     query getPeopleSocrata {
-        atd_txdot_person(limit: $limit, offset: $offset, order_by: {person_id: asc}, where: {_or: [{prsn_injry_sev_id: {_eq: 1}}, {prsn_injry_sev_id: {_eq: 4}}], _and: {crash: {city_id: {_eq: 22}}}}) {
+        atd_txdot_person(limit: $limit, offset: $offset, order_by: {person_id: asc}, where: {_or: [{prsn_injry_sev_id: {_eq: 1}}, {prsn_injry_sev_id: {_eq: 4}}], _and: {_or: [{crash: {city_id: {_eq: 22}}}, {crash: {austin_full_purpose: {_eq: "Y"}}}]}}) {
             person_id
             prsn_injry_sev_id
             prsn_age
@@ -77,7 +77,7 @@ people_query_template = Template(
                 }
             }
         }
-        atd_txdot_primaryperson(limit: $limit, offset: $offset, order_by: {primaryperson_id: asc}, where: {_or: [{prsn_injry_sev_id: {_eq: 1}}, {prsn_injry_sev_id: {_eq: 4}}], _and: {crash: {city_id: {_eq: 22}}}}) {
+        atd_txdot_primaryperson(limit: $limit, offset: $offset, order_by: {primaryperson_id: asc}, where: {_or: [{prsn_injry_sev_id: {_eq: 1}}, {prsn_injry_sev_id: {_eq: 4}}], _and: {_or: [{crash: {city_id: {_eq: 22}}}, {crash: {austin_full_purpose: {_eq: "Y"}}}]}}) {
             primaryperson_id
             prsn_injry_sev_id
             prsn_age

--- a/atd-etl/app/process_socrata_export.py
+++ b/atd-etl/app/process_socrata_export.py
@@ -14,8 +14,6 @@ import os
 import time
 from string import Template
 from sodapy import Socrata
-import csv
-import json
 from process.config import ATD_ETL_CONFIG
 from process.helpers_socrata import *
 from process.socrata_queries import *

--- a/atd-etl/app/process_socrata_export.py
+++ b/atd-etl/app/process_socrata_export.py
@@ -17,11 +17,17 @@ from sodapy import Socrata
 from process.config import ATD_ETL_CONFIG
 from process.helpers_socrata import *
 from process.socrata_queries import *
+
 print("Socrata - Exporter:  Started.")
 
 # Setup connection to Socrata
-client = Socrata("data.austintexas.gov", ATD_ETL_CONFIG["SOCRATA_APP_TOKEN"],
-                 username=ATD_ETL_CONFIG["SOCRATA_KEY_ID"], password=ATD_ETL_CONFIG["SOCRATA_KEY_SECRET"], timeout=20)
+client = Socrata(
+    "data.austintexas.gov",
+    ATD_ETL_CONFIG["SOCRATA_APP_TOKEN"],
+    username=ATD_ETL_CONFIG["SOCRATA_KEY_ID"],
+    password=ATD_ETL_CONFIG["SOCRATA_KEY_SECRET"],
+    timeout=20,
+)
 
 # Define tables to query from Hasura and publish to Socrata
 query_configs = [
@@ -35,11 +41,11 @@ query_configs = [
                 "veh_body_styl_desc": "unit_desc",
                 "veh_unit_desc_desc": "unit_mode",
                 "latitude_primary": "latitude",
-                "longitude_primary": "longitude"
-            }
+                "longitude_primary": "longitude",
+            },
         },
         # "dataset_uid": "3aut-fhzp"  # TEST
-        "dataset_uid": "y2wy-tgr5"  # PROD
+        "dataset_uid": "y2wy-tgr5",  # PROD
     },
     {
         "table": "person",
@@ -47,17 +53,12 @@ query_configs = [
         "formatter": format_person_data,
         "formatter_config": {
             "tables": ["atd_txdot_person", "atd_txdot_primaryperson"],
-            "columns_to_rename": {
-                "primaryperson_id": "person_id"
-            },
-            "prefixes": {
-                "person_id": "P",
-                "primaryperson_id": "PP",
-            }
+            "columns_to_rename": {"primaryperson_id": "person_id"},
+            "prefixes": {"person_id": "P", "primaryperson_id": "PP",},
         },
         # "dataset_uid": "v3x4-fjgm"  # TEST
-        "dataset_uid": "xecs-rpy9"  # PROD
-    }
+        "dataset_uid": "xecs-rpy9",  # PROD
+    },
 ]
 
 # Start timer
@@ -74,8 +75,7 @@ for config in query_configs:
     # Query records from Hasura and upsert to Socrata
     while records != []:
         # Create query, increment offset, and query DB
-        query = config["template"].substitute(
-            limit=limit, offset=offset)
+        query = config["template"].substitute(limit=limit, offset=offset)
         offset += limit
         data = run_hasura_query(query)
 
@@ -84,12 +84,11 @@ for config in query_configs:
 
         # Upsert records to Socrata
         client.upsert(config["dataset_uid"], records)
-        print(f'{offset} records upserted')
+        print(f"{offset} records upserted")
         total_records += len(records)
 
         if len(records) == 0:
-            print(
-                f'{total_records} {config["table"]} records upserted.')
+            print(f'{total_records} {config["table"]} records upserted.')
             print(f'Completed {config["table"]} table.')
 
 # Terminate Socrata connection
@@ -97,7 +96,6 @@ client.close()
 
 # Stop timer and print duration
 end = time.time()
-hours, rem = divmod(end-start, 3600)
+hours, rem = divmod(end - start, 3600)
 minutes, seconds = divmod(rem, 60)
-print("Finished in: {:0>2}:{:0>2}:{:05.2f}".format(
-    int(hours), int(minutes), seconds))
+print("Finished in: {:0>2}:{:0>2}:{:05.2f}".format(int(hours), int(minutes), seconds))

--- a/atd-etl/app/process_socrata_export.py
+++ b/atd-etl/app/process_socrata_export.py
@@ -46,8 +46,8 @@ query_configs = [
                 "longitude_primary": "longitude",
             },
         },
-        "dataset_uid": "3aut-fhzp"  # TEST
-        # "dataset_uid": "y2wy-tgr5",  # PROD
+        # "dataset_uid": "3aut-fhzp"  # TEST
+        "dataset_uid": "y2wy-tgr5",  # PROD
     },
     {
         "table": "person",
@@ -58,8 +58,8 @@ query_configs = [
             "columns_to_rename": {"primaryperson_id": "person_id"},
             "prefixes": {"person_id": "P", "primaryperson_id": "PP",},
         },
-        "dataset_uid": "v3x4-fjgm"  # TEST
-        # "dataset_uid": "xecs-rpy9",  # PROD
+        # "dataset_uid": "v3x4-fjgm"  # TEST
+        "dataset_uid": "xecs-rpy9",  # PROD
     },
 ]
 


### PR DESCRIPTION
Closes https://github.com/cityofaustin/atd-data-tech/issues/2910

This PR adds new GQL query filters in the ETL to fetch data where crash `austin_full_purpose = "Y"` OR `(city_id = "22" AND position = null)`. Also, I removed unused imports left behind in the parent branch.