### PR TITLE
VZ ETL | Decrease Socrata ETL limit

### DIFF
--- a/atd-etl/app/process_socrata_export.py
+++ b/atd-etl/app/process_socrata_export.py
@@ -72,7 +72,7 @@ for config in query_configs:
     client.replace(config["dataset_uid"], [])
     records = None
     offset = 0
-    limit = 6000
+    limit = 1000
     total_records = 0
 
     # Query records from Hasura and upsert to Socrata


### PR DESCRIPTION
This PR decreases the number of records requested from VZD at a time to avoid script failures.