### PR TITLE
VZV | Create By Population (Rate Per 100,000) component

### DIFF
--- a/atd-vzv/src/Components/Popover/InfoPopover.js
+++ b/atd-vzv/src/Components/Popover/InfoPopover.js
@@ -15,7 +15,7 @@ const InfoPopover = ({ config }) => {
 
     /* Style links for devices that show them as plain text */
     a {
-      color: ${colors.info};
+      color: ${colors.viridis2Of6};
       text-decoration: underline;
     }
   `;

--- a/atd-vzv/src/Components/Popover/popoverConfig.js
+++ b/atd-vzv/src/Components/Popover/popoverConfig.js
@@ -82,9 +82,7 @@ export const popoverConfig = {
           </div>
           <div className="mb-2">
             Below is a table showing how Austin's population continues to
-            increase each year. In future versions of the Vision Zero Viewer,
-            there will be a visualization showing crash numbers per 100,000
-            residents.
+            increase each year.
             <div>
               <img
                 className="mt-2 img-fluid"

--- a/atd-vzv/src/Components/Popover/popoverConfig.js
+++ b/atd-vzv/src/Components/Popover/popoverConfig.js
@@ -74,6 +74,21 @@ export const popoverConfig = {
       ),
     },
     byYear: {
+      title: "By Year & Month",
+      html: (
+        <>
+          <div>
+            This chart compares the current year's traffic fatalities and
+            serious injuries to the average traffic fatalities and serious
+            injuries of the previous five years. Users can compare traffic
+            fatalities and serious injuries per month, as well as compare how
+            the total traffic fatality and serious injury count changes
+            throughout the year.
+          </div>
+        </>
+      ),
+    },
+    byPopulation: {
       title: "Austin Area Population Histories & Forecasts",
       html: (
         <>
@@ -81,8 +96,22 @@ export const popoverConfig = {
             Austin Area Population Histories & Forecasts
           </div>
           <div className="mb-2">
-            Below is a table showing how Austin's population continues to
-            increase each year.
+            It is an industry standard to measure traffic-related deaths and
+            serious injuries in cities per 100,000 residents (see National
+            Highway Traffic Safety Administration{" "}
+            <a
+              href="https://www-fars.nhtsa.dot.gov/Main/index.aspx"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              website
+            </a>
+            ). This measure is important because it normalizes the number of
+            fatalities and serious injuries compared to a city's population.
+            This provides further insight when comparing traffic-related deaths
+            and serious injuries across peer cities, as well as changes to an
+            individual city's population over time. Below is a table showing how
+            Austin's population continues to increase each year.
             <div>
               <img
                 className="mt-2 img-fluid"

--- a/atd-vzv/src/views/nav/SideDrawerMobileNav.js
+++ b/atd-vzv/src/views/nav/SideDrawerMobileNav.js
@@ -33,7 +33,7 @@ const SideDrawerMobileNav = () => {
 
   return (
     <StyledMobileNav>
-      <Nav className="mr-auto" navbar>
+      <Nav className="mr-auto mb-2" navbar>
         {navConfig.map((config, i) => (
           <NavItem key={i}>
             <NavLink tag={A} href={config.url}>

--- a/atd-vzv/src/views/summary/CrashesByPopulation.js
+++ b/atd-vzv/src/views/summary/CrashesByPopulation.js
@@ -33,10 +33,10 @@ const CrashesByPopulation = () => {
     };
 
     const chartConfig = {
-      barOne: { color: colors.viridis5Of6, population: 913917 },
-      barTwo: { color: colors.viridis4Of6, population: 937065 },
-      barThree: { color: colors.viridis3Of6, population: 955094 },
-      barFour: { color: colors.viridis2Of6, population: 972499 },
+      barOne: { color: colors.viridis1Of6Highest, population: 913917 },
+      barTwo: { color: colors.viridis1Of6Highest, population: 937065 },
+      barThree: { color: colors.viridis1Of6Highest, population: 955094 },
+      barFour: { color: colors.viridis1Of6Highest, population: 972499 },
     };
 
     const calculateRatePer100000 = (data) => {
@@ -95,7 +95,7 @@ const CrashesByPopulation = () => {
         <Col>
           <h2 className="text-left font-weight-bold">
             By Population (Rate Per 100,000){" "}
-            <InfoPopover config={popoverConfig.summary.byYear} />
+            <InfoPopover config={popoverConfig.summary.byPopulation} />
           </h2>
         </Col>
       </Row>
@@ -112,17 +112,11 @@ const CrashesByPopulation = () => {
       <Row className="pb-2">
         <Col xs={4} s={2} m={2} l={2} xl={2}>
           <div>
-            <hr
-              className="my-1"
-              style={{
-                border: `4px solid ${colors.buttonBackground}`,
-              }}
-            ></hr>
-            <h6 className="text-center py-1 mb-0">
+            <h3 className="h6 text-center pt-2 my-1">
               <strong>Year</strong>
-            </h6>
+            </h3>
             <hr className="my-1"></hr>
-            <h6 className="text-center py-1">Ratio</h6>
+            <h3 className="h6 text-center py-1">Ratio</h3>
           </div>
         </Col>
         {!!chartData &&
@@ -131,13 +125,7 @@ const CrashesByPopulation = () => {
             <Col xs={4} s={2} m={2} l={2} xl={2} key={i}>
               <StyledDiv>
                 <div className="year-total-div">
-                  <hr
-                    className="my-1"
-                    style={{
-                      border: `4px solid ${chartData.datasets[0].backgroundColor[i]}`,
-                    }}
-                  ></hr>
-                  <h6 className="text-center py-1 mb-0">
+                  <h6 className="text-center pt-2 my-1">
                     <strong>{year}</strong>
                   </h6>
                   <hr className="my-1"></hr>

--- a/atd-vzv/src/views/summary/CrashesByPopulation.js
+++ b/atd-vzv/src/views/summary/CrashesByPopulation.js
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from "react";
 import axios from "axios";
+import styled from "styled-components";
 import { Bar } from "react-chartjs-2";
 import { Container, Row, Col } from "reactstrap";
 
@@ -14,7 +15,6 @@ const CrashesByPopulation = () => {
 
   const url = `${crashEndpointUrl}?$query=`;
 
-  // Fetch data for By Month Average and Cumulative visualizations
   useEffect(() => {
     const dateCondition = `crash_date BETWEEN '${dataStartDate.format(
       "YYYY-MM-DD"
@@ -77,6 +77,16 @@ const CrashesByPopulation = () => {
         });
   }, [crashType, url]);
 
