### PR TITLE
VZV | Summary | Update By Year Chart Type (legend and cumulative chart)

### DIFF
--- a/atd-vzv/public/index.html
+++ b/atd-vzv/public/index.html
@@ -10,7 +10,7 @@
     <meta name="theme-color" content="#000000" />
     <meta
       name="description"
-      content="Web site created using create-react-app"
+      content="A public-facing interactive web app showing crash data related to Vision Zero. View crash data by different categories, including transportation mode, demographic groups impacted, time of day, and location."
     />
     <link rel="apple-touch-icon" href="logo192.png" />
     <!--

--- a/atd-vzv/src/constants/time.js
+++ b/atd-vzv/src/constants/time.js
@@ -54,3 +54,15 @@ export const mapStartDate = moment()
   .startOf("year");
 
 export const mapEndDate = dataEndDate.clone();
+
+// Five year average
+export const fiveYearAvgStartDate = dataEndDate
+  .clone()
+  .startOf("year")
+  .subtract(5, "year")
+  .format("YYYY-MM-DD");
+export const fiveYearAvgEndDate = dataEndDate
+  .clone()
+  .subtract(1, "year")
+  .endOf("year")
+  .format("YYYY-MM-DD");

--- a/atd-vzv/src/views/summary/CrashesByMode.js
+++ b/atd-vzv/src/views/summary/CrashesByMode.js
@@ -226,7 +226,7 @@ const CrashesByMode = () => {
                 width={null}
                 options={{
                   responsive: true,
-                  aspectRatio: 1.8,
+                  aspectRatio: 1.4,
                   maintainAspectRatio: false,
                   scales: {
                     xAxes: [

--- a/atd-vzv/src/views/summary/CrashesByMode.js
+++ b/atd-vzv/src/views/summary/CrashesByMode.js
@@ -226,7 +226,7 @@ const CrashesByMode = () => {
                 width={null}
                 options={{
                   responsive: true,
-                  aspectRatio: 1.4,
+                  aspectRatio: 1.37,
                   maintainAspectRatio: false,
                   scales: {
                     xAxes: [

--- a/atd-vzv/src/views/summary/CrashesByYear.js
+++ b/atd-vzv/src/views/summary/CrashesByYear.js
@@ -26,9 +26,7 @@ const CrashesByYear = () => {
   const [byYearData, setByYearData] = useState([]);
 
   const [avgData, setAvgData] = useState([]);
-  const [avgDataTotal, setAvgDataTotal] = useState(0);
   const [currentYearData, setCurrentYearData] = useState([]);
-  const [currentYearTotal, setCurrentYearDataTotal] = useState(0);
 
   const url = `${crashEndpointUrl}?$query=`;
 
@@ -83,20 +81,11 @@ const CrashesByYear = () => {
                         WHERE sus_serious_injry_cnt > 0 AND ${currentYearDateCondition} ${queryGroupAndOrder}`,
     };
 
-    const sumAndSetMonthlyTotals = (data, key, setter) => {
-      const total = data.reduce(
-        (acc, month) => (acc += parseFloat(month[key])),
-        0
-      );
-      setter(total);
-    };
-
     !!crashType &&
       axios
         .get(url + encodeURIComponent(avgQueries[crashType.name]))
         .then((res) => {
           setAvgData(res.data);
-          sumAndSetMonthlyTotals(res.data, "avg", setAvgDataTotal);
         });
 
     !!crashType &&
@@ -104,7 +93,6 @@ const CrashesByYear = () => {
         .get(url + encodeURIComponent(currentYearQueries[crashType.name]))
         .then((res) => {
           setCurrentYearData(res.data);
-          sumAndSetMonthlyTotals(res.data, "total", setCurrentYearDataTotal);
         });
   }, [crashType, url]);
 
@@ -125,8 +113,6 @@ const CrashesByYear = () => {
           <CrashesByYearAverage
             crashType={crashType}
             avgData={avgData}
-            avgDataTotal={avgDataTotal}
-            currentYearTotal={currentYearTotal}
             currentYearData={currentYearData}
           />
         );

--- a/atd-vzv/src/views/summary/CrashesByYear.js
+++ b/atd-vzv/src/views/summary/CrashesByYear.js
@@ -1,19 +1,17 @@
 import React, { useState, useEffect } from "react";
 import axios from "axios";
-import styled from "styled-components";
 import CrashesByYearCumulative from "./CrashesByYearCumulative";
 import CrashesByYearAverage from "./CrashesByYearAverage";
 import ChartTypeSelector from "./Components/ChartTypeSelector";
 import { Container, Row, Col } from "reactstrap";
-import { colors } from "../../constants/colors";
 
 import CrashTypeSelector from "./Components/CrashTypeSelector";
 import InfoPopover from "../../Components/Popover/InfoPopover";
 import { popoverConfig } from "../../Components/Popover/popoverConfig";
 import { crashEndpointUrl } from "./queries/socrataQueries";
 import {
-  dataEndDate,
-  dataStartDate,
+  fiveYearAvgStartDate,
+  fiveYearAvgEndDate,
   summaryCurrentYearEndDate,
   summaryCurrentYearStartDate,
 } from "../../constants/time";
@@ -31,9 +29,7 @@ const CrashesByYear = () => {
 
   // Fetch data for By Month Average and Cumulative visualizations
   useEffect(() => {
-    const avgDateCondition = `crash_date BETWEEN '${dataStartDate.format(
-      "YYYY-MM-DD"
-    )}' and '${dataEndDate.format("YYYY-MM-DD")}'`;
+    const avgDateCondition = `crash_date BETWEEN '${fiveYearAvgStartDate}' and '${fiveYearAvgEndDate}'`;
     const currentYearDateCondition = `crash_date BETWEEN '${summaryCurrentYearStartDate}' and '${summaryCurrentYearEndDate}'`;
     const queryGroupAndOrder = `GROUP BY month ORDER BY month`;
 

--- a/atd-vzv/src/views/summary/CrashesByYear.js
+++ b/atd-vzv/src/views/summary/CrashesByYear.js
@@ -21,7 +21,7 @@ import {
 const CrashesByYear = () => {
   const chartTypes = ["Average", "Cumulative"];
 
-  const [crashType, setCrashType] = useState([]);
+  const [crashType, setCrashType] = useState(null);
   const [chartType, setChartType] = useState("Average");
   const [byYearData, setByYearData] = useState([]);
 
@@ -49,11 +49,12 @@ const CrashesByYear = () => {
                         WHERE sus_serious_injry_cnt > 0 AND ${byYearDateCondition} ${queryGroupAndOrder}`,
     };
 
-    axios
-      .get(url + encodeURIComponent(avgQueries[crashType.name]))
-      .then((res) => {
-        setByYearData(res.data);
-      });
+    !!crashType &&
+      axios
+        .get(url + encodeURIComponent(avgQueries[crashType.name]))
+        .then((res) => {
+          setByYearData(res.data);
+        });
   }, [crashType]);
 
   // Fetch data for By Month Average and Cumulative visualizations
@@ -92,19 +93,21 @@ const CrashesByYear = () => {
       setter(total);
     };
 
-    axios
-      .get(url + encodeURIComponent(avgQueries[crashType.name]))
-      .then((res) => {
-        setAvgData(res.data);
-        sumAndSetMonthlyTotals(res.data, "avg", setAvgDataTotal);
-      });
+    !!crashType &&
+      axios
+        .get(url + encodeURIComponent(avgQueries[crashType.name]))
+        .then((res) => {
+          setAvgData(res.data);
+          sumAndSetMonthlyTotals(res.data, "avg", setAvgDataTotal);
+        });
 
-    axios
-      .get(url + encodeURIComponent(currentYearQueries[crashType.name]))
-      .then((res) => {
-        setCurrentYearData(res.data);
-        sumAndSetMonthlyTotals(res.data, "total", setCurrentYearDataTotal);
-      });
+    !!crashType &&
+      axios
+        .get(url + encodeURIComponent(currentYearQueries[crashType.name]))
+        .then((res) => {
+          setCurrentYearData(res.data);
+          sumAndSetMonthlyTotals(res.data, "total", setCurrentYearDataTotal);
+        });
   }, [crashType]);
 
   const StyledDiv = styled.div`
@@ -162,40 +165,27 @@ const CrashesByYear = () => {
           <hr />
         </Col>
       </Row>
-      <ChartTypeSelector
-        chartTypes={chartTypes}
-        chartType={chartType}
-        setChartType={setChartType}
-      />
       <Row className="pb-2">
         <Col xs={4} s={2} m={2} l={2} xl={2}>
           <div>
-            <hr
-              className="my-1"
-              style={{
-                border: `4px solid ${colors.buttonBackground}`,
-              }}
-            ></hr>
-            <h3 className="h6 text-center py-1 mb-0">
-              <strong>Year</strong>
-            </h3>
+            <div>
+              <h4 className="h6 text-center my-1 pt-2">
+                <strong>Year</strong>
+              </h4>
+            </div>
             <hr className="my-1"></hr>
             <h3 className="h6 text-center py-1">Total</h3>
           </div>
         </Col>
         {byYearData.map((year) => (
-          <Col xs={4} s={2} m={2} l={2} xl={2}>
+          <Col xs={4} s={2} m={2} l={2} xl={2} key={year.year}>
             <StyledDiv>
               <div className="year-total-div">
-                <hr
-                  className="my-1"
-                  style={{
-                    border: `4px solid ${colors.light}`,
-                  }}
-                ></hr>
-                <h4 className="h6 text-center py-1 mb-0">
-                  <strong>{year.year}</strong>
-                </h4>
+                <div>
+                  <h4 className="h6 text-center my-1 pt-2">
+                    <strong>{year.year}</strong>
+                  </h4>
+                </div>
                 <hr className="my-1"></hr>
                 <h4 className="h6 text-center py-1">{year.total}</h4>
               </div>
@@ -203,7 +193,11 @@ const CrashesByYear = () => {
           </Col>
         ))}
       </Row>
-
+      <ChartTypeSelector
+        chartTypes={chartTypes}
+        chartType={chartType}
+        setChartType={setChartType}
+      />
       <Row className="mt-1">
         <Col>{renderChartByType(chartType)}</Col>
       </Row>

--- a/atd-vzv/src/views/summary/CrashesByYear.js
+++ b/atd-vzv/src/views/summary/CrashesByYear.js
@@ -17,10 +17,10 @@ import {
 } from "../../constants/time";
 
 const CrashesByYear = () => {
-  const chartTypes = ["Average", "Cumulative"];
+  const chartTypes = ["Monthly", "Cumulative"];
 
   const [crashType, setCrashType] = useState(null);
-  const [chartType, setChartType] = useState("Average");
+  const [chartType, setChartType] = useState("Monthly");
 
   const [avgData, setAvgData] = useState([]);
   const [currentYearData, setCurrentYearData] = useState([]);
@@ -68,7 +68,7 @@ const CrashesByYear = () => {
 
   const renderChartByType = (chartType) => {
     switch (chartType) {
-      case "Average":
+      case "Monthly":
         return (
           <CrashesByYearAverage
             crashType={crashType}

--- a/atd-vzv/src/views/summary/CrashesByYear.js
+++ b/atd-vzv/src/views/summary/CrashesByYear.js
@@ -30,31 +30,7 @@ const CrashesByYear = () => {
   const [currentYearData, setCurrentYearData] = useState([]);
   const [currentYearTotal, setCurrentYearDataTotal] = useState(0);
 
-  const renderChartByType = (chartType) => {
-    switch (chartType) {
-      case "Average":
-        return (
-          <CrashesByYearAverage
-            crashType={crashType}
-            avgData={avgData}
-            avgDataTotal={avgDataTotal}
-            currentYearTotal={currentYearTotal}
-            currentYearData={currentYearData}
-          />
-        );
-      case "Cumulative":
-        return (
-          <CrashesByYearCumulative
-            crashType={crashType}
-            avgData={avgData}
-            currentYearData={currentYearData}
-          />
-        );
-      default:
-        return "No chart selected";
-    }
-  };
-
+  // Fetch data for By Year totals
   useEffect(() => {
     const url = `${crashEndpointUrl}?$query=`;
 
@@ -80,6 +56,7 @@ const CrashesByYear = () => {
       });
   }, [crashType]);
 
+  // Fetch data for By Month Average and Cumulative visualizations
   useEffect(() => {
     const url = `${crashEndpointUrl}?$query=`;
 
@@ -139,6 +116,31 @@ const CrashesByYear = () => {
       opacity: 1;
     }
   `;
+
+  const renderChartByType = (chartType) => {
+    switch (chartType) {
+      case "Average":
+        return (
+          <CrashesByYearAverage
+            crashType={crashType}
+            avgData={avgData}
+            avgDataTotal={avgDataTotal}
+            currentYearTotal={currentYearTotal}
+            currentYearData={currentYearData}
+          />
+        );
+      case "Cumulative":
+        return (
+          <CrashesByYearCumulative
+            crashType={crashType}
+            avgData={avgData}
+            currentYearData={currentYearData}
+          />
+        );
+      default:
+        return "No chart selected";
+    }
+  };
 
   return (
     <Container className="m-0 p-0">

--- a/atd-vzv/src/views/summary/CrashesByYear.js
+++ b/atd-vzv/src/views/summary/CrashesByYear.js
@@ -23,37 +23,11 @@ const CrashesByYear = () => {
 
   const [crashType, setCrashType] = useState(null);
   const [chartType, setChartType] = useState("Average");
-  const [byYearData, setByYearData] = useState([]);
 
   const [avgData, setAvgData] = useState([]);
   const [currentYearData, setCurrentYearData] = useState([]);
 
   const url = `${crashEndpointUrl}?$query=`;
-
-  // Fetch data for By Year totals
-  useEffect(() => {
-    const byYearDateCondition = `crash_date BETWEEN '${dataStartDate
-      .clone()
-      .startOf("year")
-      .format("YYYY-MM-DD")}' and '${dataEndDate.format("YYYY-MM-DD")}'`;
-    const queryGroupAndOrder = `GROUP BY year ORDER BY year`;
-
-    const byYearQueries = {
-      fatalities: `SELECT date_extract_y(crash_date) as year, sum(death_cnt) as total
-                   WHERE death_cnt > 0 AND ${byYearDateCondition} ${queryGroupAndOrder}`,
-      fatalitiesAndSeriousInjuries: `SELECT date_extract_y(crash_date) as year, sum(death_cnt) + sum(sus_serious_injry_cnt) as total 
-                                     WHERE (death_cnt > 0 OR sus_serious_injry_cnt > 0) AND ${byYearDateCondition} ${queryGroupAndOrder}`,
-      seriousInjuries: `SELECT date_extract_y(crash_date) as year, sum(sus_serious_injry_cnt) as total
-                        WHERE sus_serious_injry_cnt > 0 AND ${byYearDateCondition} ${queryGroupAndOrder}`,
-    };
-
-    !!crashType &&
-      axios
-        .get(url + encodeURIComponent(byYearQueries[crashType.name]))
-        .then((res) => {
-          setByYearData(res.data);
-        });
-  }, [crashType, url]);
 
   // Fetch data for By Month Average and Cumulative visualizations
   useEffect(() => {
@@ -95,16 +69,6 @@ const CrashesByYear = () => {
           setCurrentYearData(res.data);
         });
   }, [crashType, url]);
-
-  const StyledDiv = styled.div`
-    .year-total-div {
-      color: ${colors.dark};
-      background: ${colors.buttonBackground} 0% 0% no-repeat padding-box;
-      border-radius: 4px;
-      border-style: none;
-      opacity: 1;
-    }
-  `;
 
   const renderChartByType = (chartType) => {
     switch (chartType) {
@@ -148,34 +112,6 @@ const CrashesByYear = () => {
         <Col>
           <hr />
         </Col>
-      </Row>
-      <Row className="pb-2">
-        <Col xs={4} s={2} m={2} l={2} xl={2}>
-          <div>
-            <div>
-              <h4 className="h6 text-center my-1 pt-2">
-                <strong>Year</strong>
-              </h4>
-            </div>
-            <hr className="my-1"></hr>
-            <h3 className="h6 text-center py-1">Total</h3>
-          </div>
-        </Col>
-        {byYearData.map((year) => (
-          <Col xs={4} s={2} m={2} l={2} xl={2} key={year.year}>
-            <StyledDiv>
-              <div className="year-total-div">
-                <div>
-                  <h4 className="h6 text-center my-1 pt-2">
-                    <strong>{year.year}</strong>
-                  </h4>
-                </div>
-                <hr className="my-1"></hr>
-                <h4 className="h6 text-center py-1">{year.total}</h4>
-              </div>
-            </StyledDiv>
-          </Col>
-        ))}
       </Row>
       <ChartTypeSelector
         chartTypes={chartTypes}

--- a/atd-vzv/src/views/summary/CrashesByYear.js
+++ b/atd-vzv/src/views/summary/CrashesByYear.js
@@ -42,7 +42,7 @@ const CrashesByYear = () => {
       </Row>
       <Row>
         <Col>
-          <hr className="mb-2" />
+          <hr />
         </Col>
       </Row>
       <ChartTypeSelector

--- a/atd-vzv/src/views/summary/CrashesByYear.js
+++ b/atd-vzv/src/views/summary/CrashesByYear.js
@@ -1,18 +1,24 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
+import axios from "axios";
+import styled from "styled-components";
 import CrashesByYearCumulative from "./CrashesByYearCumulative";
 import CrashesByYearAverage from "./CrashesByYearAverage";
 import ChartTypeSelector from "./Components/ChartTypeSelector";
 import { Container, Row, Col } from "reactstrap";
+import { colors } from "../../constants/colors";
 
 import CrashTypeSelector from "./Components/CrashTypeSelector";
 import InfoPopover from "../../Components/Popover/InfoPopover";
 import { popoverConfig } from "../../Components/Popover/popoverConfig";
+import { crashEndpointUrl } from "./queries/socrataQueries";
+import { dataEndDate, dataStartDate } from "../../constants/time";
 
 const CrashesByYear = () => {
   const chartTypes = ["Average", "Cumulative"];
 
   const [crashType, setCrashType] = useState([]);
   const [chartType, setChartType] = useState("Average");
+  const [byYearData, setByYearData] = useState([]);
 
   const renderChartByType = (chartType) => {
     switch (chartType) {
@@ -24,6 +30,41 @@ const CrashesByYear = () => {
         return "No chart selected";
     }
   };
+
+  useEffect(() => {
+    const url = `${crashEndpointUrl}?$query=`;
+
+    const byYearDateCondition = `crash_date BETWEEN '${dataStartDate
+      .clone()
+      .startOf("year")
+      .format("YYYY-MM-DD")}' and '${dataEndDate.format("YYYY-MM-DD")}'`;
+    const queryGroupAndOrder = `GROUP BY year ORDER BY year`;
+
+    const avgQueries = {
+      fatalities: `SELECT date_extract_y(crash_date) as year, sum(death_cnt) as total
+                   WHERE death_cnt > 0 AND ${byYearDateCondition} ${queryGroupAndOrder}`,
+      fatalitiesAndSeriousInjuries: `SELECT date_extract_y(crash_date) as year, sum(death_cnt) + sum(sus_serious_injry_cnt) as total 
+                                     WHERE (death_cnt > 0 OR sus_serious_injry_cnt > 0) AND ${byYearDateCondition} ${queryGroupAndOrder}`,
+      seriousInjuries: `SELECT date_extract_y(crash_date) as year, sum(sus_serious_injry_cnt) as total
+                        WHERE sus_serious_injry_cnt > 0 AND ${byYearDateCondition} ${queryGroupAndOrder}`,
+    };
+
+    axios
+      .get(url + encodeURIComponent(avgQueries[crashType.name]))
+      .then((res) => {
+        setByYearData(res.data);
+      });
+  }, [crashType]);
+
+  const StyledDiv = styled.div`
+    .year-total-div {
+      color: ${colors.dark};
+      background: ${colors.buttonBackground} 0% 0% no-repeat padding-box;
+      border-radius: 4px;
+      border-style: none;
+      opacity: 1;
+    }
+  `;
 
   return (
     <Container className="m-0 p-0">
@@ -50,6 +91,43 @@ const CrashesByYear = () => {
         chartType={chartType}
         setChartType={setChartType}
       />
+      <Row className="pb-2">
+        <Col xs={4} s={2} m={2} l={2} xl={2}>
+          <div>
+            <hr
+              className="my-1"
+              style={{
+                border: `4px solid ${colors.buttonBackground}`,
+              }}
+            ></hr>
+            <h3 className="h6 text-center py-1 mb-0">
+              <strong>Year</strong>
+            </h3>
+            <hr className="my-1"></hr>
+            <h3 className="h6 text-center py-1">Total</h3>
+          </div>
+        </Col>
+        {byYearData.map((year) => (
+          <Col xs={4} s={2} m={2} l={2} xl={2}>
+            <StyledDiv>
+              <div className="year-total-div">
+                <hr
+                  className="my-1"
+                  style={{
+                    border: `4px solid ${colors.light}`,
+                  }}
+                ></hr>
+                <h4 className="h6 text-center py-1 mb-0">
+                  <strong>{year.year}</strong>
+                </h4>
+                <hr className="my-1"></hr>
+                <h4 className="h6 text-center py-1">{year.total}</h4>
+              </div>
+            </StyledDiv>
+          </Col>
+        ))}
+      </Row>
+
       <Row className="mt-1">
         <Col>{renderChartByType(chartType)}</Col>
       </Row>

--- a/atd-vzv/src/views/summary/CrashesByYear.js
+++ b/atd-vzv/src/views/summary/CrashesByYear.js
@@ -30,17 +30,17 @@ const CrashesByYear = () => {
   const [currentYearData, setCurrentYearData] = useState([]);
   const [currentYearTotal, setCurrentYearDataTotal] = useState(0);
 
+  const url = `${crashEndpointUrl}?$query=`;
+
   // Fetch data for By Year totals
   useEffect(() => {
-    const url = `${crashEndpointUrl}?$query=`;
-
     const byYearDateCondition = `crash_date BETWEEN '${dataStartDate
       .clone()
       .startOf("year")
       .format("YYYY-MM-DD")}' and '${dataEndDate.format("YYYY-MM-DD")}'`;
     const queryGroupAndOrder = `GROUP BY year ORDER BY year`;
 
-    const avgQueries = {
+    const byYearQueries = {
       fatalities: `SELECT date_extract_y(crash_date) as year, sum(death_cnt) as total
                    WHERE death_cnt > 0 AND ${byYearDateCondition} ${queryGroupAndOrder}`,
       fatalitiesAndSeriousInjuries: `SELECT date_extract_y(crash_date) as year, sum(death_cnt) + sum(sus_serious_injry_cnt) as total 
@@ -51,16 +51,14 @@ const CrashesByYear = () => {
 
     !!crashType &&
       axios
-        .get(url + encodeURIComponent(avgQueries[crashType.name]))
+        .get(url + encodeURIComponent(byYearQueries[crashType.name]))
         .then((res) => {
           setByYearData(res.data);
         });
-  }, [crashType]);
+  }, [crashType, url]);
 
   // Fetch data for By Month Average and Cumulative visualizations
   useEffect(() => {
-    const url = `${crashEndpointUrl}?$query=`;
-
     const avgDateCondition = `crash_date BETWEEN '${dataStartDate.format(
       "YYYY-MM-DD"
     )}' and '${dataEndDate.format("YYYY-MM-DD")}'`;
@@ -108,7 +106,7 @@ const CrashesByYear = () => {
           setCurrentYearData(res.data);
           sumAndSetMonthlyTotals(res.data, "total", setCurrentYearDataTotal);
         });
-  }, [crashType]);
+  }, [crashType, url]);
 
   const StyledDiv = styled.div`
     .year-total-div {

--- a/atd-vzv/src/views/summary/CrashesByYearAverage.js
+++ b/atd-vzv/src/views/summary/CrashesByYearAverage.js
@@ -1,75 +1,18 @@
 import React, { useState, useEffect } from "react";
-import axios from "axios";
 import moment from "moment";
 import styled from "styled-components";
 import { Bar } from "react-chartjs-2";
 import { Container, Col, Row } from "reactstrap";
 
-import { crashEndpointUrl } from "./queries/socrataQueries";
-import {
-  dataEndDate,
-  summaryCurrentYearEndDate,
-  dataStartDate,
-  summaryCurrentYearStartDate,
-} from "../../constants/time";
 import { colors } from "../../constants/colors";
 
-const CrashesByYearAverage = ({ crashType }) => {
+const CrashesByYearAverage = ({
+  avgData,
+  avgDataTotal,
+  currentYearTotal,
+  currentYearData,
+}) => {
   const [chartData, setChartData] = useState({});
-  const [avgData, setAvgData] = useState([]);
-  const [avgDataTotal, setAvgDataTotal] = useState(0);
-  const [currentYearData, setCurrentYearData] = useState([]);
-  const [currentYearTotal, setCurrentYearDataTotal] = useState(0);
-
-  useEffect(() => {
-    const url = `${crashEndpointUrl}?$query=`;
-
-    const avgDateCondition = `crash_date BETWEEN '${dataStartDate.format(
-      "YYYY-MM-DD"
-    )}' and '${dataEndDate.format("YYYY-MM-DD")}'`;
-    const currentYearDateCondition = `crash_date BETWEEN '${summaryCurrentYearStartDate}' and '${summaryCurrentYearEndDate}'`;
-    const queryGroupAndOrder = `GROUP BY month ORDER BY month`;
-
-    const avgQueries = {
-      fatalities: `SELECT date_extract_m(crash_date) as month, sum(death_cnt) / 5 as avg 
-                   WHERE death_cnt > 0 AND ${avgDateCondition} ${queryGroupAndOrder}`,
-      fatalitiesAndSeriousInjuries: `SELECT date_extract_m(crash_date) as month, sum(death_cnt) / 5 + sum(sus_serious_injry_cnt) / 5 as avg 
-                                     WHERE (death_cnt > 0 OR sus_serious_injry_cnt > 0) AND ${avgDateCondition} ${queryGroupAndOrder}`,
-      seriousInjuries: `SELECT date_extract_m(crash_date) as month, sum(sus_serious_injry_cnt) / 5 as avg 
-                        WHERE sus_serious_injry_cnt > 0 AND ${avgDateCondition} ${queryGroupAndOrder}`,
-    };
-
-    const currentYearQueries = {
-      fatalities: `SELECT date_extract_m(crash_date) as month, sum(death_cnt) as total 
-                   WHERE death_cnt > 0 AND ${currentYearDateCondition} ${queryGroupAndOrder}`,
-      fatalitiesAndSeriousInjuries: `SELECT date_extract_m(crash_date) as month, sum(death_cnt) + sum(sus_serious_injry_cnt) as total 
-                                     WHERE (death_cnt > 0 OR sus_serious_injry_cnt > 0) AND ${currentYearDateCondition} ${queryGroupAndOrder}`,
-      seriousInjuries: `SELECT date_extract_m(crash_date) as month, sum(sus_serious_injry_cnt) as total 
-                        WHERE sus_serious_injry_cnt > 0 AND ${currentYearDateCondition} ${queryGroupAndOrder}`,
-    };
-
-    const sumAndSetMonthlyTotals = (data, key, setter) => {
-      const total = data.reduce(
-        (acc, month) => (acc += parseFloat(month[key])),
-        0
-      );
-      setter(total);
-    };
-
-    axios
-      .get(url + encodeURIComponent(avgQueries[crashType.name]))
-      .then((res) => {
-        setAvgData(res.data);
-        sumAndSetMonthlyTotals(res.data, "avg", setAvgDataTotal);
-      });
-
-    axios
-      .get(url + encodeURIComponent(currentYearQueries[crashType.name]))
-      .then((res) => {
-        setCurrentYearData(res.data);
-        sumAndSetMonthlyTotals(res.data, "total", setCurrentYearDataTotal);
-      });
-  }, [crashType]);
 
   useEffect(() => {
     const formatChartData = (avgData, currentYearData) => {
@@ -99,6 +42,7 @@ const CrashesByYearAverage = ({ crashType }) => {
     };
 
     const isDataFetched = !!avgData.length && !!currentYearData.length;
+
     if (isDataFetched) {
       const formattedData = formatChartData(avgData, currentYearData);
       setChartData(formattedData);

--- a/atd-vzv/src/views/summary/CrashesByYearAverage.js
+++ b/atd-vzv/src/views/summary/CrashesByYearAverage.js
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from "react";
 import axios from "axios";
 import moment from "moment";
+import styled from "styled-components";
 import { Bar } from "react-chartjs-2";
 import { Container, Col, Row } from "reactstrap";
 
@@ -92,6 +93,22 @@ const CrashesByYearAverage = ({ crashType }) => {
     }
   }, [avgData, currentYearData]);
 
+  const StyledDiv = styled.div`
+    .year-total-div {
+      color: ${colors.dark};
+      background: ${colors.buttonBackground} 0% 0% no-repeat padding-box;
+      border-radius: 4px;
+      border-style: none;
+      opacity: 1;
+    }
+
+    .year-total-div:hover {
+      cursor: pointer;
+      color: ${colors.buttonBackground};
+      background: dimgray 0% 0% no-repeat padding-box;
+    }
+  `;
+
   return (
     <>
       <Row className="pb-2">
@@ -109,6 +126,40 @@ const CrashesByYearAverage = ({ crashType }) => {
             <hr className="my-1"></hr>
             <h3 className="h6 text-center py-1">Total</h3>
           </div>
+        </Col>
+        <Col xs={4} s={2} m={2} l={2} xl={2}>
+          <StyledDiv>
+            <div className="year-total-div">
+              <hr
+                className="my-1"
+                style={{
+                  border: `4px solid ${colors.viridis3Of6}`,
+                }}
+              ></hr>
+              <h4 className="h6 text-center py-1 mb-0">
+                <strong>Title</strong>
+              </h4>
+              <hr className="my-1"></hr>
+              <h4 className="h6 text-center py-1">Total</h4>
+            </div>
+          </StyledDiv>
+        </Col>
+        <Col xs={4} s={2} m={2} l={2} xl={2}>
+          <StyledDiv>
+            <div className="year-total-div">
+              <hr
+                className="my-1"
+                style={{
+                  border: `4px solid ${colors.viridis1Of6Highest}`,
+                }}
+              ></hr>
+              <h4 className="h6 text-center py-1 mb-0">
+                <strong>Title 1</strong>
+              </h4>
+              <hr className="my-1"></hr>
+              <h4 className="h6 text-center py-1">Total 1</h4>
+            </div>
+          </StyledDiv>
         </Col>
       </Row>
       <Container>

--- a/atd-vzv/src/views/summary/CrashesByYearAverage.js
+++ b/atd-vzv/src/views/summary/CrashesByYearAverage.js
@@ -61,7 +61,7 @@ const CrashesByYearAverage = ({
 
   return (
     <>
-      <Row className="pb-2">
+      {/* <Row className="pb-2">
         <Col xs={4} s={2} m={2} l={2} xl={2}>
           <div>
             <hr
@@ -111,7 +111,7 @@ const CrashesByYearAverage = ({
             </div>
           </StyledDiv>
         </Col>
-      </Row>
+      </Row> */}
       <Container>
         <Bar
           data={chartData}
@@ -121,9 +121,6 @@ const CrashesByYearAverage = ({
             responsive: true,
             aspectRatio: 1.16,
             maintainAspectRatio: false,
-            legend: {
-              display: false,
-            },
             scales: {
               yAxes: [
                 {

--- a/atd-vzv/src/views/summary/CrashesByYearAverage.js
+++ b/atd-vzv/src/views/summary/CrashesByYearAverage.js
@@ -20,13 +20,15 @@ const CrashesByYearAverage = ({ avgData, currentYearData }) => {
         datasets: [
           {
             label: "Five Year Average",
-            backgroundColor: colors.viridis3Of6,
+            backgroundColor: colors.viridis4Of6,
+            hoverBackgroundColor: colors.viridis4Of6,
             data: avgValues,
             barPercentage: 1.0,
           },
           {
             label: "Total Year to Date",
             backgroundColor: colors.viridis1Of6Highest,
+            hoverBackgroundColor: colors.viridis1Of6Highest,
             data: currentYearValues,
             barPercentage: 1.0,
           },
@@ -51,6 +53,9 @@ const CrashesByYearAverage = ({ avgData, currentYearData }) => {
         responsive: true,
         aspectRatio: 1.11,
         maintainAspectRatio: false,
+        tooltips: {
+          mode: "index",
+        },
         scales: {
           yAxes: [
             {

--- a/atd-vzv/src/views/summary/CrashesByYearAverage.js
+++ b/atd-vzv/src/views/summary/CrashesByYearAverage.js
@@ -1,17 +1,10 @@
 import React, { useState, useEffect } from "react";
 import moment from "moment";
-import styled from "styled-components";
 import { Bar } from "react-chartjs-2";
-import { Container, Col, Row } from "reactstrap";
 
 import { colors } from "../../constants/colors";
 
-const CrashesByYearAverage = ({
-  avgData,
-  avgDataTotal,
-  currentYearTotal,
-  currentYearData,
-}) => {
+const CrashesByYearAverage = ({ avgData, currentYearData }) => {
   const [chartData, setChartData] = useState({});
 
   useEffect(() => {
@@ -49,91 +42,29 @@ const CrashesByYearAverage = ({
     }
   }, [avgData, currentYearData]);
 
-  const StyledDiv = styled.div`
-    .year-total-div {
-      color: ${colors.dark};
-      background: ${colors.buttonBackground} 0% 0% no-repeat padding-box;
-      border-radius: 4px;
-      border-style: none;
-      opacity: 1;
-    }
-  `;
-
   return (
-    <>
-      {/* <Row className="pb-2">
-        <Col xs={4} s={2} m={2} l={2} xl={2}>
-          <div>
-            <hr
-              className="my-1"
-              style={{
-                border: `4px solid ${colors.buttonBackground}`,
-              }}
-            ></hr>
-            <h3 className="h6 text-center py-1 mb-0">
-              <strong>Year</strong>
-            </h3>
-            <hr className="my-1"></hr>
-            <h3 className="h6 text-center py-1">Total</h3>
-          </div>
-        </Col>
-        <Col xs={4} s={2} m={2} l={2} xl={2}>
-          <StyledDiv>
-            <div className="year-total-div">
-              <hr
-                className="my-1"
-                style={{
-                  border: `4px solid ${colors.viridis3Of6}`,
-                }}
-              ></hr>
-              <h4 className="h6 text-center py-1 mb-0">
-                <strong>Five Year Average</strong>
-              </h4>
-              <hr className="my-1"></hr>
-              <h4 className="h6 text-center py-1">{avgDataTotal}</h4>
-            </div>
-          </StyledDiv>
-        </Col>
-        <Col xs={4} s={2} m={2} l={2} xl={2}>
-          <StyledDiv>
-            <div className="year-total-div">
-              <hr
-                className="my-1"
-                style={{
-                  border: `4px solid ${colors.viridis1Of6Highest}`,
-                }}
-              ></hr>
-              <h4 className="h6 text-center py-1 mb-0">
-                <strong>{moment().format("YYYY")}</strong>
-              </h4>
-              <hr className="my-1"></hr>
-              <h4 className="h6 text-center py-1">{currentYearTotal}</h4>
-            </div>
-          </StyledDiv>
-        </Col>
-      </Row> */}
-      <Container>
-        <Bar
-          data={chartData}
-          width={null}
-          height={null}
-          options={{
-            responsive: true,
-            aspectRatio: 1.16,
-            maintainAspectRatio: false,
-            scales: {
-              yAxes: [
-                {
-                  ticks: {
-                    beginAtZero: true,
-                  },
-                },
-              ],
+    <Bar
+      data={chartData}
+      width={null}
+      height={null}
+      options={{
+        responsive: true,
+        aspectRatio: 1.11,
+        maintainAspectRatio: false,
+        scales: {
+          yAxes: [
+            {
+              ticks: {
+                beginAtZero: true,
+              },
             },
-          }}
-        />
-      </Container>
-    </>
+          ],
+        },
+        legend: {
+          onClick: (e) => e.stopPropagation(),
+        },
+      }}
+    />
   );
 };
 

--- a/atd-vzv/src/views/summary/CrashesByYearAverage.js
+++ b/atd-vzv/src/views/summary/CrashesByYearAverage.js
@@ -20,13 +20,13 @@ const CrashesByYearAverage = ({ avgData, currentYearData }) => {
         datasets: [
           {
             label: "Five Year Average",
-            backgroundColor: colors.viridis4Of6,
-            hoverBackgroundColor: colors.viridis4Of6,
+            backgroundColor: colors.viridis3Of6,
+            hoverBackgroundColor: colors.viridis3Of6,
             data: avgValues,
             barPercentage: 1.0,
           },
           {
-            label: "Total Year to Date",
+            label: "Current Year",
             backgroundColor: colors.viridis1Of6Highest,
             hoverBackgroundColor: colors.viridis1Of6Highest,
             data: currentYearValues,
@@ -51,7 +51,7 @@ const CrashesByYearAverage = ({ avgData, currentYearData }) => {
       height={null}
       options={{
         responsive: true,
-        aspectRatio: 1.11,
+        aspectRatio: 0.849,
         maintainAspectRatio: false,
         tooltips: {
           mode: "index",

--- a/atd-vzv/src/views/summary/CrashesByYearAverage.js
+++ b/atd-vzv/src/views/summary/CrashesByYearAverage.js
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from "react";
 import axios from "axios";
 import moment from "moment";
 import { Bar } from "react-chartjs-2";
+import { Container, Col, Row } from "reactstrap";
 
 import { crashEndpointUrl } from "./queries/socrataQueries";
 import {
@@ -91,28 +92,47 @@ const CrashesByYearAverage = ({ crashType }) => {
 
   return (
     <>
-      <Bar
-        data={chartData}
-        width={null}
-        height={null}
-        options={{
-          responsive: true,
-          aspectRatio: 0.97,
-          maintainAspectRatio: false,
-          legend: {
-            display: false,
-          },
-          scales: {
-            yAxes: [
-              {
-                ticks: {
-                  beginAtZero: true,
+      <Row className="pb-2">
+        <Col xs={4} s={2} m={2} l={2} xl={2}>
+          <div>
+            <hr
+              className="my-1"
+              style={{
+                border: `4px solid ${colors.buttonBackground}`,
+              }}
+            ></hr>
+            <h3 className="h6 text-center py-1 mb-0">
+              <strong>Year</strong>
+            </h3>
+            <hr className="my-1"></hr>
+            <h3 className="h6 text-center py-1">Total</h3>
+          </div>
+        </Col>
+      </Row>
+      <Container>
+        <Bar
+          data={chartData}
+          width={null}
+          height={null}
+          options={{
+            responsive: true,
+            aspectRatio: 1.16,
+            maintainAspectRatio: false,
+            legend: {
+              display: false,
+            },
+            scales: {
+              yAxes: [
+                {
+                  ticks: {
+                    beginAtZero: true,
+                  },
                 },
-              },
-            ],
-          },
-        }}
-      />
+              ],
+            },
+          }}
+        />
+      </Container>
     </>
   );
 };

--- a/atd-vzv/src/views/summary/CrashesByYearAverage.js
+++ b/atd-vzv/src/views/summary/CrashesByYearAverage.js
@@ -17,7 +17,9 @@ import { colors } from "../../constants/colors";
 const CrashesByYearAverage = ({ crashType }) => {
   const [chartData, setChartData] = useState({});
   const [avgData, setAvgData] = useState([]);
+  const [avgDataTotal, setAvgDataTotal] = useState(0);
   const [currentYearData, setCurrentYearData] = useState([]);
+  const [currentYearTotal, setCurrentYearDataTotal] = useState(0);
 
   useEffect(() => {
     const url = `${crashEndpointUrl}?$query=`;
@@ -46,16 +48,26 @@ const CrashesByYearAverage = ({ crashType }) => {
                         WHERE sus_serious_injry_cnt > 0 AND ${currentYearDateCondition} ${queryGroupAndOrder}`,
     };
 
+    const sumAndSetMonthlyTotals = (data, key, setter) => {
+      const total = data.reduce(
+        (acc, month) => (acc += parseFloat(month[key])),
+        0
+      );
+      setter(total);
+    };
+
     axios
       .get(url + encodeURIComponent(avgQueries[crashType.name]))
       .then((res) => {
         setAvgData(res.data);
+        sumAndSetMonthlyTotals(res.data, "avg", setAvgDataTotal);
       });
 
     axios
       .get(url + encodeURIComponent(currentYearQueries[crashType.name]))
       .then((res) => {
         setCurrentYearData(res.data);
+        sumAndSetMonthlyTotals(res.data, "total", setCurrentYearDataTotal);
       });
   }, [crashType]);
 
@@ -101,12 +113,6 @@ const CrashesByYearAverage = ({ crashType }) => {
       border-style: none;
       opacity: 1;
     }
-
-    .year-total-div:hover {
-      cursor: pointer;
-      color: ${colors.buttonBackground};
-      background: dimgray 0% 0% no-repeat padding-box;
-    }
   `;
 
   return (
@@ -137,10 +143,10 @@ const CrashesByYearAverage = ({ crashType }) => {
                 }}
               ></hr>
               <h4 className="h6 text-center py-1 mb-0">
-                <strong>Title</strong>
+                <strong>Five Year Average</strong>
               </h4>
               <hr className="my-1"></hr>
-              <h4 className="h6 text-center py-1">Total</h4>
+              <h4 className="h6 text-center py-1">{avgDataTotal}</h4>
             </div>
           </StyledDiv>
         </Col>
@@ -154,10 +160,10 @@ const CrashesByYearAverage = ({ crashType }) => {
                 }}
               ></hr>
               <h4 className="h6 text-center py-1 mb-0">
-                <strong>Title 1</strong>
+                <strong>{moment().format("YYYY")}</strong>
               </h4>
               <hr className="my-1"></hr>
-              <h4 className="h6 text-center py-1">Total 1</h4>
+              <h4 className="h6 text-center py-1">{currentYearTotal}</h4>
             </div>
           </StyledDiv>
         </Col>

--- a/atd-vzv/src/views/summary/CrashesByYearCumulative.js
+++ b/atd-vzv/src/views/summary/CrashesByYearCumulative.js
@@ -11,62 +11,47 @@ const CrashesByYearCumulative = ({ avgData, currentYearData }) => {
       const labels = avgData.map((data) =>
         moment({ month: parseInt(data.month) - 1 }).format("MMM")
       );
-      const avgValues = avgData.reduce((acc, data, i) => {
-        i === 0 && acc.push(parseFloat(data.avg));
-        i !== 0 && acc.push(acc[i - 1] + parseFloat(data.avg));
-        return acc;
-      }, []);
-      const currentYearValues = currentYearData.reduce((acc, data, i) => {
-        i === 0 && acc.push(parseFloat(data.total));
-        i !== 0 && acc.push(acc[i - 1] + parseFloat(data.total));
-        return acc;
-      }, []);
+
+      const reduceCumulativeTotals = (data, valueKey) =>
+        data.reduce((acc, data, i) => {
+          i === 0 && acc.push(parseFloat(data[valueKey]));
+          i !== 0 && acc.push(acc[i - 1] + parseFloat(data[valueKey]));
+          return acc;
+        }, []);
+
+      const avgValues = reduceCumulativeTotals(avgData, "avg");
+      const currentValues = reduceCumulativeTotals(currentYearData, "total");
+
+      const formatDataset = (dataArr, label, color) => ({
+        label: label,
+        fill: false,
+        lineTension: 0.1,
+        backgroundColor: color,
+        borderColor: color,
+        borderCapStyle: "butt",
+        borderJoinStyle: "miter",
+        borderWidth: 3.5,
+        pointBorderColor: color,
+        pointBackgroundColor: color,
+        pointBorderWidth: 1,
+        pointHoverRadius: 5,
+        pointHoverBackgroundColor: color,
+        pointHoverBorderColor: color,
+        pointHoverBorderWidth: 2,
+        pointRadius: 1,
+        pointHitRadius: 10,
+        data: dataArr,
+      });
 
       return {
         labels,
         datasets: [
-          {
-            label: "Five Year Average",
-            fill: false,
-            lineTension: 0.1,
-            backgroundColor: colors.viridis3Of6,
-            borderColor: colors.viridis3Of6,
-            borderCapStyle: "butt",
-            borderDash: [],
-            borderDashOffset: 0.0,
-            borderJoinStyle: "miter",
-            pointBorderColor: colors.viridis3Of6,
-            pointBackgroundColor: colors.viridis3Of6,
-            pointBorderWidth: 1,
-            pointHoverRadius: 5,
-            pointHoverBackgroundColor: colors.viridis3Of6,
-            pointHoverBorderColor: colors.viridis3Of6,
-            pointHoverBorderWidth: 2,
-            pointRadius: 1,
-            pointHitRadius: 10,
-            data: avgValues,
-          },
-          {
-            label: "Total Year to Date",
-            fill: false,
-            lineTension: 0.1,
-            backgroundColor: colors.viridis1Of6Highest,
-            borderColor: colors.viridis1Of6Highest,
-            borderCapStyle: "butt",
-            borderDash: [],
-            borderDashOffset: 0.0,
-            borderJoinStyle: "miter",
-            pointBorderColor: colors.viridis1Of6Highest,
-            pointBackgroundColor: colors.viridis1Of6Highest,
-            pointBorderWidth: 1,
-            pointHoverRadius: 5,
-            pointHoverBackgroundColor: colors.viridis1Of6Highest,
-            pointHoverBorderColor: colors.viridis1Of6Highest,
-            pointHoverBorderWidth: 2,
-            pointRadius: 1,
-            pointHitRadius: 10,
-            data: currentYearValues,
-          },
+          formatDataset(avgValues, "Five Year Average", colors.viridis4Of6),
+          formatDataset(
+            currentValues,
+            "Total Year to Date",
+            colors.viridis1Of6Highest
+          ),
         ],
       };
     };

--- a/atd-vzv/src/views/summary/CrashesByYearCumulative.js
+++ b/atd-vzv/src/views/summary/CrashesByYearCumulative.js
@@ -16,13 +16,11 @@ const CrashesByYearCumulative = ({ avgData, currentYearData }) => {
         i !== 0 && acc.push(acc[i - 1] + parseFloat(data.avg));
         return acc;
       }, []);
-      const currentYearValues =
-        // currentYearData.map((data) => data.total);
-        currentYearData.reduce((acc, data, i) => {
-          i === 0 && acc.push(parseInt(data.total));
-          i !== 0 && acc.push(acc[i - 1] + parseInt(data.total));
-          return acc;
-        }, []);
+      const currentYearValues = currentYearData.reduce((acc, data, i) => {
+        i === 0 && acc.push(parseFloat(data.total));
+        i !== 0 && acc.push(acc[i - 1] + parseFloat(data.total));
+        return acc;
+      }, []);
 
       return {
         labels,
@@ -77,7 +75,6 @@ const CrashesByYearCumulative = ({ avgData, currentYearData }) => {
 
     if (isDataFetched) {
       const formattedData = formatChartData(avgData, currentYearData);
-      console.log(formattedData);
       setChartData(formattedData);
     }
   }, [avgData, currentYearData]);
@@ -102,6 +99,9 @@ const CrashesByYearCumulative = ({ avgData, currentYearData }) => {
               },
             },
           ],
+        },
+        legend: {
+          onClick: (e) => e.stopPropagation(),
         },
       }}
     />

--- a/atd-vzv/src/views/summary/CrashesByYearCumulative.js
+++ b/atd-vzv/src/views/summary/CrashesByYearCumulative.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from "react";
+import React, { useState, useEffect } from "react";
 import axios from "axios";
 import moment from "moment";
 import { Line } from "react-chartjs-2";
@@ -13,161 +13,197 @@ import {
 } from "../../constants/time";
 import { colors } from "../../constants/colors";
 
-const CrashesByYearCumulative = ({ crashType }) => {
+const CrashesByYearCumulative = ({ avgData, currentYearData }) => {
   // Set years order ascending
   const chartYearsArray = yearsArray().sort((a, b) => b - a);
 
-  const chartColors = [
-    colors.viridis1Of6Highest,
-    colors.viridis2Of6,
-    colors.viridis3Of6,
-    colors.viridis4Of6,
-    colors.viridis5Of6,
-  ];
-
   const [chartData, setChartData] = useState(null); // {yearInt: [monthTotal, monthTotal, ...]}
-  const [chartLegend, setChartLegend] = useState(null);
-  const [legendColors, setLegendColors] = useState([...chartColors].reverse());
 
-  const chartRef = useRef();
+  // useEffect(() => {
+  //   const calculateYearMonthlyTotals = (data) => {
+  //     // Determine if the data is a complete year or not and which records to process
+  //     const isCurrentYear =
+  //       data.length > 0 &&
+  //       data[0].crash_date.includes(dataEndDate.format("YYYY"));
 
-  useEffect(() => {
-    const calculateYearMonthlyTotals = (data) => {
-      // Determine if the data is a complete year or not and which records to process
-      const isCurrentYear =
-        data.length > 0 &&
-        data[0].crash_date.includes(dataEndDate.format("YYYY"));
+  //     const monthLimit = isCurrentYear ? dataEndDate.format("MM") : "12";
 
-      const monthLimit = isCurrentYear ? dataEndDate.format("MM") : "12";
+  //     let monthTotalArray = [];
+  //     for (let i = 1; i <= parseInt(monthLimit); i++) {
+  //       monthTotalArray.push(0);
+  //     }
 
-      let monthTotalArray = [];
-      for (let i = 1; i <= parseInt(monthLimit); i++) {
-        monthTotalArray.push(0);
-      }
+  //     // Calculate totals for each month in data
+  //     const monthTotals = data.reduce((acc, record) => {
+  //       const recordMonth = moment(record.crash_date).format("MM");
+  //       const monthIndex = parseInt(recordMonth) - 1;
 
-      // Calculate totals for each month in data
-      const monthTotals = data.reduce((acc, record) => {
-        const recordMonth = moment(record.crash_date).format("MM");
-        const monthIndex = parseInt(recordMonth) - 1;
+  //       if (monthIndex < monthTotalArray.length) {
+  //         switch (crashType.name) {
+  //           case "fatalities":
+  //             acc[monthIndex] += parseInt(record.death_cnt);
+  //             break;
+  //           case "seriousInjuries":
+  //             acc[monthIndex] += parseInt(record.sus_serious_injry_cnt);
+  //             break;
+  //           default:
+  //             acc[monthIndex] +=
+  //               parseInt(record.death_cnt) +
+  //               parseInt(record.sus_serious_injry_cnt);
+  //             break;
+  //         }
+  //       }
+  //       return acc;
+  //     }, monthTotalArray);
 
-        if (monthIndex < monthTotalArray.length) {
-          switch (crashType.name) {
-            case "fatalities":
-              acc[monthIndex] += parseInt(record.death_cnt);
-              break;
-            case "seriousInjuries":
-              acc[monthIndex] += parseInt(record.sus_serious_injry_cnt);
-              break;
-            default:
-              acc[monthIndex] +=
-                parseInt(record.death_cnt) +
-                parseInt(record.sus_serious_injry_cnt);
-              break;
-          }
-        }
-        return acc;
-      }, monthTotalArray);
+  //     // Accumulate the monthly totals over the year of data
+  //     const accumulatedTotals = monthTotals.reduce((acc, month, i) => {
+  //       acc.push((month += acc[i - 1] || 0));
+  //       return acc;
+  //     }, []);
 
-      // Accumulate the monthly totals over the year of data
-      const accumulatedTotals = monthTotals.reduce((acc, month, i) => {
-        acc.push((month += acc[i - 1] || 0));
-        return acc;
-      }, []);
+  //     return accumulatedTotals;
+  //   };
 
-      return accumulatedTotals;
-    };
+  //   // Wait for crashType to be passed up from setCrashType component
+  //   if (crashType.queryStringCrash) {
+  //     const getChartData = async () => {
+  //       let newData = {};
+  //       // Use Promise.all to let all requests resolve before setting chart data by year
+  //       await Promise.all(
+  //         yearsArray().map(async (year) => {
+  //           // If getting data for current year (only including years past January), set end of query to last day of previous month,
+  //           // else if getting data for previous years, set end of query to last day of year
+  //           let endDate =
+  //             year.toString() === dataEndDate.format("YYYY")
+  //               ? `${summaryCurrentYearEndDate}T23:59:59`
+  //               : `${year}-12-31T23:59:59`;
+  //           let url = `${crashEndpointUrl}?$where=${crashType.queryStringCrash} AND crash_date between '${year}-01-01T00:00:00' and '${endDate}'&$order=crash_date ASC`;
+  //           await axios.get(url).then((res) => {
+  //             const yearData = calculateYearMonthlyTotals(res.data);
+  //             newData = { ...newData, ...{ [year]: yearData } };
+  //           });
+  //           return null;
+  //         })
+  //       );
+  //       setChartData(newData);
+  //     };
+  //     getChartData();
+  //   }
+  // }, [crashType]);
 
-    // Wait for crashType to be passed up from setCrashType component
-    if (crashType.queryStringCrash) {
-      const getChartData = async () => {
-        let newData = {};
-        // Use Promise.all to let all requests resolve before setting chart data by year
-        await Promise.all(
-          yearsArray().map(async (year) => {
-            // If getting data for current year (only including years past January), set end of query to last day of previous month,
-            // else if getting data for previous years, set end of query to last day of year
-            let endDate =
-              year.toString() === dataEndDate.format("YYYY")
-                ? `${summaryCurrentYearEndDate}T23:59:59`
-                : `${year}-12-31T23:59:59`;
-            let url = `${crashEndpointUrl}?$where=${crashType.queryStringCrash} AND crash_date between '${year}-01-01T00:00:00' and '${endDate}'&$order=crash_date ASC`;
-            await axios.get(url).then((res) => {
-              const yearData = calculateYearMonthlyTotals(res.data);
-              newData = { ...newData, ...{ [year]: yearData } };
-            });
-            return null;
-          })
-        );
-        setChartData(newData);
-      };
-      getChartData();
-    }
-  }, [crashType]);
-
-  useEffect(() => {
-    !!chartRef.current &&
-      !!chartData &&
-      setChartLegend(chartRef.current.chartInstance.generateLegend());
-  }, [chartData, legendColors]);
+  // useEffect(() => {
+  //   !!chartRef.current &&
+  //     !!chartData &&
+  //     setChartLegend(chartRef.current.chartInstance.generateLegend());
+  // }, [chartData, legendColors]);
 
   // Create dataset for each year, data property is an array of cumulative totals by month
-  const createDatasets = () => {
-    const chartDatasets = chartYearsArray.map((year, i) => ({
-      label: year,
-      fill: false,
-      lineTension: 0.1,
-      backgroundColor: chartColors[i], // Legend box
-      borderColor: chartColors[i],
-      borderCapStyle: "butt",
-      borderDash: [],
-      borderDashOffset: 0.0,
-      borderJoinStyle: "miter",
-      pointBorderColor: chartColors[i],
-      pointBackgroundColor: chartColors[i],
-      pointBorderWidth: 1,
-      pointHoverRadius: 5,
-      pointHoverBackgroundColor: chartColors[i],
-      pointHoverBorderColor: chartColors[i],
-      pointHoverBorderWidth: 2,
-      pointRadius: 1,
-      pointHitRadius: 10,
-      data: chartData[year],
-    }));
+  // const createDatasets = () => {
+  //   const chartDatasets = chartYearsArray.map((year, i) => ({
+  //     label: year,
+  //     fill: false,
+  //     lineTension: 0.1,
+  //     backgroundColor: chartColors[i], // Legend box
+  //     borderColor: chartColors[i],
+  //     borderCapStyle: "butt",
+  //     borderDash: [],
+  //     borderDashOffset: 0.0,
+  //     borderJoinStyle: "miter",
+  //     pointBorderColor: chartColors[i],
+  //     pointBackgroundColor: chartColors[i],
+  //     pointBorderWidth: 1,
+  //     pointHoverRadius: 5,
+  //     pointHoverBackgroundColor: chartColors[i],
+  //     pointHoverBorderColor: chartColors[i],
+  //     pointHoverBorderWidth: 2,
+  //     pointRadius: 1,
+  //     pointHitRadius: 10,
+  //     data: chartData[year],
+  //   }));
 
-    return chartDatasets;
-  };
+  //   return chartDatasets;
+  // };
 
-  // Build data objects
-  const data = {
-    labels: moment.monthsShort(),
-    datasets: !!chartData && createDatasets(),
-  };
+  // // Build data objects
+  // const data = {
+  //   labels: moment.monthsShort(),
+  //   datasets: !!chartData && createDatasets(),
+  // };
 
-  const StyledDiv = styled.div`
-    .year-total-div {
-      color: ${colors.dark};
-      background: ${colors.buttonBackground} 0% 0% no-repeat padding-box;
-      border-radius: 4px;
-      border-style: none;
-      opacity: 1;
+  useEffect(() => {
+    const formatChartData = (avgData, currentYearData) => {
+      const labels = avgData.map((data) =>
+        moment({ month: parseInt(data.month) - 1 }).format("MMM")
+      );
+      const avgValues = avgData.map((data) => data.avg);
+      const currentYearValues = currentYearData.map((data) => data.total);
+
+      return {
+        labels,
+        datasets: [
+          {
+            label: "Five Year Average",
+            fill: false,
+            lineTension: 0.1,
+            backgroundColor: colors.viridis3Of6,
+            borderColor: colors.viridis3Of6,
+            borderCapStyle: "butt",
+            borderDash: [],
+            borderDashOffset: 0.0,
+            borderJoinStyle: "miter",
+            pointBorderColor: colors.viridis3Of6,
+            pointBackgroundColor: colors.viridis3Of6,
+            pointBorderWidth: 1,
+            pointHoverRadius: 5,
+            pointHoverBackgroundColor: colors.viridis3Of6,
+            pointHoverBorderColor: colors.viridis3Of6,
+            pointHoverBorderWidth: 2,
+            pointRadius: 1,
+            pointHitRadius: 10,
+            data: avgValues,
+          },
+          {
+            label: "Total Year to Date",
+            fill: false,
+            lineTension: 0.1,
+            backgroundColor: colors.viridis1Of6Highest,
+            borderColor: colors.viridis1Of6Highest,
+            borderCapStyle: "butt",
+            borderDash: [],
+            borderDashOffset: 0.0,
+            borderJoinStyle: "miter",
+            pointBorderColor: colors.viridis1Of6Highest,
+            pointBackgroundColor: colors.viridis1Of6Highest,
+            pointBorderWidth: 1,
+            pointHoverRadius: 5,
+            pointHoverBackgroundColor: colors.viridis1Of6Highest,
+            pointHoverBorderColor: colors.viridis1Of6Highest,
+            pointHoverBorderWidth: 2,
+            pointRadius: 1,
+            pointHitRadius: 10,
+            data: currentYearValues,
+          },
+        ],
+      };
+    };
+
+    const isDataFetched = !!avgData.length && !!currentYearData.length;
+
+    if (isDataFetched) {
+      const formattedData = formatChartData(avgData, currentYearData);
+      console.log(formattedData);
+      setChartData(formattedData);
     }
-
-    .year-total-div:hover {
-      cursor: pointer;
-      color: ${colors.buttonBackground};
-      background: dimgray 0% 0% no-repeat padding-box;
-    }
-  `;
+  }, [avgData, currentYearData]);
 
   return (
     <>
-      {chartLegend}
       {
         // Wrapping the chart in a div prevents it from getting caught in a rerendering loop
         <Container>
           <Line
-            ref={(ref) => (chartRef.current = ref)}
-            data={data}
+            data={chartData}
             height={null}
             width={null}
             options={{
@@ -179,99 +215,6 @@ const CrashesByYearCumulative = ({ crashType }) => {
               },
               legend: {
                 display: false,
-              },
-              legendCallback: function (chart) {
-                return (
-                  <Row className="pb-2">
-                    <Col xs={4} s={2} m={2} l={2} xl={2}>
-                      <div>
-                        <hr
-                          className="my-1"
-                          style={{
-                            border: `4px solid ${colors.buttonBackground}`,
-                          }}
-                        ></hr>
-                        <h3 className="h6 text-center py-1 mb-0">
-                          <strong>Year</strong>
-                        </h3>
-                        <hr className="my-1"></hr>
-                        <h3 className="h6 text-center py-1">Total</h3>
-                      </div>
-                    </Col>
-                    {
-                      // Reverse data and colors arrays and render so they appear chronologically
-                      [...chartYearsArray].reverse().map((year, i) => {
-                        const yearTotalData = chartData[year];
-                        const yearTotal =
-                          yearTotalData[yearTotalData.length - 1];
-                        const legendColor = legendColors[i];
-
-                        const updateLegendColors = () => {
-                          const legendColorsClone = [...legendColors];
-                          legendColor !== colors.buttonBackground
-                            ? legendColorsClone.splice(
-                                i,
-                                1,
-                                colors.buttonBackground
-                              )
-                            : legendColorsClone.splice(
-                                i,
-                                1,
-                                chartColors.reverse()[i]
-                              );
-                          setLegendColors(legendColorsClone);
-                        };
-
-                        const customLegendClickHandler = () => {
-                          const legendItems = [
-                            ...chart.legend.legendItems,
-                          ].reverse();
-                          const legendItem = legendItems[i];
-                          const index = legendItem.datasetIndex;
-                          const ci = chartRef.current.chartInstance.chart;
-                          const meta = ci.getDatasetMeta(index);
-
-                          // See controller.isDatasetVisible comment
-                          meta.hidden =
-                            meta.hidden === null
-                              ? !ci.data.datasets[index].hidden
-                              : null;
-
-                          // We hid a dataset ... rerender the chart
-                          ci.update();
-
-                          // Update legend colors to show data has been hidden
-                          updateLegendColors();
-                        };
-
-                        return (
-                          <Col xs={4} s={2} m={2} l={2} xl={2} key={i}>
-                            <StyledDiv>
-                              <div
-                                className="year-total-div"
-                                onClick={customLegendClickHandler}
-                              >
-                                <hr
-                                  className="my-1"
-                                  style={{
-                                    border: `4px solid ${legendColor}`,
-                                  }}
-                                ></hr>
-                                <h4 className="h6 text-center py-1 mb-0">
-                                  <strong>{!!chartData && year}</strong>
-                                </h4>
-                                <hr className="my-1"></hr>
-                                <h4 className="h6 text-center py-1">
-                                  {!!chartData && yearTotal}
-                                </h4>
-                              </div>
-                            </StyledDiv>
-                          </Col>
-                        );
-                      })
-                    }
-                  </Row>
-                );
               },
             }}
           />

--- a/atd-vzv/src/views/summary/CrashesByYearCumulative.js
+++ b/atd-vzv/src/views/summary/CrashesByYearCumulative.js
@@ -1,143 +1,28 @@
 import React, { useState, useEffect } from "react";
-import axios from "axios";
 import moment from "moment";
 import { Line } from "react-chartjs-2";
-import { Container, Row, Col } from "reactstrap";
-import styled from "styled-components";
-
-import { crashEndpointUrl } from "./queries/socrataQueries";
-import {
-  dataEndDate,
-  summaryCurrentYearEndDate,
-  yearsArray,
-} from "../../constants/time";
 import { colors } from "../../constants/colors";
 
 const CrashesByYearCumulative = ({ avgData, currentYearData }) => {
-  // Set years order ascending
-  const chartYearsArray = yearsArray().sort((a, b) => b - a);
-
-  const [chartData, setChartData] = useState(null); // {yearInt: [monthTotal, monthTotal, ...]}
-
-  // useEffect(() => {
-  //   const calculateYearMonthlyTotals = (data) => {
-  //     // Determine if the data is a complete year or not and which records to process
-  //     const isCurrentYear =
-  //       data.length > 0 &&
-  //       data[0].crash_date.includes(dataEndDate.format("YYYY"));
-
-  //     const monthLimit = isCurrentYear ? dataEndDate.format("MM") : "12";
-
-  //     let monthTotalArray = [];
-  //     for (let i = 1; i <= parseInt(monthLimit); i++) {
-  //       monthTotalArray.push(0);
-  //     }
-
-  //     // Calculate totals for each month in data
-  //     const monthTotals = data.reduce((acc, record) => {
-  //       const recordMonth = moment(record.crash_date).format("MM");
-  //       const monthIndex = parseInt(recordMonth) - 1;
-
-  //       if (monthIndex < monthTotalArray.length) {
-  //         switch (crashType.name) {
-  //           case "fatalities":
-  //             acc[monthIndex] += parseInt(record.death_cnt);
-  //             break;
-  //           case "seriousInjuries":
-  //             acc[monthIndex] += parseInt(record.sus_serious_injry_cnt);
-  //             break;
-  //           default:
-  //             acc[monthIndex] +=
-  //               parseInt(record.death_cnt) +
-  //               parseInt(record.sus_serious_injry_cnt);
-  //             break;
-  //         }
-  //       }
-  //       return acc;
-  //     }, monthTotalArray);
-
-  //     // Accumulate the monthly totals over the year of data
-  //     const accumulatedTotals = monthTotals.reduce((acc, month, i) => {
-  //       acc.push((month += acc[i - 1] || 0));
-  //       return acc;
-  //     }, []);
-
-  //     return accumulatedTotals;
-  //   };
-
-  //   // Wait for crashType to be passed up from setCrashType component
-  //   if (crashType.queryStringCrash) {
-  //     const getChartData = async () => {
-  //       let newData = {};
-  //       // Use Promise.all to let all requests resolve before setting chart data by year
-  //       await Promise.all(
-  //         yearsArray().map(async (year) => {
-  //           // If getting data for current year (only including years past January), set end of query to last day of previous month,
-  //           // else if getting data for previous years, set end of query to last day of year
-  //           let endDate =
-  //             year.toString() === dataEndDate.format("YYYY")
-  //               ? `${summaryCurrentYearEndDate}T23:59:59`
-  //               : `${year}-12-31T23:59:59`;
-  //           let url = `${crashEndpointUrl}?$where=${crashType.queryStringCrash} AND crash_date between '${year}-01-01T00:00:00' and '${endDate}'&$order=crash_date ASC`;
-  //           await axios.get(url).then((res) => {
-  //             const yearData = calculateYearMonthlyTotals(res.data);
-  //             newData = { ...newData, ...{ [year]: yearData } };
-  //           });
-  //           return null;
-  //         })
-  //       );
-  //       setChartData(newData);
-  //     };
-  //     getChartData();
-  //   }
-  // }, [crashType]);
-
-  // useEffect(() => {
-  //   !!chartRef.current &&
-  //     !!chartData &&
-  //     setChartLegend(chartRef.current.chartInstance.generateLegend());
-  // }, [chartData, legendColors]);
-
-  // Create dataset for each year, data property is an array of cumulative totals by month
-  // const createDatasets = () => {
-  //   const chartDatasets = chartYearsArray.map((year, i) => ({
-  //     label: year,
-  //     fill: false,
-  //     lineTension: 0.1,
-  //     backgroundColor: chartColors[i], // Legend box
-  //     borderColor: chartColors[i],
-  //     borderCapStyle: "butt",
-  //     borderDash: [],
-  //     borderDashOffset: 0.0,
-  //     borderJoinStyle: "miter",
-  //     pointBorderColor: chartColors[i],
-  //     pointBackgroundColor: chartColors[i],
-  //     pointBorderWidth: 1,
-  //     pointHoverRadius: 5,
-  //     pointHoverBackgroundColor: chartColors[i],
-  //     pointHoverBorderColor: chartColors[i],
-  //     pointHoverBorderWidth: 2,
-  //     pointRadius: 1,
-  //     pointHitRadius: 10,
-  //     data: chartData[year],
-  //   }));
-
-  //   return chartDatasets;
-  // };
-
-  // // Build data objects
-  // const data = {
-  //   labels: moment.monthsShort(),
-  //   datasets: !!chartData && createDatasets(),
-  // };
+  const [chartData, setChartData] = useState({});
 
   useEffect(() => {
     const formatChartData = (avgData, currentYearData) => {
       const labels = avgData.map((data) =>
         moment({ month: parseInt(data.month) - 1 }).format("MMM")
       );
-      const avgValues = avgData.map((data) => data.avg);
-      const currentYearValues = currentYearData.map((data) => data.total);
+      const avgValues = avgData.reduce((acc, data, i) => {
+        i === 0 && acc.push(parseFloat(data.avg));
+        i !== 0 && acc.push(acc[i - 1] + parseFloat(data.avg));
+        return acc;
+      }, []);
+      const currentYearValues =
+        // currentYearData.map((data) => data.total);
+        currentYearData.reduce((acc, data, i) => {
+          i === 0 && acc.push(parseInt(data.total));
+          i !== 0 && acc.push(acc[i - 1] + parseInt(data.total));
+          return acc;
+        }, []);
 
       return {
         labels,
@@ -198,29 +83,28 @@ const CrashesByYearCumulative = ({ avgData, currentYearData }) => {
   }, [avgData, currentYearData]);
 
   return (
-    <>
-      {
-        // Wrapping the chart in a div prevents it from getting caught in a rerendering loop
-        <Container>
-          <Line
-            data={chartData}
-            height={null}
-            width={null}
-            options={{
-              responsive: true,
-              aspectRatio: 1.16,
-              maintainAspectRatio: false,
-              tooltips: {
-                mode: "x",
+    <Line
+      data={chartData}
+      height={null}
+      width={null}
+      options={{
+        responsive: true,
+        aspectRatio: 1.16,
+        maintainAspectRatio: false,
+        tooltips: {
+          mode: "x",
+        },
+        scales: {
+          yAxes: [
+            {
+              ticks: {
+                beginAtZero: true,
               },
-              legend: {
-                display: false,
-              },
-            }}
-          />
-        </Container>
-      }
-    </>
+            },
+          ],
+        },
+      }}
+    />
   );
 };
 

--- a/atd-vzv/src/views/summary/CrashesByYearCumulative.js
+++ b/atd-vzv/src/views/summary/CrashesByYearCumulative.js
@@ -16,6 +16,7 @@ const CrashesByYearCumulative = ({ avgData, currentYearData }) => {
         data.reduce((acc, data, i) => {
           const num = parseFloat(data[valueKey]);
           const roundNum = (num) => Math.floor(num * 100) / 100;
+
           i === 0 && acc.push(roundNum(num));
           i !== 0 && acc.push(roundNum(acc[i - 1] + num));
           return acc;
@@ -48,10 +49,10 @@ const CrashesByYearCumulative = ({ avgData, currentYearData }) => {
       return {
         labels,
         datasets: [
-          formatDataset(avgValues, "Five Year Average", colors.viridis4Of6),
+          formatDataset(avgValues, "Five Year Average", colors.viridis3Of6),
           formatDataset(
             currentValues,
-            "Total Year to Date",
+            "Current Year",
             colors.viridis1Of6Highest
           ),
         ],
@@ -73,7 +74,7 @@ const CrashesByYearCumulative = ({ avgData, currentYearData }) => {
       width={null}
       options={{
         responsive: true,
-        aspectRatio: 1.16,
+        aspectRatio: 0.849,
         maintainAspectRatio: false,
         tooltips: {
           mode: "x",

--- a/atd-vzv/src/views/summary/CrashesByYearCumulative.js
+++ b/atd-vzv/src/views/summary/CrashesByYearCumulative.js
@@ -14,8 +14,10 @@ const CrashesByYearCumulative = ({ avgData, currentYearData }) => {
 
       const reduceCumulativeTotals = (data, valueKey) =>
         data.reduce((acc, data, i) => {
-          i === 0 && acc.push(parseFloat(data[valueKey]));
-          i !== 0 && acc.push(acc[i - 1] + parseFloat(data[valueKey]));
+          const num = parseFloat(data[valueKey]);
+          const roundNum = (num) => Math.floor(num * 100) / 100;
+          i === 0 && acc.push(roundNum(num));
+          i !== 0 && acc.push(roundNum(acc[i - 1] + num));
           return acc;
         }, []);
 


### PR DESCRIPTION
Closes part of https://github.com/cityofaustin/atd-data-tech/issues/3391

This PR adds a legend to the By Year & Month average and cumulative charts and also pulls the data requests to the `CrashesByYear` components so fewer requests are needed for the two chart types. Existing code was also removed to make the charts less interactive as defined in the requirements.

There are some tasks needed before merge (along with feedback):
- [x] Update height of cumulative chart to match the average chart
- [x] Update wording of average chart legend for current year

#### Screen grab
![ByYear](https://user-images.githubusercontent.com/37249039/88595995-c1177d00-d029-11ea-8806-ac175d398c34.gif)

#### By Month (average) with legend
<img width="659" alt="Screen Shot 2020-07-27 at 4 51 57 PM" src="https://user-images.githubusercontent.com/37249039/88595910-8ad9fd80-d029-11ea-92ca-bfc5b6010296.png">

#### By Month (cumulative) with legend
<img width="659" alt="Screen Shot 2020-07-27 at 4 52 00 PM" src="https://user-images.githubusercontent.com/37249039/88595919-90374800-d029-11ea-9826-165165f6ee84.png">
