### PR TITLE
Temp record creation tool

### DIFF
--- a/atd-vzd/migrations/migration_crashes_2020_07_27--2217.sql
+++ b/atd-vzd/migrations/migration_crashes_2020_07_27--2217.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "public"."atd_txdot_crashes" ADD COLUMN "temp_record" bool DEFAULT 'FALSE';
+

--- a/atd-vzd/migrations/migration_crashes_2020_07_27--2217.sql
+++ b/atd-vzd/migrations/migration_crashes_2020_07_27--2217.sql
@@ -1,2 +1,5 @@
 ALTER TABLE "public"."atd_txdot_crashes" ADD COLUMN "temp_record" bool DEFAULT 'FALSE';
 
+-- Creates an index for the column for faster sorting
+create index atd_txdot_crashes_temp_record_index
+	on atd_txdot_crashes (temp_record);

--- a/atd-vze/src/_nav.js
+++ b/atd-vze/src/_nav.js
@@ -69,6 +69,11 @@ export const navigation = roles => {
           url: "/tools/upload_non_cr3",
           icon: "icon-cloud-upload",
         },
+              {
+                name: "Create Crash Record",
+                url: "/tools/create_crash_record",
+                icon: "icon-shield",
+              },
       ],
     },
     {

--- a/atd-vze/src/routes.js
+++ b/atd-vze/src/routes.js
@@ -53,6 +53,7 @@ const AddUser = React.lazy(() => import("./views/Users/AddUser"));
 const EditUser = React.lazy(() => import("./views/Users/EditUser"));
 const ReportsInconsistentKSI = React.lazy(() => import("./views/Reports/ReportsInconsistentKSI"));
 const ToolsUploadNonCR3 = React.lazy(() => import("./views/Tools/ToolsUploadNonCR3"));
+const CreateCrashRecord = React.lazy(() => import("./views/Tools/CreateCrashRecord"));
 // https://github.com/ReactTraining/react-router/tree/master/packages/react-router-config
 // Accept roles arg for role-based access to routes
 const routes = roles => [
@@ -181,6 +182,12 @@ const routes = roles => [
     exact: true,
     name: "Upload Non-CR3 Crashes",
     component: ToolsUploadNonCR3,
+  },
+  (isAdmin(roles) || isItSupervisor(roles)) && {
+    path: "/tools/create_crash_record",
+    exact: true,
+    name: "Create Crash Record",
+    component: CreateCrashRecord,
   },
   (isAdmin(roles) || isItSupervisor(roles)) && {
     path: "/users",

--- a/atd-vze/src/views/Crashes/Crash.js
+++ b/atd-vze/src/views/Crashes/Crash.js
@@ -135,7 +135,7 @@ function Crash(props) {
   };
 
   const {
-    death_cnt: deathCount,
+    atd_fatality_count: deathCount,
     sus_serious_injry_cnt: seriousInjuryCount,
     latitude_primary: latitude,
     longitude_primary: longitude,

--- a/atd-vze/src/views/Tools/CreateCrashRecord.js
+++ b/atd-vze/src/views/Tools/CreateCrashRecord.js
@@ -1,0 +1,93 @@
+import React, { useState, useEffect } from "react";
+import {
+  Button,
+  Card,
+  CardBody,
+  CardHeader,
+  CardFooter,
+  Col,
+  Input,
+  Label,
+  Form,
+  FormGroup,
+  FormText,
+} from "reactstrap";
+
+import { withApollo } from "react-apollo";
+
+import "./CreateCrashRecord.css";
+
+const CreateCrashRecord = () => {
+  return (
+    <Card>
+      <CardHeader>Create New Crash Record Set</CardHeader>
+      <CardBody>
+        <Form action="" method="post" className="form-horizontal">
+          <FormGroup row>
+            <Col md="3">
+              <Label htmlFor="hf-email">Case ID</Label>
+            </Col>
+            <Col xs="12" md="9">
+              <Input
+                type="number"
+                id="hf-case-id"
+                name="hf-case-id"
+                placeholder="Enter Case ID..."
+                // autoComplete="email"
+              />
+              <FormText className="help-block">
+                Please enter the Case ID
+              </FormText>
+            </Col>
+          </FormGroup>
+          <FormGroup row>
+            <Col md="3">
+              <Label htmlFor="hf-fatality-count">Fatality Count</Label>
+            </Col>
+            <Col xs="12" md="9">
+              <Input
+                type="number"
+                id="hf-fatality-count"
+                name="hf-fatality-count"
+                placeholder="Enter Fatality Count..."
+                // autoComplete="current-fatality-count"
+              />
+              <FormText className="help-block">
+                Please enter the Fatality Count
+              </FormText>
+            </Col>
+          </FormGroup>
+          <FormGroup row>
+            <Col md="3">
+              <Label htmlFor="hf-fatality-count">
+                Suspected Serious Injury Count
+              </Label>
+            </Col>
+            <Col xs="12" md="9">
+              <Input
+                type="number"
+                id="hf-fatality-count"
+                name="hf-fatality-count"
+                placeholder="Enter Suspected Serious Injury Count..."
+                // autoComplete="current-fatality-count"
+              />
+              <FormText className="help-block">
+                Please enter the Suspected Serious Injury Count
+              </FormText>
+            </Col>
+          </FormGroup>
+        </Form>
+      </CardBody>
+      <CardFooter>
+        <Button type="submit" size="sm" color="primary">
+          <i className="fa fa-dot-circle-o"></i> Submit
+        </Button>
+        <Button type="reset" size="sm" color="danger">
+          <i className="fa fa-ban"></i> Reset
+        </Button>
+      </CardFooter>
+    </Card>
+  );
+};
+
+export default withApollo(CreateCrashRecord);

--- a/atd-vze/src/views/Tools/CreateCrashRecord.js
+++ b/atd-vze/src/views/Tools/CreateCrashRecord.js
@@ -15,7 +15,7 @@ import {
   FormGroup,
   FormText,
 } from "reactstrap";
-
+import moment from "moment";
 import { withApollo } from "react-apollo";
 import { gql } from "apollo-boost";
 import "./CreateCrashRecord.css";
@@ -26,6 +26,9 @@ const CreateCrashRecord = ({ client }) => {
   const [fatalityCount, setFatalityCount] = useState(0);
   const [susSeriousInjuryCount, setSusSeriousInjuryCount] = useState(0);
   const [successfulNewRecordId, setSuccessfulNewRecordId] = useState(null);
+  const [crashDate, setCrashDate] = useState(
+    moment(new Date()).format("YYYY-MM-DD")
+  );
   const [feedback, setFeedback] = useState(false);
 
   useEffect(() => {
@@ -96,6 +99,7 @@ const CreateCrashRecord = ({ client }) => {
         $crash_fatal_fl: String
         $atd_fatality_count: Int
         $sus_serious_injry_cnt: Int
+        $crash_date: date
       ) {
         insert_atd_txdot_crashes(
           objects: [
@@ -106,6 +110,7 @@ const CreateCrashRecord = ({ client }) => {
               atd_fatality_count: $atd_fatality_count
               sus_serious_injry_cnt: $sus_serious_injry_cnt
               temp_record: true
+              crash_date: $crash_date
             }
           ]
         ) {
@@ -133,6 +138,7 @@ const CreateCrashRecord = ({ client }) => {
       crash_fatal_fl: fatalityCount > 0 ? "Y" : "N",
       atd_fatality_count: fatalityCount,
       sus_serious_injry_cnt: susSeriousInjuryCount,
+      crash_date: crashDate,
     };
 
     client
@@ -202,6 +208,24 @@ const CreateCrashRecord = ({ client }) => {
               />
               <FormText className="help-block">
                 Please enter the Case ID
+              </FormText>
+            </Col>
+          </FormGroup>
+          <FormGroup row>
+            <Col md="3">
+              <Label htmlFor="date-input">Crash Date</Label>
+            </Col>
+            <Col xs="12" md="9">
+              <Input
+                type="date"
+                id="date-input"
+                name="date-input"
+                placeholder="date"
+                value={crashDate}
+                onChange={e => setCrashDate(e.target.value)}
+              />
+              <FormText className="help-block">
+                Please enter the Crash Date
               </FormText>
             </Col>
           </FormGroup>

--- a/atd-vze/src/views/Tools/CreateCrashRecord.js
+++ b/atd-vze/src/views/Tools/CreateCrashRecord.js
@@ -20,15 +20,6 @@ import { withApollo } from "react-apollo";
 import { gql } from "apollo-boost";
 import "./CreateCrashRecord.css";
 
-// TODOS:
-// - [x] validate if I'm generating crash IDs in an acceptable way
-// - [x] pass other variables from form into insert mutation
-// - [x] Add field to prod/stag for temp flag, and add to mutation
-// - [x] Create related records
-// - [x] Show success/error states, offer redirect on success
-// - [ ] Show exisiting placeholder records in table
-// - [ ] Offer delete action for crash record and related records
-
 const CreateCrashRecord = ({ client }) => {
   const [tempId, setTempId] = useState(1000);
   const [caseId, setCaseId] = useState("");

--- a/atd-vze/src/views/Tools/CreateCrashRecord.js
+++ b/atd-vze/src/views/Tools/CreateCrashRecord.js
@@ -14,15 +14,81 @@ import {
 } from "reactstrap";
 
 import { withApollo } from "react-apollo";
+import { gql } from "apollo-boost";
+import { useMutation } from "@apollo/react-hooks";
+
+import moment from "moment";
 
 import "./CreateCrashRecord.css";
 
-const CreateCrashRecord = () => {
+// TODOS:
+// - [ ] validate if I'm generating crash IDs in an acceptable way
+// - [ ] pass other variables from form into insert mutation
+// - [ ] Add field to prod/stag for temp flag, and add to mutation
+// - [ ] Create related records
+// - [ ] Show success/error states, offer redirect on success
+// - [ ] Show exisiting placeholder records in table
+// - [ ] Offer delete action for crash record and related records
+
+const CreateCrashRecord = ({ client }) => {
+  // console.log(...props);
+
+  /**
+   * Handle Create crash record form submit.
+   * @param {SyntheticEvent} e - The event object.
+   */
+  const handleFormSubmit = e => {
+    e.preventDefault();
+
+    const INSERT_ONE_CRASH = gql`
+      mutation insertOneCrash(
+        $crash_id: Int
+        $case_id: String
+        $crash_fatal_fl: String
+        $atd_fatality_count: Int
+        $sus_serious_injry_cnt: Int
+      ) {
+        insert_atd_txdot_crashes_one(
+          object: {
+            crash_id: $crash_id
+            case_id: $case_id
+            crash_fatal_fl: $crash_fatal_fl
+            atd_fatality_count: $atd_fatality_count
+            sus_serious_injry_cnt: $sus_serious_injry_cnt
+          }
+        ) {
+          crash_id
+        }
+      }
+    `;
+
+    // Generate a unique ID to give to the crash record that won't
+    // conflict with future Crash IDs from CRIS and that isn't out
+    // of bounds for the GraphQL Int type.
+    // https://github.com/graphql/graphql-js/issues/292
+    const now = Number(moment(new Date()).format("YYMDHmmss"));
+
+    debugger;
+
+    const variables = {
+      crash_id: now,
+    };
+
+    client
+      .mutate({
+        mutation: INSERT_ONE_CRASH,
+        variables: variables,
+      })
+      .then(res => {
+        console.log(res);
+      });
+  };
+
   return (
     <Card>
-      <CardHeader>Create New Crash Record Set</CardHeader>
-      <CardBody>
-        <Form action="" method="post" className="form-horizontal">
+      <Form onSubmit={e => handleFormSubmit(e)} className="form-horizontal">
+        <CardHeader>Create New Crash Record Set</CardHeader>
+        <CardBody>
           <FormGroup row>
             <Col md="3">
               <Label htmlFor="hf-email">Case ID</Label>
@@ -76,16 +142,16 @@ const CreateCrashRecord = () => {
               </FormText>
             </Col>
           </FormGroup>
-        </Form>
-      </CardBody>
-      <CardFooter>
-        <Button type="submit" size="sm" color="primary">
-          <i className="fa fa-dot-circle-o"></i> Submit
-        </Button>
-        <Button type="reset" size="sm" color="danger">
-          <i className="fa fa-ban"></i> Reset
-        </Button>
-      </CardFooter>
+        </CardBody>
+        <CardFooter>
+          <Button type="submit" size="sm" color="primary" className="mr-2">
+            <i className="fa fa-dot-circle-o"></i> Submit
+          </Button>
+          <Button type="reset" size="sm" color="danger">
+            <i className="fa fa-ban"></i> Reset
+          </Button>
+        </CardFooter>
+      </Form>
     </Card>
   );
 };


### PR DESCRIPTION
Closes https://github.com/cityofaustin/atd-data-tech/issues/3431

This is the most bare bones implementation of Sergio's Temp Record Creator UI. I'm going to break up the index view of all temp records into another backlog issue for follow up: 
- [ ] Show all temp records in table below form
- [ ] Enable Delete action for crash record with cascade for related records

I'm wondering if we should add these features:
- [x] Add a date input field? Date seems pretty important for how a temp record effect counts.
- [ ] Add number of units field? Right now we default to only 1. But if we added the option for more, it might get confusing and difficult to associate the proper injury/fatalities. But maybe the unit modes are important for a temp record?
- [ ] Client side form validation? Right now, even a blank form should submit without error. Do we need to require a Case ID field or other client side form validation? **Yes, validate non nulls for Case ID & Date**

## Blank Form
![Screen Shot 2020-07-27 at 2 27 00 AM](https://user-images.githubusercontent.com/5697474/88515598-9093fc80-cfb1-11ea-89f7-819d12caf42e.jpg)

## Example Error State
![Screen Shot 2020-07-27 at 2 27 32 AM](https://user-images.githubusercontent.com/5697474/88515597-8ffb6600-cfb1-11ea-9c14-0c6c49fd7dd6.jpg)

## Complete Form on success
![Screen Shot 2020-07-27 at 2 28 08 AM](https://user-images.githubusercontent.com/5697474/88515595-8f62cf80-cfb1-11ea-8037-6a4a12383efb.jpg)

## Crash Details for new record(s)
![Screen Shot 2020-07-27 at 2 31 34 AM](https://user-images.githubusercontent.com/5697474/88515593-8d990c00-cfb1-11ea-92a8-872ddbb65730.jpg)