+  const StyledDiv = styled.div`
+    .year-total-div {
+      color: ${colors.dark};
+      background: ${colors.buttonBackground};
+      border-radius: 4px;
+      border-style: none;
+      opacity: 1;
+    }
+  `;
+
   return (
     <Container className="m-0 p-0">
       <Row>
@@ -95,6 +105,46 @@ const CrashesByPopulation = () => {
         <Col>
           <hr />
         </Col>
+      </Row>
+      <Row className="pb-2">
+        <Col xs={4} s={2} m={2} l={2} xl={2}>
+          <div>
+            <hr
+              className="my-1"
+              style={{
+                border: `4px solid ${colors.buttonBackground}`,
+              }}
+            ></hr>
+            <h6 className="text-center py-1 mb-0">
+              <strong>Year</strong>
+            </h6>
+            <hr className="my-1"></hr>
+            <h6 className="text-center py-1">Ratio</h6>
+          </div>
+        </Col>
+        {!!chartData &&
+          chartData.labels &&
+          chartData.labels.map((year, i) => (
+            <Col xs={4} s={2} m={2} l={2} xl={2} key={i}>
+              <StyledDiv>
+                <div className="year-total-div">
+                  <hr
+                    className="my-1"
+                    style={{
+                      border: `4px solid ${chartData.datasets[0].backgroundColor[i]}`,
+                    }}
+                  ></hr>
+                  <h6 className="text-center py-1 mb-0">
+                    <strong>{year}</strong>
+                  </h6>
+                  <hr className="my-1"></hr>
+                  <h6 className="text-center py-1">
+                    {chartData.datasets[0].data[i]}
+                  </h6>
+                </div>
+              </StyledDiv>
+            </Col>
+          ))}
       </Row>
       <Row className="mt-1">
         <Col>

--- a/atd-vzv/src/views/summary/CrashesByPopulation.js
+++ b/atd-vzv/src/views/summary/CrashesByPopulation.js
@@ -1,0 +1,73 @@
+import React, { useState, useEffect } from "react";
+import axios from "axios";
+import { Container, Row, Col } from "reactstrap";
+
+import CrashTypeSelector from "./Components/CrashTypeSelector";
+import InfoPopover from "../../Components/Popover/InfoPopover";
+import { popoverConfig } from "../../Components/Popover/popoverConfig";
+import { crashEndpointUrl } from "./queries/socrataQueries";
+import {
+  fiveYearAvgStartDate,
+  fiveYearAvgEndDate,
+  summaryCurrentYearEndDate,
+  summaryCurrentYearStartDate,
+} from "../../constants/time";
+
+const CrashesByPopulation = () => {
+  const [crashType, setCrashType] = useState(null);
+
+  const [avgData, setAvgData] = useState([]);
+
+  const url = `${crashEndpointUrl}?$query=`;
+
+  // Fetch data for By Month Average and Cumulative visualizations
+  useEffect(() => {
+    const avgDateCondition = `crash_date BETWEEN '${fiveYearAvgStartDate}' and '${fiveYearAvgEndDate}'`;
+    const currentYearDateCondition = `crash_date BETWEEN '${summaryCurrentYearStartDate}' and '${summaryCurrentYearEndDate}'`;
+    const queryGroupAndOrder = `GROUP BY month ORDER BY month`;
+
+    const avgQueries = {
+      fatalities: `SELECT date_extract_y(crash_date) as month, sum(death_cnt) / 5 as avg 
+                   WHERE death_cnt > 0 AND ${avgDateCondition} ${queryGroupAndOrder}`,
+      fatalitiesAndSeriousInjuries: `SELECT date_extract_y(crash_date) as month, sum(death_cnt) / 5 + sum(sus_serious_injry_cnt) / 5 as avg 
+                                     WHERE (death_cnt > 0 OR sus_serious_injry_cnt > 0) AND ${avgDateCondition} ${queryGroupAndOrder}`,
+      seriousInjuries: `SELECT date_extract_y(crash_date) as month, sum(sus_serious_injry_cnt) / 5 as avg 
+                        WHERE sus_serious_injry_cnt > 0 AND ${avgDateCondition} ${queryGroupAndOrder}`,
+    };
+
+    !!crashType &&
+      axios
+        .get(url + encodeURIComponent(avgQueries[crashType.name]))
+        .then((res) => {
+          setAvgData(res.data);
+        });
+  }, [crashType, url]);
+
+  return (
+    <Container className="m-0 p-0">
+      <Row>
+        <Col>
+          <h2 className="text-left font-weight-bold">
+            By Year & Month{" "}
+            <InfoPopover config={popoverConfig.summary.byYear} />
+          </h2>
+        </Col>
+      </Row>
+      <Row>
+        <Col>
+          <CrashTypeSelector setCrashType={setCrashType} />
+        </Col>
+      </Row>
+      <Row>
+        <Col>
+          <hr />
+        </Col>
+      </Row>
+      <Row className="mt-1">
+        <Col>Chart</Col>
+      </Row>
+    </Container>
+  );
+};
+
+export default CrashesByPopulation;

--- a/atd-vzv/src/views/summary/CrashesByPopulation.js
+++ b/atd-vzv/src/views/summary/CrashesByPopulation.js
@@ -9,15 +9,8 @@ import { dataStartDate, fiveYearAvgEndDate } from "../../constants/time";
 import { colors } from "../../constants/colors";
 
 const CrashesByPopulation = () => {
-  const chartConfig = {
-    barOne: { color: colors.viridis5Of6, population: 913917 },
-    barTwo: { color: colors.viridis4Of6, population: 937065 },
-    barThree: { color: colors.viridis3Of6, population: 955094 },
-    barFour: { color: colors.viridis1Of6Highest, population: 972499 },
-  };
-
   const [crashType, setCrashType] = useState(null);
-  const [chartData, setChartData] = useState([]);
+  const [chartData, setChartData] = useState({});
 
   const url = `${crashEndpointUrl}?$query=`;
 
@@ -40,7 +33,7 @@ const CrashesByPopulation = () => {
     const calculateRatePer100000 = (data) => {
       const round = (num) => Math.floor(num * 10) / 10;
 
-      data.map((year, i) => {
+      return data.map((year, i) => {
         const population = Object.values(chartConfig)[i].population;
         const rate = (year.total / population) * 100000;
         year.total = round(rate);
@@ -48,13 +41,41 @@ const CrashesByPopulation = () => {
       });
     };
 
+    const chartConfig = {
+      barOne: { color: colors.viridis5Of6, population: 913917 },
+      barTwo: { color: colors.viridis4Of6, population: 937065 },
+      barThree: { color: colors.viridis3Of6, population: 955094 },
+      barFour: { color: colors.viridis1Of6Highest, population: 972499 },
+    };
+
+    const formatChartData = (data) => {
+      const labels = data.map((year) => year.year);
+      const rateValues = data.map((year) => year.total);
+      const colors = Object.values(chartConfig).map((bar) => bar.color);
+
+      return {
+        labels,
+        datasets: [
+          {
+            label: "Years",
+            backgroundColor: colors,
+            hoverBackgroundColor: colors,
+            data: rateValues,
+            barPercentage: 1.0,
+          },
+        ],
+      };
+    };
+
     !!crashType &&
       axios
         .get(url + encodeURIComponent(queries[crashType.name]))
         .then((res) => {
-          setChartData(calculateRatePer100000(res.data));
+          const calculatedData = calculateRatePer100000(res.data);
+          const formattedData = formatChartData(calculatedData);
+          setChartData(formattedData);
         });
-  }, [crashType, url, chartConfig]);
+  }, [crashType, url]);
 
   return (
     <Container className="m-0 p-0">
@@ -77,8 +98,7 @@ const CrashesByPopulation = () => {
       </Row>
       <Row className="mt-1">
         <Col>
-          {JSON.stringify(chartData)}
-          {/* <Bar
+          <Bar
             data={chartData}
             width={null}
             height={null}
@@ -99,10 +119,10 @@ const CrashesByPopulation = () => {
                 ],
               },
               legend: {
-                onClick: (e) => e.stopPropagation(),
+                display: false,
               },
             }}
-          /> */}
+          />
         </Col>
       </Row>
     </Container>

--- a/atd-vzv/src/views/summary/CrashesByPopulation.js
+++ b/atd-vzv/src/views/summary/CrashesByPopulation.js
@@ -32,6 +32,13 @@ const CrashesByPopulation = () => {
                         WHERE sus_serious_injry_cnt > 0 AND ${dateCondition} ${queryGroupAndOrder}`,
     };
 
+    const chartConfig = {
+      barOne: { color: colors.viridis5Of6, population: 913917 },
+      barTwo: { color: colors.viridis4Of6, population: 937065 },
+      barThree: { color: colors.viridis3Of6, population: 955094 },
+      barFour: { color: colors.viridis2Of6, population: 972499 },
+    };
+
     const calculateRatePer100000 = (data) => {
       const round = (num) => Math.floor(num * 10) / 10;
 
@@ -43,13 +50,6 @@ const CrashesByPopulation = () => {
       });
     };
 
-    const chartConfig = {
-      barOne: { color: colors.viridis5Of6, population: 913917 },
-      barTwo: { color: colors.viridis4Of6, population: 937065 },
-      barThree: { color: colors.viridis3Of6, population: 955094 },
-      barFour: { color: colors.viridis2Of6, population: 972499 },
-    };
-
     const formatChartData = (data) => {
       const labels = data.map((year) => year.year);
       const rateValues = data.map((year) => year.total);
@@ -59,7 +59,7 @@ const CrashesByPopulation = () => {
         labels,
         datasets: [
           {
-            label: "Years",
+            label: "Ratio",
             backgroundColor: colors,
             hoverBackgroundColor: colors,
             data: rateValues,

--- a/atd-vzv/src/views/summary/CrashesByPopulation.js
+++ b/atd-vzv/src/views/summary/CrashesByPopulation.js
@@ -5,6 +5,8 @@ import { Bar } from "react-chartjs-2";
 import { Container, Row, Col } from "reactstrap";
 
 import CrashTypeSelector from "./Components/CrashTypeSelector";
+import InfoPopover from "../../Components/Popover/InfoPopover";
+import { popoverConfig } from "../../Components/Popover/popoverConfig";
 import { crashEndpointUrl } from "./queries/socrataQueries";
 import { dataStartDate, fiveYearAvgEndDate } from "../../constants/time";
 import { colors } from "../../constants/colors";
@@ -45,7 +47,7 @@ const CrashesByPopulation = () => {
       barOne: { color: colors.viridis5Of6, population: 913917 },
       barTwo: { color: colors.viridis4Of6, population: 937065 },
       barThree: { color: colors.viridis3Of6, population: 955094 },
-      barFour: { color: colors.viridis1Of6Highest, population: 972499 },
+      barFour: { color: colors.viridis2Of6, population: 972499 },
     };
 
     const formatChartData = (data) => {
@@ -92,7 +94,8 @@ const CrashesByPopulation = () => {
       <Row>
         <Col>
           <h2 className="text-left font-weight-bold">
-            By Population (Rate Per 100,000)
+            By Population (Rate Per 100,000){" "}
+            <InfoPopover config={popoverConfig.summary.byYear} />
           </h2>
         </Col>
       </Row>

--- a/atd-vzv/src/views/summary/Summary.js
+++ b/atd-vzv/src/views/summary/Summary.js
@@ -40,7 +40,7 @@ const Summary = () => {
 
     /* Style links for devices that show them as plain text */
     a {
-      color: ${colors.infoDark};
+      color: ${colors.viridis2Of6};
       text-decoration: underline;
     }
   `;

--- a/atd-vzv/src/views/summary/Summary.js
+++ b/atd-vzv/src/views/summary/Summary.js
@@ -3,6 +3,7 @@ import CrashesByYear from "./CrashesByYear";
 import CrashesByTimeOfDay from "./CrashesByTimeOfDay";
 import PeopleByDemographics from "./PeopleByDemographics";
 import CrashesByMode from "./CrashesByMode";
+import CrashesByPopulation from "./CrashesByPopulation";
 import SummaryView from "./SummaryView";
 import SummaryCard from "./SummaryCard";
 import { colors } from "../../constants/colors";
@@ -20,6 +21,7 @@ const children = [
   { component: <CrashesByMode /> },
   { component: <CrashesByTimeOfDay /> },
   { component: <PeopleByDemographics /> },
+  { component: <CrashesByPopulation /> },
 ];
 
 const Summary = () => {

--- a/atd-vzv/src/views/summary/Summary.js
+++ b/atd-vzv/src/views/summary/Summary.js
@@ -50,7 +50,7 @@ const Summary = () => {
   return (
     <Container fluid>
       {/* Create whitespace on sides of view until mobile */}
-      <Row className="px-xs-0 mx-xs-0 px-lg-3 mx-lg-4 mt-xs-3 mt-lg-4">
+      <Row className="px-xs-0 mx-xs-0 px-lg-3 mx-lg-4 mt-md-3 mt-lg-4">
         <Col className="px-xs-0">
           <StyledSummary>
             <Row className="summary-child">


### PR DESCRIPTION
Closes https://github.com/cityofaustin/atd-data-tech/issues/2547

This PR adds a By Population chart to visualize traffic-related fatalities and serious injuries per 100,000 residents. The info modal text for the By Year and By Population charts was updated along with the hyperlink text color for accessibility. I also made a few UI fixes shown below.

#### By Population (All)
<img width="667" alt="Screen Shot 2020-07-31 at 12 56 05 PM" src="https://user-images.githubusercontent.com/37249039/89063151-47cfa100-d32d-11ea-8949-7929f31df906.png">

#### By Population (Fatalities)
<img width="667" alt="Screen Shot 2020-07-31 at 12 56 12 PM" src="https://user-images.githubusercontent.com/37249039/89063169-4c945500-d32d-11ea-9c12-db4a39f6066d.png">

#### Updated info modal
<img width="537" alt="Screen Shot 2020-07-30 at 2 16 12 PM" src="https://user-images.githubusercontent.com/37249039/88970280-bf42f900-d277-11ea-9998-e0302fc7d931.png">

#### Margin below mobile nav buttons (before & after)
<img width="435" alt="Screen Shot 2020-07-30 at 11 17 30 AM" src="https://user-images.githubusercontent.com/37249039/88951091-28684380-d25b-11ea-866d-e7ae1c989be9.png">

<img width="435" alt="Screen Shot 2020-07-30 at 11 22 54 AM" src="https://user-images.githubusercontent.com/37249039/88951100-29997080-d25b-11ea-9c4c-7b858f8e8a29.png">

#### Summary Info Alert margin on medium devices (before & after)
<img width="951" alt="Screen Shot 2020-07-30 at 11 23 30 AM" src="https://user-images.githubusercontent.com/37249039/88951205-4afa5c80-d25b-11ea-963a-7f81f41a3620.png">

<img width="951" alt="Screen Shot 2020-07-30 at 11 23 40 AM" src="https://user-images.githubusercontent.com/37249039/88951210-4cc42000-d25b-11ea-960d-cb4697c80532.png">
