### PR TITLE
VZV | Summary | Update banner text

### DIFF
--- a/atd-vzv/src/views/summary/Summary.js
+++ b/atd-vzv/src/views/summary/Summary.js
@@ -51,23 +51,38 @@ const Summary = () => {
               version.
             </span>
           </Alert>
-          <Alert
-            style={{
-              backgroundColor: colors.buttonBackground,
-              color: colors.dark,
-              borderStyle: "none",
-            }}
-          >
-            Data through {lastUpdated}. <strong>Crash data</strong>{" "}
-            <InfoPopover config={popoverConfig.map.trafficCrashes} /> includes
-            crashes within City of Austin geographic boundaries, inclusive of
-            all public safety jurisdictions.
-          </Alert>
         </Col>
       </Row>
       <Row className="px-xs-0 mx-xs-0 px-lg-3 mx-lg-4">
         <Col className="px-xs-0">
           <StyledSummary>
+            <Row className="summary-child">
+              <Alert
+                color="secondary"
+                style={{
+                  backgroundColor: colors.white,
+                  color: colors.dark,
+                }}
+                className="mb-0"
+              >
+                <div className="mb-2">
+                  Austin is consistently ranked as one of America's best places
+                  to live, but too many of our fellow Austinites are killed or
+                  seriously injured in traffic crashes each year. To learn more
+                  about what the City of Austin is doing to reduce traffic
+                  deaths and serious injuries in Austin, visit Austin
+                  Transportation's Vision Zero Program website and find updates
+                  on all recent bond-funded mobility projects on the City's
+                  Capital Projects Explorer tool.
+                </div>
+                <div>
+                  Data through {lastUpdated}. <strong>Crash data</strong>{" "}
+                  <InfoPopover config={popoverConfig.map.trafficCrashes} />{" "}
+                  includes crashes within City of Austin geographic boundaries,
+                  inclusive of all public safety jurisdictions.
+                </div>
+              </Alert>
+            </Row>
             <SummaryView />
             <Row>
               {children.map((child, i) => (

--- a/atd-vzv/src/views/summary/Summary.js
+++ b/atd-vzv/src/views/summary/Summary.js
@@ -32,6 +32,17 @@ const Summary = () => {
     [class*=".col-"] {
       padding: 0.75em;
     }
+
+    .banner {
+      background: ${colors.white};
+      color: ${colors.dark};
+    }
+
+    /* Style links for devices that show them as plain text */
+    a {
+      color: ${colors.infoDark};
+      text-decoration: underline;
+    }
   `;
 
   const lastUpdated = moment(dataEndDate).format("MMMM DD, YYYY");
@@ -57,23 +68,31 @@ const Summary = () => {
         <Col className="px-xs-0">
           <StyledSummary>
             <Row className="summary-child">
-              <Alert
-                color="secondary"
-                style={{
-                  backgroundColor: colors.white,
-                  color: colors.dark,
-                }}
-                className="mb-0"
-              >
+              <Alert color="secondary" className="mb-0 banner">
                 <div className="mb-2">
                   Austin is consistently ranked as one of America's best places
                   to live, but too many of our fellow Austinites are killed or
                   seriously injured in traffic crashes each year. To learn more
                   about what the City of Austin is doing to reduce traffic
                   deaths and serious injuries in Austin, visit Austin
-                  Transportation's Vision Zero Program website and find updates
-                  on all recent bond-funded mobility projects on the City's
-                  Capital Projects Explorer tool.
+                  Transportation's Vision Zero Program{" "}
+                  <a
+                    href="https://austintexas.gov/page/programs-and-initiatives"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    website
+                  </a>{" "}
+                  and find updates on all recent bond-funded mobility projects
+                  on the City's{" "}
+                  <a
+                    href="https://capitalprojects.austintexas.gov/projects?categoryId=Mobility%2520Infrastructure:&tab=projects"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    Capital Projects Explorer
+                  </a>{" "}
+                  tool.
                 </div>
                 <div>
                   Data through {lastUpdated}. <strong>Crash data</strong>{" "}

--- a/atd-vzv/src/views/summary/Summary.js
+++ b/atd-vzv/src/views/summary/Summary.js
@@ -34,8 +34,9 @@ const Summary = () => {
     }
 
     .banner {
-      background: ${colors.white};
+      background: ${colors.light};
       color: ${colors.dark};
+      border-style: none;
     }
 
     /* Style links for devices that show them as plain text */
@@ -50,7 +51,6 @@ const Summary = () => {
   return (
     <Container fluid>
       <DataModal />
-      {/* Create whitespace on sides of view until mobile */}
       <Row className="px-xs-0 mx-xs-0 px-lg-3 mx-lg-4 mt-4 mb-0">
         <Col>
           <Alert color="danger">
@@ -64,7 +64,8 @@ const Summary = () => {
           </Alert>
         </Col>
       </Row>
-      <Row className="px-xs-0 mx-xs-0 px-lg-3 mx-lg-4">
+      {/* Create whitespace on sides of view until mobile */}
+      <Row className="px-xs-0 mx-xs-0 px-lg-3 mx-lg-4 mt-xs-3 mt-lg-4">
         <Col className="px-xs-0">
           <StyledSummary>
             <Row className="summary-child">
@@ -73,9 +74,8 @@ const Summary = () => {
                   Austin is consistently ranked as one of America's best places
                   to live, but too many of our fellow Austinites are killed or
                   seriously injured in traffic crashes each year. To learn more
-                  about what the City of Austin is doing to reduce traffic
-                  deaths and serious injuries in Austin, visit Austin
-                  Transportation's Vision Zero Program{" "}
+                  about the City's transportation safety initiatives, visit
+                  Austin Transportation's Vision Zero Program{" "}
                   <a
                     href="https://austintexas.gov/page/programs-and-initiatives"
                     target="_blank"
@@ -83,8 +83,7 @@ const Summary = () => {
                   >
                     website
                   </a>{" "}
-                  and find updates on all recent bond-funded mobility projects
-                  on the City's{" "}
+                  and the City's{" "}
                   <a
                     href="https://capitalprojects.austintexas.gov/projects?categoryId=Mobility%2520Infrastructure:&tab=projects"
                     target="_blank"


### PR DESCRIPTION
Closes https://github.com/cityofaustin/atd-data-tech/issues/3329

This PR updates the grey banner content, and it updates the width of the banner to match the grid below.

#### Updates
<img width="1431" alt="Screen Shot 2020-07-10 at 2 20 22 PM" src="https://user-images.githubusercontent.com/37249039/87195181-298efc00-c2bf-11ea-8c47-cd91024ecfb3.png">
