### PR TITLE
VZV | Small UI improvements

### DIFF
--- a/atd-vzv/src/Components/Widgets/SummaryWidget.js
+++ b/atd-vzv/src/Components/Widgets/SummaryWidget.js
@@ -48,6 +48,10 @@ const SummaryWidget = ({
       bottom: 5px;
     }
 
+    .widget-header-text > h3 {
+      font-size: 1.2em;
+    }
+
     /* Center footer text with widget body text above */
     .widget-footer-text {
       padding-left: 22.75px;
@@ -106,7 +110,7 @@ const SummaryWidget = ({
           </Row>
           <div className="text-left d-flex flex-row">
             {renderIcon()}
-            <div className="d-flex flex-column">
+            <div className="d-flex flex-column widget-header-text">
               <h3 className="h5 mb-0">
                 {text} {infoPopover}
               </h3>

--- a/atd-vzv/src/Components/Widgets/SummaryWidget.js
+++ b/atd-vzv/src/Components/Widgets/SummaryWidget.js
@@ -34,14 +34,6 @@ const SummaryWidget = ({
       font-size: 4em;
     }
 
-    .footer {
-      /* position: absolute;
-      bottom: 0; */
-      flex-shrink: 0;
-      width: 100%;
-      padding: 15px;
-    }
-
     /* Shift icon left to align with Bootstrap card text */
     .widget-icon {
       position: relative;

--- a/atd-vzv/src/Components/Widgets/SummaryWidget.js
+++ b/atd-vzv/src/Components/Widgets/SummaryWidget.js
@@ -46,6 +46,11 @@ const SummaryWidget = ({
     }
 
     /* Center footer text with widget body text above */
+    .widget-header-text {
+      font-size: 18px;
+    }
+
+    /* Center footer text with widget body text above */
     .widget-footer-text {
       padding-left: 22.75px;
     }
@@ -104,10 +109,10 @@ const SummaryWidget = ({
           <div className="text-left d-flex flex-row">
             {renderIcon()}
             <div className="d-flex flex-column">
-              <h3 className="h5 mb-0">
+              <h3 className="h5 mb-0 widget-header-text">
                 {text} {infoPopover}
               </h3>
-              <h3 className="h5 text-muted">{`in ${currentYear}`}</h3>
+              <h3 className="h5 text-muted widget-header-text">{`in ${currentYear}`}</h3>
             </div>
           </div>
         </CardBody>

--- a/atd-vzv/src/Components/Widgets/SummaryWidget.js
+++ b/atd-vzv/src/Components/Widgets/SummaryWidget.js
@@ -28,8 +28,18 @@ const SummaryWidget = ({
   infoPopover,
 }) => {
   const StyledWidget = styled.div`
+    flex-grow: 1;
+
     .total {
       font-size: 4em;
+    }
+
+    .footer {
+      /* position: absolute;
+      bottom: 0; */
+      flex-shrink: 0;
+      width: 100%;
+      padding: 15px;
     }
 
     /* Shift icon left to align with Bootstrap card text */
@@ -40,14 +50,10 @@ const SummaryWidget = ({
     }
 
     /* Center footer icon in footer with .widget-icon above */
-    .widget-footer-icon {
+    .widget-footer-icon > svg {
       position: relative;
       left: 12.25px;
-    }
-
-    /* Center footer text with widget body text above */
-    .widget-header-text {
-      font-size: 18px;
+      bottom: 5px;
     }
 
     /* Center footer text with widget body text above */
@@ -82,7 +88,7 @@ const SummaryWidget = ({
       <div className="text-left widget-footer-icon d-flex flex-row card-bottom">
         <FontAwesomeIcon size="2x" icon={icon} color={colors.dark} />
         {!!lastYearTotal && (
-          <div className="text-muted text-wrap pt-1 pr-1 widget-footer-text">
+          <div className="text-muted text-wrap pb-1 pr-1 widget-footer-text">
             {`${text} ${numberWithCommas(lastYearTotal)} this time last year`}
           </div>
         )}
@@ -91,9 +97,9 @@ const SummaryWidget = ({
   };
 
   return (
-    <Card>
+    <Card className="h-100">
       <StyledWidget>
-        <CardBody className="pb-2">
+        <CardBody className="pb-1 h-75">
           <Row>
             <Col>
               {/* Show spinner while waiting for data, add thousands separator to total */}
@@ -109,15 +115,15 @@ const SummaryWidget = ({
           <div className="text-left d-flex flex-row">
             {renderIcon()}
             <div className="d-flex flex-column">
-              <h3 className="h5 mb-0 widget-header-text">
+              <h3 className="h5 mb-0">
                 {text} {infoPopover}
               </h3>
-              <h3 className="h5 text-muted widget-header-text">{`in ${currentYear}`}</h3>
+              <h3 className="h5 text-muted">{`in ${currentYear}`}</h3>
             </div>
           </div>
         </CardBody>
         {!!totalsObject && (
-          <CardFooter className="bg-white">
+          <CardFooter className="bg-white h-25">
             {renderFooterBasedOnChange(
               totalsObject[currentYear],
               totalsObject[prevYear]

--- a/atd-vzv/src/views/summary/PeopleByDemographics.js
+++ b/atd-vzv/src/views/summary/PeopleByDemographics.js
@@ -275,6 +275,7 @@ const PeopleByDemographics = () => {
       <Row>
         <Col>
           <HorizontalBar
+            redraw
             data={data}
             height={null}
             width={null}


### PR DESCRIPTION
Closes https://github.com/cityofaustin/atd-data-tech/issues/3574

This fixes the Summary widgets so that they remain equal height regardless of viewport width. The solution revolves around adding bootstrap height classes to the body and footer (75% height for the body and 25% for the footer).  Then, I added `flex-grow` to the styled.div that contains all the CSS styles for the widget elements. This makes sure that the card body and card footer can always take up their portion of the full card height correctly.

This also patches an issue with the chart legends in the By Demographics visualization. I added a redraw prop to force chart re-render on each component re-render.

@sergiogcx - I plan on reviewing these changes with @JaceDeloney early next week, and I'm including your text-size change idea from the other day. 🙏 **Update 8/10: Font size changed so say 👋 to words wrapping!**

### Improved widget responsiveness
<img width="1123" alt="Screen Shot 2020-08-07 at 3 24 26 PM" src="https://user-images.githubusercontent.com/37249039/89685553-2be67500-d8c2-11ea-8b6e-3666f54bc794.png">
<img width="1256" alt="Screen Shot 2020-08-07 at 3 24 13 PM" src="https://user-images.githubusercontent.com/37249039/89685557-2c7f0b80-d8c2-11ea-80ad-69d4cd02274c.png">
<img width="1343" alt="Screen Shot 2020-08-07 at 3 23 58 PM" src="https://user-images.githubusercontent.com/37249039/89685559-2d17a200-d8c2-11ea-9242-caaba2939b9b.png">

### Demographics legend bug fix
![demoFix](https://user-images.githubusercontent.com/37249039/89685834-be871400-d8c2-11ea-8b64-3c6259a523d2.gif)

