### PR TITLE
VZV | Map | Date picker opens mobile keyboard on Android devices/tablets

### DIFF
--- a/atd-vzv/src/views/nav/SideMapControlDateRange.js
+++ b/atd-vzv/src/views/nav/SideMapControlDateRange.js
@@ -249,7 +249,7 @@ const SideMapControlDateRange = ({ type }) => {
         focusedInput={focused} // PropTypes.oneOf([START_DATE, END_DATE]) or null,
         onFocusChange={(focusedInput) => {
           setFocused(focusedInput);
-          isMobile && document.activeElement.blur(); // Do not prompt the keyboard on mobile
+          isTablet && document.activeElement.blur(); // Do not prompt the keyboard on mobile/tablet
         }} // PropTypes.func.isRequired,
         keepFocusOnInput
         minDate={dataStartDate}


### PR DESCRIPTION
Closes https://github.com/cityofaustin/atd-data-tech/issues/3354

When investigating the Android keyboard picker, I found that the virtual keyboard opened up on many tablets as well. I changed the condition for preventing the keyboard from opening in as many of these cases as possible but also prompt keyboard entry on desktops.

#### Before
<img width="500" alt="Screen Shot 2020-07-16 at 1 36 36 PM" src="https://user-images.githubusercontent.com/37249039/87709130-6b112280-c769-11ea-913f-ead78f3ee4a7.png">

#### After
<img width="500" alt="Screen Shot 2020-07-16 at 1 36 00 PM" src="https://user-images.githubusercontent.com/37249039/87709133-6d737c80-c769-11ea-89ef-11b78a8ab282.png">
