### PR TITLE
VZV | Map | Date picker updates

### DIFF
--- a/atd-vzv/public/index.html
+++ b/atd-vzv/public/index.html
@@ -3,7 +3,10 @@
   <head>
     <meta charset="utf-8" />
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, maximum-scale=1.0, user-scalable=0"
+    />
     <meta name="theme-color" content="#000000" />
     <meta
       name="description"

--- a/atd-vzv/src/views/map/Map.js
+++ b/atd-vzv/src/views/map/Map.js
@@ -76,30 +76,29 @@ const Map = () => {
   useEffect(() => {
     // Sort and count crash data into fatality and injury subsets
     const sortAndCountMapData = (data) => {
-      const crashCounts = {};
-      const features = data.features.reduce(
-        (acc, feature) => {
-          crashCounts["injury"] =
-            (crashCounts["injury"] || 0) +
-            parseInt(feature.properties.sus_serious_injry_cnt);
+      const crashCounts = { injury: 0, fatality: 0 };
+      const features =
+        data.features &&
+        data.features.reduce(
+          (acc, feature) => {
+            crashCounts["injury"] += parseInt(
+              feature.properties.sus_serious_injry_cnt
+            );
+            crashCounts["fatality"] += parseInt(feature.properties.death_cnt);
 
-          crashCounts["fatality"] =
-            (crashCounts["fatality"] || 0) +
-            parseInt(feature.properties.death_cnt);
-
-          if (parseInt(feature.properties.sus_serious_injry_cnt) > 0) {
-            acc.injuries.features.push(feature);
+            if (parseInt(feature.properties.sus_serious_injry_cnt) > 0) {
+              acc.injuries.features.push(feature);
+            }
+            if (parseInt(feature.properties.death_cnt) > 0) {
+              acc.fatalities.features.push(feature);
+            }
+            return acc;
+          },
+          {
+            fatalities: { ...data, features: [] },
+            injuries: { ...data, features: [] },
           }
-          if (parseInt(feature.properties.death_cnt) > 0) {
-            acc.fatalities.features.push(feature);
-          }
-          return acc;
-        },
-        {
-          fatalities: { ...data, features: [] },
-          injuries: { ...data, features: [] },
-        }
-      );
+        );
 
       setCrashCounts(crashCounts);
       return features;

--- a/atd-vzv/src/views/nav/SideMapControlDateRange.js
+++ b/atd-vzv/src/views/nav/SideMapControlDateRange.js
@@ -20,7 +20,11 @@ import {
 import { colors } from "../../constants/colors";
 import { useIsMobile } from "../../constants/responsive";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faRedoAlt, faTimesCircle } from "@fortawesome/free-solid-svg-icons";
+import {
+  faRedoAlt,
+  faTimesCircle,
+  faCalendar,
+} from "@fortawesome/free-solid-svg-icons";
 
 const SideMapControlDateRange = ({ type }) => {
   const [focused, setFocused] = useState(null);
@@ -138,7 +142,7 @@ const SideMapControlDateRange = ({ type }) => {
   // Create year dropdown picker in calendar
   const StyledMonthYearDropdown = styled(UncontrolledDropdown)`
     /* TODO: Figure out headers rendering above */
-    z-index: 1305;
+    /* z-index: 1310 !important; */
   `;
 
   const renderMonthElement = ({ month, onYearSelect }) => {
@@ -194,16 +198,24 @@ const SideMapControlDateRange = ({ type }) => {
     height: 34px;
     border-radius: 4px;
     padding-left: 2px;
-    /* width: 210px; */
+    /* TODO: try wildcard selector with DayPicker_weekHeader_ambd88 for z-index day header issue */
+  `;
+
+  const calendarInputIconStyles = `position: relative;
+    top: 2px;
+    width: 16px;
+    height: 16px;`;
+
+  const StyledCalendarIcon = styled(FontAwesomeIcon)`
+    /* Center and enlarge calendar icon or button */
+    ${calendarInputIconStyles}
+    left: 1px;
   `;
 
   const StyledRedoButton = styled(FontAwesomeIcon)`
     /* Center and enlarge picker reset button */
-    position: relative;
-    top: 2px;
-    /* right: 2px; */
-    width: 16px;
-    height: 16px;
+    ${calendarInputIconStyles}
+    right: 1px;
     cursor: pointer;
   `;
 
@@ -216,7 +228,11 @@ const SideMapControlDateRange = ({ type }) => {
         endDate={end} // momentPropTypes.momentObj or null,
         onDatesChange={handleDateChange} // PropTypes.func.isRequired,
         focusedInput={focused} // PropTypes.oneOf([START_DATE, END_DATE]) or null,
-        onFocusChange={(focusedInput) => setFocused(focusedInput)} // PropTypes.func.isRequired,
+        onFocusChange={(focusedInput) => {
+          setFocused(focusedInput);
+          document.activeElement.blur(); // Do not prompt the keyboard on mobile
+        }} // PropTypes.func.isRequired,
+        keepFocusOnInput
         minDate={dataStartDate}
         maxDate={dataEndDate}
         renderCalendarInfo={() => (isMobile && renderCalendarInfo()) || true} // Render custom close button on mobile
@@ -230,16 +246,24 @@ const SideMapControlDateRange = ({ type }) => {
         isDayBlocked={isOutsideDateLimits} // Grey out dates
       />
       {/* Reset button to restore default date range */}
-      {/* {(start !== mapStartDate || end !== mapEndDate) && ( */}
-      <StyledRedoButton
-        title="Reset to current year"
-        icon={faRedoAlt}
-        color={colors.dark}
-        onClick={() => {
-          setStart(mapStartDate);
-          setEnd(mapEndDate);
-        }}
-      />
+      {start !== mapStartDate || end !== mapEndDate ? (
+        <StyledRedoButton
+          title="Reset to default date range"
+          icon={faRedoAlt}
+          color={colors.dark}
+          onClick={() => {
+            setStart(mapStartDate);
+            setEnd(mapEndDate);
+          }}
+        />
+      ) : (
+        <StyledCalendarIcon
+          title="Default date range"
+          icon={faCalendar}
+          color={colors.dark}
+          onClick={() => null}
+        />
+      )}
     </StyledButtonContainer>
   );
 };

--- a/atd-vzv/src/views/nav/SideMapControlDateRange.js
+++ b/atd-vzv/src/views/nav/SideMapControlDateRange.js
@@ -5,7 +5,16 @@ import aphroditeInterface from "react-with-styles-interface-aphrodite";
 import DefaultTheme from "react-dates/lib/theme/DefaultTheme";
 import styled from "styled-components";
 import { DateRangePicker } from "react-dates";
-import { Input, FormGroup, Form, Col } from "reactstrap";
+import {
+  Input,
+  FormGroup,
+  Form,
+  Col,
+  UncontrolledDropdown,
+  DropdownItem,
+  DropdownMenu,
+  DropdownToggle,
+} from "reactstrap";
 import {
   dataStartDate,
   dataEndDate,
@@ -15,14 +24,11 @@ import {
 import { colors } from "../../constants/colors";
 import { useIsMobile } from "../../constants/responsive";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import {
-  faRedoAlt,
-  faTimesCircle,
-  faTimes,
-} from "@fortawesome/free-solid-svg-icons";
+import { faRedoAlt, faTimesCircle } from "@fortawesome/free-solid-svg-icons";
 
 const SideMapControlDateRange = ({ type }) => {
   const [focused, setFocused] = useState(null);
+  const [dropdownOpen, setDropdownOpen] = useState(false);
   const [start, setStart] = useState(mapStartDate);
   const [end, setEnd] = useState(mapEndDate);
 
@@ -142,27 +148,20 @@ const SideMapControlDateRange = ({ type }) => {
     }
 
     return (
-      <Form className="form-inline justify-content-center">
-        <FormGroup row className="w-75">
-          <Col>
-            <Input
-              type="select"
-              name="select"
-              id="yearSelect"
-              value={month.year()}
-              onChange={(e) => {
-                onYearSelect(month, e.target.value);
+      <UncontrolledDropdown>
+        <DropdownToggle caret>{month.format("MMMM YYYY")}</DropdownToggle>
+        <DropdownMenu>
+          {yearArray.map((year) => (
+            <DropdownItem
+              onClick={(e) => {
+                onYearSelect(month, year);
               }}
             >
-              {yearArray.map((year) => (
-                <option value={year}>
-                  {month.format("MMMM")} {year}
-                </option>
-              ))}
-            </Input>
-          </Col>
-        </FormGroup>
-      </Form>
+              {month.format("MMMM")} {year}
+            </DropdownItem>
+          ))}
+        </DropdownMenu>
+      </UncontrolledDropdown>
     );
   };
 

--- a/atd-vzv/src/views/nav/SideMapControlDateRange.js
+++ b/atd-vzv/src/views/nav/SideMapControlDateRange.js
@@ -55,7 +55,7 @@ const SideMapControlDateRange = ({ type }) => {
       },
       color: {
         ...DefaultTheme.reactDates.color,
-        placeholderText: `${colors.dark}`, // Set to same color as .dropdown-header to overcome z-index issue (hide it)
+        placeholderText: `${colors.dark}`, // Set to same color as .dropdown-header to overcome z-index issue (hide text)
         border: `transparent`, // Hide DateRangePicker border and show StyledButtonContainer instead
         selected: {
           backgroundColor: `${colors.dark}`,
@@ -143,6 +143,7 @@ const SideMapControlDateRange = ({ type }) => {
   // Create year dropdown picker in calendar
   const StyledMonthYearDropdown = styled(UncontrolledDropdown)`
     .dropdown-header {
+      /* Set color and position to hide weekday calendar headers with unchangeable z-index */
       background: ${colors.dark};
       color: ${colors.white};
       position: relative;
@@ -161,7 +162,7 @@ const SideMapControlDateRange = ({ type }) => {
         <DropdownToggle caret color="dark">
           {month.format("MMMM YYYY")}
         </DropdownToggle>
-        <DropdownMenu>
+        <DropdownMenu flip={false}>
           <DropdownItem header className="dropdown-header">
             Choose a year
           </DropdownItem>
@@ -214,19 +215,18 @@ const SideMapControlDateRange = ({ type }) => {
     }
   `;
 
+  // Center and size calendar icon or button
   const calendarInputIconStyles = `position: relative;
     top: 2px;
     width: 16px;
     height: 16px;`;
 
   const StyledCalendarIcon = styled(FontAwesomeIcon)`
-    /* Center and enlarge calendar icon or button */
     ${calendarInputIconStyles}
     left: 1px;
   `;
 
   const StyledRedoButton = styled(FontAwesomeIcon)`
-    /* Center and enlarge picker reset button */
     ${calendarInputIconStyles}
     right: 1px;
     cursor: pointer;
@@ -243,7 +243,7 @@ const SideMapControlDateRange = ({ type }) => {
         focusedInput={focused} // PropTypes.oneOf([START_DATE, END_DATE]) or null,
         onFocusChange={(focusedInput) => {
           setFocused(focusedInput);
-          document.activeElement.blur(); // Do not prompt the keyboard on mobile
+          isMobile && document.activeElement.blur(); // Do not prompt the keyboard on mobile
         }} // PropTypes.func.isRequired,
         keepFocusOnInput
         minDate={dataStartDate}

--- a/atd-vzv/src/views/nav/SideMapControlDateRange.js
+++ b/atd-vzv/src/views/nav/SideMapControlDateRange.js
@@ -138,7 +138,7 @@ const SideMapControlDateRange = ({ type }) => {
   // Create year dropdown picker in calendar
   const StyledMonthYearDropdown = styled(UncontrolledDropdown)`
     /* TODO: Figure out headers rendering above */
-    /* z-index: 1305; */
+    z-index: 1305;
   `;
 
   const renderMonthElement = ({ month, onYearSelect }) => {

--- a/atd-vzv/src/views/nav/SideMapControlDateRange.js
+++ b/atd-vzv/src/views/nav/SideMapControlDateRange.js
@@ -192,44 +192,42 @@ const SideMapControlDateRange = ({ type }) => {
     height: 34px;
     border-radius: 4px;
     padding-left: 2px;
-    width: 210px;
+    /* width: 210px; */
   `;
 
   const StyledRedoButton = styled(FontAwesomeIcon)`
     /* Center and enlarge picker reset button */
     position: relative;
-    top: 5px;
-    right: 2px;
+    top: 2px;
+    /* right: 2px; */
     width: 16px;
     height: 16px;
     cursor: pointer;
   `;
 
   return (
-    <>
-      <StyledButtonContainer className="pr-0 picker-outline">
-        <DateRangePicker
-          startDateId={`start_date_${type}`} // PropTypes.string.isRequired,
-          endDateId={`end_date_${type}`} // PropTypes.string.isRequired,
-          startDate={start} // momentPropTypes.momentObj or null,
-          endDate={end} // momentPropTypes.momentObj or null,
-          onDatesChange={handleDateChange} // PropTypes.func.isRequired,
-          focusedInput={focused} // PropTypes.oneOf([START_DATE, END_DATE]) or null,
-          onFocusChange={(focusedInput) => setFocused(focusedInput)} // PropTypes.func.isRequired,
-          minDate={dataStartDate}
-          maxDate={dataEndDate}
-          renderCalendarInfo={() => (isMobile && renderCalendarInfo()) || true} // Render custom close button on mobile
-          calendarInfoPosition="top" // Position custom close button
-          appendToBody // Allow calendar to pop out over SideDrawer and Map components
-          withFullScreenPortal={isMobile} // Show full screen picker on mobile
-          small
-          renderMonthElement={renderMonthElement} // Render year picker
-          orientation={isMobile ? "vertical" : "horizontal"} // More mobile friendly than horizontal
-          isOutsideRange={() => false} // Enable past dates
-          isDayBlocked={isOutsideDateLimits} // Grey out dates
-        />
-        {/* Reset button to restore default date range */}
-      </StyledButtonContainer>
+    <StyledButtonContainer className="pr-0 picker-outline">
+      <DateRangePicker
+        startDateId={`start_date_${type}`} // PropTypes.string.isRequired,
+        endDateId={`end_date_${type}`} // PropTypes.string.isRequired,
+        startDate={start} // momentPropTypes.momentObj or null,
+        endDate={end} // momentPropTypes.momentObj or null,
+        onDatesChange={handleDateChange} // PropTypes.func.isRequired,
+        focusedInput={focused} // PropTypes.oneOf([START_DATE, END_DATE]) or null,
+        onFocusChange={(focusedInput) => setFocused(focusedInput)} // PropTypes.func.isRequired,
+        minDate={dataStartDate}
+        maxDate={dataEndDate}
+        renderCalendarInfo={() => (isMobile && renderCalendarInfo()) || true} // Render custom close button on mobile
+        calendarInfoPosition="top" // Position custom close button
+        appendToBody // Allow calendar to pop out over SideDrawer and Map components
+        withFullScreenPortal={isMobile} // Show full screen picker on mobile
+        small
+        renderMonthElement={renderMonthElement} // Render year picker
+        orientation={isMobile ? "vertical" : "horizontal"} // More mobile friendly than horizontal
+        isOutsideRange={() => false} // Enable past dates
+        isDayBlocked={isOutsideDateLimits} // Grey out dates
+      />
+      {/* Reset button to restore default date range */}
       {/* {(start !== mapStartDate || end !== mapEndDate) && ( */}
       <StyledRedoButton
         title="Reset to current year"
@@ -240,7 +238,7 @@ const SideMapControlDateRange = ({ type }) => {
           setEnd(mapEndDate);
         }}
       />
-    </>
+    </StyledButtonContainer>
   );
 };
 

--- a/atd-vzv/src/views/nav/SideMapControlDateRange.js
+++ b/atd-vzv/src/views/nav/SideMapControlDateRange.js
@@ -55,6 +55,7 @@ const SideMapControlDateRange = ({ type }) => {
       },
       color: {
         ...DefaultTheme.reactDates.color,
+        placeholderText: `${colors.dark}`,
         border: `transparent`, // Hide DateRangePicker border and show StyledButtonContainer instead
         selected: {
           backgroundColor: `${colors.dark}`,
@@ -141,8 +142,12 @@ const SideMapControlDateRange = ({ type }) => {
 
   // Create year dropdown picker in calendar
   const StyledMonthYearDropdown = styled(UncontrolledDropdown)`
-    /* TODO: Figure out headers rendering above */
-    /* z-index: 1310 !important; */
+    .dropdown-header {
+      background: ${colors.dark};
+      color: ${colors.white};
+      position: relative;
+      top: -2px;
+    }
   `;
 
   const renderMonthElement = ({ month, onYearSelect }) => {
@@ -157,6 +162,9 @@ const SideMapControlDateRange = ({ type }) => {
           {month.format("MMMM YYYY")}
         </DropdownToggle>
         <DropdownMenu>
+          <DropdownItem header className="dropdown-header">
+            Choose a year
+          </DropdownItem>
           {yearArray.map((year) => (
             <DropdownItem
               key={`${month.format("MMMM")}-${year}`}
@@ -198,7 +206,11 @@ const SideMapControlDateRange = ({ type }) => {
     height: 34px;
     border-radius: 4px;
     padding-left: 2px;
-    /* TODO: try wildcard selector with DayPicker_weekHeader_ambd88 for z-index day header issue */
+
+    /* Center start and end date inputs */
+    [class^="DateInput_"] {
+      text-align: center;
+    }
   `;
 
   const calendarInputIconStyles = `position: relative;

--- a/atd-vzv/src/views/nav/SideMapControlDateRange.js
+++ b/atd-vzv/src/views/nav/SideMapControlDateRange.js
@@ -15,7 +15,11 @@ import {
 import { colors } from "../../constants/colors";
 import { useIsMobile } from "../../constants/responsive";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faTimesCircle } from "@fortawesome/free-solid-svg-icons";
+import {
+  faRedoAlt,
+  faTimesCircle,
+  faTimes,
+} from "@fortawesome/free-solid-svg-icons";
 
 const SideMapControlDateRange = ({ type }) => {
   const [focused, setFocused] = useState(null);
@@ -188,52 +192,55 @@ const SideMapControlDateRange = ({ type }) => {
     height: 34px;
     border-radius: 4px;
     padding-left: 2px;
+    width: 210px;
+  `;
 
+  const StyledRedoButton = styled(FontAwesomeIcon)`
     /* Center and enlarge picker reset button */
-    .reset-button {
-      position: relative;
-      top: 5px;
-      right: 2px;
-      width: 22px;
-      height: 22px;
-      cursor: pointer;
-    }
+    position: relative;
+    top: 5px;
+    right: 2px;
+    width: 16px;
+    height: 16px;
+    cursor: pointer;
   `;
 
   return (
-    <StyledButtonContainer className="pr-0 picker-outline w-100">
-      <DateRangePicker
-        startDateId={`start_date_${type}`} // PropTypes.string.isRequired,
-        endDateId={`end_date_${type}`} // PropTypes.string.isRequired,
-        startDate={start} // momentPropTypes.momentObj or null,
-        endDate={end} // momentPropTypes.momentObj or null,
-        onDatesChange={handleDateChange} // PropTypes.func.isRequired,
-        focusedInput={focused} // PropTypes.oneOf([START_DATE, END_DATE]) or null,
-        onFocusChange={(focusedInput) => setFocused(focusedInput)} // PropTypes.func.isRequired,
-        minDate={dataStartDate}
-        maxDate={dataEndDate}
-        renderCalendarInfo={() => (isMobile && renderCalendarInfo()) || true} // Render custom close button on mobile
-        calendarInfoPosition="top" // Position custom close button
-        appendToBody // Allow calendar to pop out over SideDrawer and Map components
-        withFullScreenPortal={isMobile} // Show full screen picker on mobile
-        small
-        renderMonthElement={renderMonthElement} // Render year picker
-        orientation={isMobile ? "vertical" : "horizontal"} // More mobile friendly than horizontal
-        isOutsideRange={() => false} // Enable past dates
-        isDayBlocked={isOutsideDateLimits} // Grey out dates
-      />
-      {/* Reset button to restore default date range */}
-      <FontAwesomeIcon
-        className="reset-button"
+    <>
+      <StyledButtonContainer className="pr-0 picker-outline">
+        <DateRangePicker
+          startDateId={`start_date_${type}`} // PropTypes.string.isRequired,
+          endDateId={`end_date_${type}`} // PropTypes.string.isRequired,
+          startDate={start} // momentPropTypes.momentObj or null,
+          endDate={end} // momentPropTypes.momentObj or null,
+          onDatesChange={handleDateChange} // PropTypes.func.isRequired,
+          focusedInput={focused} // PropTypes.oneOf([START_DATE, END_DATE]) or null,
+          onFocusChange={(focusedInput) => setFocused(focusedInput)} // PropTypes.func.isRequired,
+          minDate={dataStartDate}
+          maxDate={dataEndDate}
+          renderCalendarInfo={() => (isMobile && renderCalendarInfo()) || true} // Render custom close button on mobile
+          calendarInfoPosition="top" // Position custom close button
+          appendToBody // Allow calendar to pop out over SideDrawer and Map components
+          withFullScreenPortal={isMobile} // Show full screen picker on mobile
+          small
+          renderMonthElement={renderMonthElement} // Render year picker
+          orientation={isMobile ? "vertical" : "horizontal"} // More mobile friendly than horizontal
+          isOutsideRange={() => false} // Enable past dates
+          isDayBlocked={isOutsideDateLimits} // Grey out dates
+        />
+        {/* Reset button to restore default date range */}
+      </StyledButtonContainer>
+      {/* {(start !== mapStartDate || end !== mapEndDate) && ( */}
+      <StyledRedoButton
         title="Reset to current year"
-        icon={faTimesCircle}
+        icon={faRedoAlt}
         color={colors.dark}
         onClick={() => {
           setStart(mapStartDate);
           setEnd(mapEndDate);
         }}
       />
-    </StyledButtonContainer>
+    </>
   );
 };
 

--- a/atd-vzv/src/views/nav/SideMapControlDateRange.js
+++ b/atd-vzv/src/views/nav/SideMapControlDateRange.js
@@ -6,10 +6,6 @@ import DefaultTheme from "react-dates/lib/theme/DefaultTheme";
 import styled from "styled-components";
 import { DateRangePicker } from "react-dates";
 import {
-  Input,
-  FormGroup,
-  Form,
-  Col,
   UncontrolledDropdown,
   DropdownItem,
   DropdownMenu,
@@ -28,7 +24,6 @@ import { faRedoAlt, faTimesCircle } from "@fortawesome/free-solid-svg-icons";
 
 const SideMapControlDateRange = ({ type }) => {
   const [focused, setFocused] = useState(null);
-  const [dropdownOpen, setDropdownOpen] = useState(false);
   const [start, setStart] = useState(mapStartDate);
   const [end, setEnd] = useState(mapEndDate);
 
@@ -141,6 +136,11 @@ const SideMapControlDateRange = ({ type }) => {
   const isMobile = useIsMobile();
 
   // Create year dropdown picker in calendar
+  const StyledMonthYearDropdown = styled(UncontrolledDropdown)`
+    /* TODO: Figure out headers rendering above */
+    /* z-index: 1305; */
+  `;
+
   const renderMonthElement = ({ month, onYearSelect }) => {
     let yearArray = [];
     for (let i = dataStartDate.year(); i <= dataEndDate.year(); i++) {
@@ -148,12 +148,15 @@ const SideMapControlDateRange = ({ type }) => {
     }
 
     return (
-      <UncontrolledDropdown>
-        <DropdownToggle caret>{month.format("MMMM YYYY")}</DropdownToggle>
+      <StyledMonthYearDropdown>
+        <DropdownToggle caret color="dark">
+          {month.format("MMMM YYYY")}
+        </DropdownToggle>
         <DropdownMenu>
           {yearArray.map((year) => (
             <DropdownItem
-              onClick={(e) => {
+              key={`${month.format("MMMM")}-${year}`}
+              onClick={() => {
                 onYearSelect(month, year);
               }}
             >
@@ -161,7 +164,7 @@ const SideMapControlDateRange = ({ type }) => {
             </DropdownItem>
           ))}
         </DropdownMenu>
-      </UncontrolledDropdown>
+      </StyledMonthYearDropdown>
     );
   };
 

--- a/atd-vzv/src/views/nav/SideMapControlDateRange.js
+++ b/atd-vzv/src/views/nav/SideMapControlDateRange.js
@@ -55,7 +55,7 @@ const SideMapControlDateRange = ({ type }) => {
       },
       color: {
         ...DefaultTheme.reactDates.color,
-        placeholderText: `${colors.dark}`,
+        placeholderText: `${colors.dark}`, // Set to same color as .dropdown-header to overcome z-index issue (hide it)
         border: `transparent`, // Hide DateRangePicker border and show StyledButtonContainer instead
         selected: {
           backgroundColor: `${colors.dark}`,
@@ -208,7 +208,8 @@ const SideMapControlDateRange = ({ type }) => {
     padding-left: 2px;
 
     /* Center start and end date inputs */
-    [class^="DateInput_"] {
+    [id^="start_date_"],
+    [id^="end_date_"] {
       text-align: center;
     }
   `;
@@ -257,7 +258,7 @@ const SideMapControlDateRange = ({ type }) => {
         isOutsideRange={() => false} // Enable past dates
         isDayBlocked={isOutsideDateLimits} // Grey out dates
       />
-      {/* Reset button to restore default date range */}
+      {/* Show reset button to restore default date range or show calendar icon if default*/}
       {start !== mapStartDate || end !== mapEndDate ? (
         <StyledRedoButton
           title="Reset to default date range"


### PR DESCRIPTION
Closes https://github.com/cityofaustin/atd-data-tech/issues/3222

This PR fixes several bugs with the map date range picker as well as updating the icon displayed to the right of the date range in the sidebar - calendar icon when at default range (not interactive) and a redo icon (instead of an X) for when a custom range is selected (clickable to reset to default range).

#### New default date input icon
<img width="257" alt="Screen Shot 2020-07-08 at 5 35 17 PM" src="https://user-images.githubusercontent.com/37249039/86977121-882e6b80-c141-11ea-8a1d-2d194ad1c673.png">

## Bugs
- In the mobile full screen date picker, focus would remain on the input fields below, a cursor would show through the calendar picker when attempting to choose a date, and the mobile keyboard would appear.
![mobileKeyboardBug](https://user-images.githubusercontent.com/37249039/86976423-0722a480-c140-11ea-80ba-72a78b99b7e2.gif)

- Interacting with the mobile full screen date picker would cause the zoom of the overall window to shift which created vertical and horizontal scroll bars and zoomed the map view which hid the map controls.
#### Before
![calZoomBug](https://user-images.githubusercontent.com/37249039/86976433-0be75880-c140-11ea-93ba-509243ef201e.gif)

#### After
![calZoomBugFix](https://user-images.githubusercontent.com/37249039/86976447-1570c080-c140-11ea-9892-ad4d8e16d0ad.gif)

- Text-align center style on the date inputs applied locally in dev but not in deployed app. This was fixed by adding styles to the ids of the inputs.
#### Before
<img width="257" alt="inputBug" src="https://user-images.githubusercontent.com/37249039/86976600-739da380-c140-11ea-939c-16fc7575f426.png">

#### After
<img width="257" alt="inputFixed" src="https://user-images.githubusercontent.com/37249039/86976608-77c9c100-c140-11ea-95b1-f6561e1a4222.png">

- The map view would crash when fetching a date range with no crash features. This bug stemmed from the Map component where the logic expected features to always be associated with the crash data fetched from Socrata. I added handling for no features.

