### PR TITLE
VZV: By Time of Day Bug

### DIFF
--- a/atd-vzv/package-lock.json
+++ b/atd-vzv/package-lock.json
@@ -9793,6 +9793,11 @@
       "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
       "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
     },
+    "lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
+    },
     "lodash.isequal": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",

--- a/atd-vzv/package.json
+++ b/atd-vzv/package.json
@@ -24,6 +24,7 @@
     "chart.js": "^2.9.3",
     "events-polyfill": "^2.1.2",
     "hookrouter": "^1.2.3",
+    "lodash.clonedeep": "^4.5.0",
     "moment": "^2.24.0",
     "patch-package": "^6.2.2",
     "react": "^16.10.2",

--- a/atd-vzv/src/views/summary/CrashesByTimeOfDay.js
+++ b/atd-vzv/src/views/summary/CrashesByTimeOfDay.js
@@ -46,9 +46,9 @@ const CrashesByTimeOfDay = () => {
 
     const buildDataArray = () => {
       // This array holds weekday totals for each hour window within a day
-      // Heatmap expects array of weekday total objs to be reversed in order
+      // Reaviz Heatmap expects array of weekday total objs to be reversed in order
       const hourWindowTotalsByDay = dayOfWeekArray
-        .map((day) => ({ key: day, data: null })) // Initialize totals as null unweight 0 in viz
+        .map((day) => ({ key: day, data: null })) // Initialize totals as null to unweight 0 in viz
         .reverse();
 
       // Return array of objs for each hour window that holds totals of each day of the week

--- a/atd-vzv/src/views/summary/CrashesByTimeOfDay.js
+++ b/atd-vzv/src/views/summary/CrashesByTimeOfDay.js
@@ -91,28 +91,42 @@ const CrashesByTimeOfDay = () => {
 
     const calculateHourBlockTotals = (data) => {
       const dataArray = buildDataArray();
-      debugger;
+
       data.data.forEach((record) => {
-        const date = new Date(record.crash_date);
-        const dayOfWeek = date.getDay();
-        const time = record.crash_time;
-        const timeArray = time.split(":");
-        const hour = parseInt(timeArray[0]);
-        switch (crashType.name) {
-          case "fatalities":
-            dataArray[hour].data[dayOfWeek].data += parseInt(record.death_cnt);
-            break;
-          case "seriousInjuries":
-            dataArray[hour].data[dayOfWeek].data += parseInt(
-              record.sus_serious_injry_cnt
-            );
-            break;
-          default:
-            dataArray[hour].data[dayOfWeek].data +=
-              parseInt(record.death_cnt) +
-              parseInt(record.sus_serious_injry_cnt);
-            break;
-        }
+        // const date = new Date(record.crash_date);
+        // const dayOfWeek = date.getDay();
+        // const time = record.crash_time;
+        // const timeArray = time.split(":");
+        // const hour = parseInt(timeArray[0]);
+        // For each record, get hour hhA and day of week
+        // Then place in dataArray
+        const recordDateTime = moment(record.crash_date);
+        const hourString = recordDateTime.format("hhA");
+        const dayOfWeek = recordDateTime.format("ddd");
+
+        const hourToIncrease = dataArray.find((hour) => hour.key === hourString)
+          .data;
+        const dayToIncrease = hourToIncrease.find(
+          (day) => day.key === dayOfWeek
+        ).data;
+        debugger;
+        // switch (crashType.name) {
+        //   case "fatalities":
+
+        //     debugger;
+        //     // dataArray[hour].data[dayOfWeek].data += parseInt(record.death_cnt);
+        //     break;
+        //   case "seriousInjuries":
+        //     // dataArray[hour].data[dayOfWeek].data += parseInt(
+        //     //   record.sus_serious_injry_cnt
+        //     // );
+        //     break;
+        //   default:
+        //     // dataArray[hour].data[dayOfWeek].data +=
+        //     //   parseInt(record.death_cnt) +
+        //     //   parseInt(record.sus_serious_injry_cnt);
+        //     break;
+        // }
       });
       // Set any 0 values to null so that the reaviz library
       // recognizes them as "blank cells" and fills them accordingly

--- a/atd-vzv/src/views/summary/CrashesByTimeOfDay.js
+++ b/atd-vzv/src/views/summary/CrashesByTimeOfDay.js
@@ -39,50 +39,19 @@ const CrashesByTimeOfDay = () => {
   useEffect(() => {
     const dayOfWeekArray = moment.weekdaysShort();
 
-    const hourBlockArray = [
-      "12AM",
-      "01AM",
-      "02AM",
-      "03AM",
-      "04AM",
-      "05AM",
-      "06AM",
-      "07AM",
-      "08AM",
-      "09AM",
-      "10AM",
-      "11AM",
-      "12PM",
-      "01PM",
-      "02PM",
-      "03PM",
-      "04PM",
-      "05PM",
-      "06PM",
-      "07PM",
-      "08PM",
-      "09PM",
-      "10PM",
-      "11PM",
-    ];
+    const hourBlockArray = [];
+    for (let hour = 0; hour < 24; hour++) {
+      hourBlockArray.push(moment({ hour }).format("hhA"));
+    }
 
     const buildDataArray = () => {
       // This array holds weekday totals for each hour window within a day
       // Heatmap expects array of weekday total objs to be reversed in order
       const hourWindowTotalsByDay = dayOfWeekArray
-        .map((day) => ({ key: day, data: null }))
+        .map((day) => ({ key: day, data: null })) // Initialize totals as null unweight 0 in viz
         .reverse();
 
       // Return array of objs for each hour window that holds totals of each day of the week
-      // [
-      //   {
-      //     key: "12AM",
-      //     data: [
-      //       { key: "Mon", data: 3 },
-      //       { key: "Sun", data: 1 },
-      //     ],
-      //   },
-      // ]
       return hourBlockArray.map((hour) => ({
         key: hour,
         data: clonedeep(hourWindowTotalsByDay),
@@ -92,7 +61,6 @@ const CrashesByTimeOfDay = () => {
     const calculateHourBlockTotals = (records) => {
       const dataArray = buildDataArray();
 
-      let fatalityCount = 0;
       records.forEach((record) => {
         const recordDateTime = moment(record.crash_date);
         const recordHour = recordDateTime.format("hhA");
@@ -104,7 +72,6 @@ const CrashesByTimeOfDay = () => {
         switch (crashType.name) {
           case "fatalities":
             dayToIncrement.data += parseInt(record.death_cnt);
-            fatalityCount += parseInt(record.death_cnt);
             break;
           case "seriousInjuries":
             dayToIncrement.data += parseInt(record.sus_serious_injry_cnt);
@@ -116,7 +83,7 @@ const CrashesByTimeOfDay = () => {
             break;
         }
       });
-      console.log(fatalityCount);
+
       return dataArray;
     };
 

--- a/atd-vzv/src/views/summary/CrashesByTimeOfDay.js
+++ b/atd-vzv/src/views/summary/CrashesByTimeOfDay.js
@@ -36,6 +36,23 @@ const CrashesByTimeOfDay = () => {
   };
 
   useEffect(() => {
+    // [
+    //   {
+    //     key: "12AM",
+    //     data: [
+    //       { key: "Mon", data: 3 },
+    //       { key: "Sun", data: 1 },
+    //     ],
+    //   },
+    //   {
+    //     key: "01AM",
+    //     data: [
+    //       { key: "Mon", data: 3 },
+    //       { key: "Sun", data: 1 },
+    //     ],
+    //   },
+    // ]
+
     const dayOfWeekArray = moment.weekdaysShort();
 
     const hourBlockArray = [
@@ -81,7 +98,9 @@ const CrashesByTimeOfDay = () => {
           };
           hourObject.data.push(dayObject);
         });
+
         hourObject.data.reverse();
+
         dataArray.push(hourObject);
       });
     };
@@ -119,6 +138,7 @@ const CrashesByTimeOfDay = () => {
           }
         });
       });
+      console.log(dataArray);
       return dataArray;
     };
 
@@ -202,7 +222,23 @@ const CrashesByTimeOfDay = () => {
         <Col>
           <Heatmap
             height={267}
-            data={heatmapData}
+            // data={heatmapData}
+            data={[
+              {
+                key: "12AM",
+                data: [
+                  { key: "Mon", data: 3 },
+                  { key: "Sun", data: 1 },
+                ],
+              },
+              {
+                key: "01AM",
+                data: [
+                  { key: "Mon", data: 3 },
+                  { key: "Sun", data: 1 },
+                ],
+              },
+            ]}
             series={
               <HeatmapSeries
                 colorScheme={[

--- a/atd-vzv/src/views/summary/CrashesByTimeOfDay.js
+++ b/atd-vzv/src/views/summary/CrashesByTimeOfDay.js
@@ -67,7 +67,7 @@ const CrashesByTimeOfDay = () => {
         const recordDay = recordDateTime.format("ddd");
 
         const hourData = dataArray.find((hour) => hour.key === recordHour).data;
-        let dayToIncrement = hourData.find((day) => day.key === recordDay);
+        const dayToIncrement = hourData.find((day) => day.key === recordDay);
 
         switch (crashType.name) {
           case "fatalities":

--- a/atd-vzv/src/views/summary/CrashesByTimeOfDay.js
+++ b/atd-vzv/src/views/summary/CrashesByTimeOfDay.js
@@ -89,33 +89,34 @@ const CrashesByTimeOfDay = () => {
       }));
     };
 
-    const calculateHourBlockTotals = (data) => {
+    const calculateHourBlockTotals = (records) => {
       const dataArray = buildDataArray();
 
-      data.data.forEach((record) => {
+      let fatalityCount = 0;
+      records.forEach((record) => {
         const recordDateTime = moment(record.crash_date);
-        const hourString = recordDateTime.format("hhA");
-        const dayOfWeek = recordDateTime.format("ddd");
+        const recordHour = recordDateTime.format("hhA");
+        const recordDay = recordDateTime.format("ddd");
 
-        const hourToIncrease = dataArray.find((hour) => hour.key === hourString)
-          .data;
-        let dayToIncrease = hourToIncrease.find((day) => day.key === dayOfWeek);
+        const hourData = dataArray.find((hour) => hour.key === recordHour).data;
+        let dayToIncrement = hourData.find((day) => day.key === recordDay);
 
         switch (crashType.name) {
           case "fatalities":
-            dayToIncrease.data += parseInt(record.death_cnt);
+            dayToIncrement.data += parseInt(record.death_cnt);
+            fatalityCount += parseInt(record.death_cnt);
             break;
           case "seriousInjuries":
-            dayToIncrease.data += parseInt(record.sus_serious_injry_cnt);
+            dayToIncrement.data += parseInt(record.sus_serious_injry_cnt);
             break;
           default:
-            dayToIncrease.data +=
+            dayToIncrement.data +=
               parseInt(record.death_cnt) +
               parseInt(record.sus_serious_injry_cnt);
             break;
         }
       });
-
+      console.log(fatalityCount);
       return dataArray;
     };
 
@@ -132,7 +133,7 @@ const CrashesByTimeOfDay = () => {
     // then fetch records for selected year
     if (crashType.queryStringCrash)
       axios.get(getFatalitiesByYearsAgoUrl()).then((res) => {
-        setHeatmapData(calculateHourBlockTotals(res));
+        setHeatmapData(calculateHourBlockTotals(res.data));
       });
   }, [activeTab, crashType]);
 

--- a/atd-vzv/src/views/summary/CrashesByTimeOfDay.js
+++ b/atd-vzv/src/views/summary/CrashesByTimeOfDay.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useMemo } from "react";
 import axios from "axios";
 import moment from "moment";
 import clonedeep from "lodash.clonedeep";
@@ -36,13 +36,13 @@ const CrashesByTimeOfDay = () => {
     if (activeTab !== tab) setActiveTab(tab);
   };
 
+  const hourBlockArray = useMemo(
+    () => [...Array(24).keys()].map((hour) => moment({ hour }).format("hhA")),
+    []
+  );
+
   useEffect(() => {
     const dayOfWeekArray = moment.weekdaysShort();
-
-    const hourBlockArray = [];
-    for (let hour = 0; hour < 24; hour++) {
-      hourBlockArray.push(moment({ hour }).format("hhA"));
-    }
 
     const buildDataArray = () => {
       // This array holds weekday totals for each hour window within a day
@@ -102,7 +102,7 @@ const CrashesByTimeOfDay = () => {
       axios.get(getFatalitiesByYearsAgoUrl()).then((res) => {
         setHeatmapData(calculateHourBlockTotals(res.data));
       });
-  }, [activeTab, crashType]);
+  }, [activeTab, crashType, hourBlockArray]);
 
   const formatValue = (d) => {
     const value = d.data.value ? d.data.value : 0;

--- a/atd-vzv/src/views/summary/CrashesByTimeOfDay.js
+++ b/atd-vzv/src/views/summary/CrashesByTimeOfDay.js
@@ -36,23 +36,6 @@ const CrashesByTimeOfDay = () => {
   };
 
   useEffect(() => {
-    // [
-    //   {
-    //     key: "12AM",
-    //     data: [
-    //       { key: "Mon", data: 3 },
-    //       { key: "Sun", data: 1 },
-    //     ],
-    //   },
-    //   {
-    //     key: "01AM",
-    //     data: [
-    //       { key: "Mon", data: 3 },
-    //       { key: "Sun", data: 1 },
-    //     ],
-    //   },
-    // ]
-
     const dayOfWeekArray = moment.weekdaysShort();
 
     const hourBlockArray = [
@@ -82,37 +65,33 @@ const CrashesByTimeOfDay = () => {
       "11PM",
     ];
 
-    let dataArray = [];
-
-    // This array holds weekday totals for each hour window within a day
-    // Heatmap expects array of weekday total objs to be reversed in sequence
-    const hourWindowTotalsByDay = dayOfWeekArray
-      .map((day) => ({ key: day, data: 0 }))
-      .reverse();
-
     const buildDataArray = () => {
-      dataArray = [];
-      hourBlockArray.forEach((hour) => {
-        let hourObject = {
-          key: hour,
-          data: [],
-        };
-        dayOfWeekArray.forEach((day) => {
-          let dayObject = {
-            key: day,
-            data: 0,
-          };
-          hourObject.data.push(dayObject);
-        });
+      // This array holds weekday totals for each hour window within a day
+      // Heatmap expects array of weekday total objs to be reversed in order
+      const hourWindowTotalsByDay = dayOfWeekArray
+        .map((day) => ({ key: day, data: 0 }))
+        .reverse();
 
-        hourObject.data.reverse();
-
-        dataArray.push(hourObject);
-      });
+      // Return array of objs for each hour window that holds totals of each day of the week
+      // [
+      //   {
+      //     key: "12AM",
+      //     data: [
+      //       { key: "Mon", data: 3 },
+      //       { key: "Sun", data: 1 },
+      //     ],
+      //   },
+      //   ...
+      // ]
+      return hourBlockArray.map((hour) => ({
+        key: hour,
+        data: hourWindowTotalsByDay,
+      }));
     };
 
     const calculateHourBlockTotals = (data) => {
-      buildDataArray();
+      const dataArray = buildDataArray();
+      debugger;
       data.data.forEach((record) => {
         const date = new Date(record.crash_date);
         const dayOfWeek = date.getDay();
@@ -228,23 +207,7 @@ const CrashesByTimeOfDay = () => {
         <Col>
           <Heatmap
             height={267}
-            // data={heatmapData}
-            data={[
-              {
-                key: "12AM",
-                data: [
-                  { key: "Mon", data: 3 },
-                  { key: "Sun", data: 1 },
-                ],
-              },
-              {
-                key: "01AM",
-                data: [
-                  { key: "Mon", data: 3 },
-                  { key: "Sun", data: 1 },
-                ],
-              },
-            ]}
+            data={heatmapData}
             series={
               <HeatmapSeries
                 colorScheme={[

--- a/atd-vzv/src/views/summary/CrashesByTimeOfDay.js
+++ b/atd-vzv/src/views/summary/CrashesByTimeOfDay.js
@@ -84,6 +84,12 @@ const CrashesByTimeOfDay = () => {
 
     let dataArray = [];
 
+    // This array holds weekday totals for each hour window within a day
+    // Heatmap expects array of weekday total objs to be reversed in sequence
+    const hourWindowTotalsByDay = dayOfWeekArray
+      .map((day) => ({ key: day, data: 0 }))
+      .reverse();
+
     const buildDataArray = () => {
       dataArray = [];
       hourBlockArray.forEach((hour) => {

--- a/atd-vzv/src/views/summary/queries/socrataQueries.js
+++ b/atd-vzv/src/views/summary/queries/socrataQueries.js
@@ -1,6 +1,7 @@
 import { isDevelopment } from "../../../constants/nav";
 
-const crashDatasetID = isDevelopment ? "3aut-fhzp" : "y2wy-tgr5";
+// const crashDatasetID = isDevelopment ? "3aut-fhzp" : "y2wy-tgr5";
+const crashDatasetID = "y2wy-tgr5";
 const personDatasetID = isDevelopment ? "v3x4-fjgm" : "xecs-rpy9";
 
 export const crashEndpointUrl = `https://data.austintexas.gov/resource/${crashDatasetID}.json`;

--- a/atd-vzv/src/views/summary/queries/socrataQueries.js
+++ b/atd-vzv/src/views/summary/queries/socrataQueries.js
@@ -1,7 +1,6 @@
 import { isDevelopment } from "../../../constants/nav";
 
-// const crashDatasetID = isDevelopment ? "3aut-fhzp" : "y2wy-tgr5";
-const crashDatasetID = "y2wy-tgr5";
+const crashDatasetID = isDevelopment ? "3aut-fhzp" : "y2wy-tgr5";
 const personDatasetID = isDevelopment ? "v3x4-fjgm" : "xecs-rpy9";
 
 export const crashEndpointUrl = `https://data.austintexas.gov/resource/${crashDatasetID}.json`;


### PR DESCRIPTION
Closes https://github.com/cityofaustin/atd-data-tech/issues/2791

This PR fixes a bug where the y-axis was being plotted in the "By Time of Day" heatmap in reverse order. It also refactors the code that builds the data structure fed to the heatmap and the calculations for fatalities/serious injuries.

### Before
<img width="626" alt="Screen Shot 2020-07-06 at 3 00 04 PM" src="https://user-images.githubusercontent.com/37249039/86636616-2089ec00-bf9a-11ea-9af0-a437be1a5156.png">

### After
<img width="626" alt="Screen Shot 2020-07-06 at 2 59 39 PM" src="https://user-images.githubusercontent.com/37249039/86636642-27b0fa00-bf9a-11ea-86a4-bc04eb726926.png">
