### PR TITLE
VZV | Add padding to bottom text in summary widgets

### DIFF
--- a/atd-vzv/src/Components/Widgets/SummaryWidget.js
+++ b/atd-vzv/src/Components/Widgets/SummaryWidget.js
@@ -27,25 +27,33 @@ const SummaryWidget = ({
   backgroundColor,
   infoPopover,
 }) => {
-  const StyledWidget = styled.div`
+  const StyledWidgetCard = styled(Card)`
+    height: 100%;
     flex-grow: 1;
 
     .total {
       font-size: 4em;
     }
 
+    .widget-body {
+      height: 70%;
+    }
+
+    .widget-footer {
+      height: 30%;
+    }
+
     /* Shift icon left to align with Bootstrap card text */
     .widget-icon {
       position: relative;
       right: 5.25px;
-      padding-right: 20px;
     }
 
     /* Center footer icon in footer with .widget-icon above */
     .widget-footer-icon > svg {
       position: relative;
       left: 12.25px;
-      bottom: 5px;
+      bottom: 1px;
     }
 
     .widget-header-text > h3 {
@@ -54,7 +62,7 @@ const SummaryWidget = ({
 
     /* Center footer text with widget body text above */
     .widget-footer-text {
-      padding-left: 22.75px;
+      /* padding-left: 24px; */
     }
   `;
 
@@ -81,53 +89,51 @@ const SummaryWidget = ({
       "Same as";
 
     return (
-      <div className="text-left widget-footer-icon d-flex flex-row card-bottom">
+      <div className="text-left widget-footer-icon d-flex flex-row align-items-center">
         <FontAwesomeIcon size="2x" icon={icon} color={colors.dark} />
         {!!lastYearTotal && (
-          <div className="text-muted text-wrap pb-1 pr-1 widget-footer-text">
+          <span className="text-muted text-wrap widget-footer-text pl-4">
             {`${text} ${numberWithCommas(lastYearTotal)} this time last year`}
-          </div>
+          </span>
         )}
       </div>
     );
   };
 
   return (
-    <Card className="h-100">
-      <StyledWidget>
-        <CardBody className="pb-1 h-75">
-          <Row>
-            <Col>
-              {/* Show spinner while waiting for data, add thousands separator to total */}
-              <h2 className="h1 total">
-                {!!totalsObject ? (
-                  numberWithCommas(totalsObject[currentYear])
-                ) : (
-                  <ColorSpinner color={backgroundColor} />
-                )}
-              </h2>
-            </Col>
-          </Row>
-          <div className="text-left d-flex flex-row">
-            {renderIcon()}
-            <div className="d-flex flex-column widget-header-text">
-              <h3 className="h5 mb-0">
-                {text} {infoPopover}
-              </h3>
-              <h3 className="h5 text-muted">{`in ${currentYear}`}</h3>
-            </div>
+    <StyledWidgetCard>
+      <CardBody className="widget-body">
+        <Row>
+          <Col>
+            {/* Show spinner while waiting for data, add thousands separator to total */}
+            <h2 className="h1 total">
+              {!!totalsObject ? (
+                numberWithCommas(totalsObject[currentYear])
+              ) : (
+                <ColorSpinner color={backgroundColor} />
+              )}
+            </h2>
+          </Col>
+        </Row>
+        <div className="text-left d-flex flex-row">
+          {renderIcon()}
+          <div className="d-flex flex-column widget-header-text">
+            <h3 className="h5 mb-0">
+              {text} {infoPopover}
+            </h3>
+            <h3 className="h5 text-muted">{`in ${currentYear}`}</h3>
           </div>
-        </CardBody>
-        {!!totalsObject && (
-          <CardFooter className="bg-white h-25">
-            {renderFooterBasedOnChange(
-              totalsObject[currentYear],
-              totalsObject[prevYear]
-            )}
-          </CardFooter>
-        )}
-      </StyledWidget>
-    </Card>
+        </div>
+      </CardBody>
+      {!!totalsObject && (
+        <CardFooter className="bg-white d-flex widget-footer">
+          {renderFooterBasedOnChange(
+            totalsObject[currentYear],
+            totalsObject[prevYear]
+          )}
+        </CardFooter>
+      )}
+    </StyledWidgetCard>
   );
 };
 

--- a/atd-vzv/src/Components/Widgets/SummaryWidget.js
+++ b/atd-vzv/src/Components/Widgets/SummaryWidget.js
@@ -59,11 +59,6 @@ const SummaryWidget = ({
     .widget-header-text > h3 {
       font-size: 1.2em;
     }
-
-    /* Center footer text with widget body text above */
-    .widget-footer-text {
-      /* padding-left: 24px; */
-    }
   `;
 
   const renderIcon = () => (
@@ -92,7 +87,7 @@ const SummaryWidget = ({
       <div className="text-left widget-footer-icon d-flex flex-row align-items-center">
         <FontAwesomeIcon size="2x" icon={icon} color={colors.dark} />
         {!!lastYearTotal && (
-          <span className="text-muted text-wrap widget-footer-text pl-4">
+          <span className="text-muted text-wrap pl-4">
             {`${text} ${numberWithCommas(lastYearTotal)} this time last year`}
           </span>
         )}


### PR DESCRIPTION
Closes https://github.com/cityofaustin/atd-data-tech/issues/3650

This PR updates the `SummaryWidget` component styles to keep the padding within the card footers and the card heights even across the widgets whether the text wraps or not. The height of the card body and footer were change from 75%/25% to 70%/30% and then some custom CSS was replaced with Bootstrap classes to keep the arrows and text in the footer vertically aligned.

### Update screenshots 
<img width="1333" alt="Screen Shot 2020-08-13 at 11 08 07 AM" src="https://user-images.githubusercontent.com/37249039/90159660-58810d80-dd56-11ea-9221-d226918e4b81.png">
<img width="1333" alt="Screen Shot 2020-08-13 at 11 08 23 AM" src="https://user-images.githubusercontent.com/37249039/90159671-5ae36780-dd56-11ea-9af0-94ef4a3de9dc.png">
<img width="1209" alt="Screen Shot 2020-08-13 at 11 08 46 AM" src="https://user-images.githubusercontent.com/37249039/90159677-5cad2b00-dd56-11ea-851e-dcaf4e5b42d0.png">
