### PR TITLE
ETL: Fix ETL to Revert last successful data upload if the ETL fails

### DIFF
--- a/atd-etl/app/process/config.py
+++ b/atd-etl/app/process/config.py
@@ -44,6 +44,8 @@ ATD_ETL_CONFIG = {
     "SOCRATA_KEY_ID": os.getenv("SOCRATA_KEY_ID", ""),
     "SOCRATA_KEY_SECRET": os.getenv("SOCRATA_KEY_SECRET", ""),
     "SOCRATA_APP_TOKEN": os.getenv("SOCRATA_APP_TOKEN", ""),
+    "SOCRATA_DATASET_CRASHES": os.getenv("SOCRATA_DATASET_CRASHES", ""),
+    "SOCRATA_DATASET_PERSONS": os.getenv("SOCRATA_DATASET_PERSONS", ""),
 
     # CR3
     "ATD_CRIS_CR3_URL": "https://cris.dot.state.tx.us/secure/ImageServices/DisplayImageServlet?target=",

--- a/atd-etl/app/process_socrata_export.py
+++ b/atd-etl/app/process_socrata_export.py
@@ -45,8 +45,7 @@ query_configs = [
                 "atd_fatality_count": "death_cnt",
             },
         },
-        # "dataset_uid": "3aut-fhzp"  # TEST
-        "dataset_uid": "y2wy-tgr5",  # PROD
+        "dataset_uid": ATD_ETL_CONFIG["SOCRATA_DATASET_CRASHES"]
     },
     {
         "table": "person",
@@ -57,8 +56,7 @@ query_configs = [
             "columns_to_rename": {"primaryperson_id": "person_id"},
             "prefixes": {"person_id": "P", "primaryperson_id": "PP",},
         },
-        # "dataset_uid": "v3x4-fjgm"  # TEST
-        "dataset_uid": "xecs-rpy9",  # PROD
+        "dataset_uid": ATD_ETL_CONFIG["SOCRATA_DATASET_PERSONS"]
     },
 ]
 


### PR DESCRIPTION
This small adjustment allows the configuration of the dataset to be run by Airflow