### PR TITLE
VZV | Update mode filter buttons

### DIFF
--- a/atd-vzv/package-lock.json
+++ b/atd-vzv/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "atd-vzv",
-  "version": "1.12.0",
+  "version": "1.12.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1166,6 +1166,21 @@
       "integrity": "sha512-xmPmP2t8qrdo8RyKihTkGb09RnZoc+7HFBCnr0/6ZhStdGDSLeEd7ajV181+2W29NWIFfylO13rU+s3fpy3cnA==",
       "requires": {
         "@fortawesome/fontawesome-common-types": "^0.2.29"
+      }
+    },
+    "@fortawesome/free-regular-svg-icons": {
+      "version": "5.14.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-5.14.0.tgz",
+      "integrity": "sha512-6LCFvjGSMPoUQbn3NVlgiG4CY5iIY8fOm+to/D6QS/GvdqhDt+xZklQeERdCvVRbnFa1ITc1rJHPRXqkX5wztQ==",
+      "requires": {
+        "@fortawesome/fontawesome-common-types": "^0.2.30"
+      },
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": {
+          "version": "0.2.30",
+          "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.30.tgz",
+          "integrity": "sha512-TsRwpTuKwFNiPhk1UfKgw7zNPeV5RhNp2Uw3pws+9gDAkPGKrtjR1y2lI3SYn7+YzyfuNknflpBA1LRKjt7hMg=="
+        }
       }
     },
     "@fortawesome/free-solid-svg-icons": {

--- a/atd-vzv/package.json
+++ b/atd-vzv/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^1.2.26",
+    "@fortawesome/free-regular-svg-icons": "^5.14.0",
     "@fortawesome/free-solid-svg-icons": "^5.12.0",
     "@fortawesome/react-fontawesome": "^0.1.8",
     "@mapbox/mapbox-gl-draw": "^1.1.2",

--- a/atd-vzv/src/views/nav/SideMapControl.js
+++ b/atd-vzv/src/views/nav/SideMapControl.js
@@ -21,8 +21,11 @@ import {
   faEllipsisH,
 } from "@fortawesome/free-solid-svg-icons";
 
+// Keep type buttons from wrapping on Windows (scroll bar takes extra width)
+const typeFilterTextSize = navigator.appVersion.indexOf("Win") !== -1 ? 12 : 14;
+
 const StyledCard = styled.div`
-  font-size: 1.2em;
+  font-size: 1rem;
 
   .card-title {
     font-weight: bold;
@@ -43,7 +46,7 @@ const StyledCard = styled.div`
   }
 
   .type-button {
-    font-size: 12px;
+    font-size: ${typeFilterTextSize}px;
     color: ${colors.dark};
     background: ${colors.buttonBackground};
     border-style: none;
@@ -55,10 +58,6 @@ const StyledCard = styled.div`
   }
   [class^="DateInput_"] {
     text-align: center;
-  }
-
-  .icon-container {
-    min-width: 24px;
   }
 `;
 
@@ -291,78 +290,85 @@ const SideMapControl = ({ type }) => {
           <Row className="mx-0 mb-3" key={`${group}-buttons`}>
             {/* Create buttons for each filter within a group of mapFilters */}
             {Object.entries(groupParameters).map(([name, parameter], i) => {
-              return parameter.uiType === "button" ? (
-                <Col
-                  xs={parameter.colSize && parameter.colSize}
-                  className="px-0"
-                  key={name}
-                >
-                  <Button
-                    key={name}
-                    id={name}
-                    color="dark"
-                    className={`p-1 filter-button ${
-                      parameter.buttonClass && parameter.buttonClass
-                    }`}
-                    onClick={
-                      parameter.handler
-                        ? parameter.handler
-                        : (event) => handleFilterClick(event, group)
-                    }
-                    active={
-                      parameter.isSelected
-                        ? parameter.isSelected
-                        : isFilterSet(name)
-                    }
-                    outline={
-                      parameter.isSelected
-                        ? !parameter.isSelected
-                        : !isFilterSet(name)
-                    }
-                  >
-                    {parameter.icon && (
-                      <FontAwesomeIcon
-                        icon={parameter.icon}
-                        className="mr-1 ml-1"
-                        color={parameter.iconColor && parameter.iconColor}
-                      />
-                    )}
-                    {parameter.text}
-                  </Button>
-                </Col>
-              ) : (
-                <Col xs={12} key={name} className="py-1">
-                  <Label className="text-dark" check>
-                    <Input
+              switch (parameter.uiType) {
+                case "button":
+                  return (
+                    <Col
+                      xs={parameter.colSize && parameter.colSize}
+                      className="px-0"
                       key={name}
-                      id={name}
-                      type="checkbox"
-                      className={"filter-button"}
-                      color="dark"
-                      onClick={
-                        parameter.handler
-                          ? parameter.handler
-                          : (event) => handleFilterClick(event, group)
-                      }
-                      checked={
-                        parameter.isSelected
-                          ? parameter.isSelected
-                          : isFilterSet(name)
-                      }
-                    />{" "}
-                    <span className="ml-3">
-                      {parameter.icon && (
-                        <FontAwesomeIcon
-                          icon={parameter.icon}
-                          className="mr-1 fa-fw"
-                          color={parameter.iconColor && parameter.iconColor}
-                        />
-                      )}{" "}
-                      {name[0].toUpperCase() + name.slice(1)}
-                    </span>
-                  </Label>
-                </Col>
-              );
+                    >
+                      <Button
+                        key={name}
+                        id={name}
+                        color="dark"
+                        className={`p-1 filter-button ${
+                          parameter.buttonClass && parameter.buttonClass
+                        }`}
+                        onClick={
+                          parameter.handler
+                            ? parameter.handler
+                            : (event) => handleFilterClick(event, group)
+                        }
+                        active={
+                          parameter.isSelected
+                            ? parameter.isSelected
+                            : isFilterSet(name)
+                        }
+                        outline={
+                          parameter.isSelected
+                            ? !parameter.isSelected
+                            : !isFilterSet(name)
+                        }
+                      >
+                        {parameter.icon && (
+                          <FontAwesomeIcon
+                            icon={parameter.icon}
+                            className="mr-1 ml-1"
+                            color={parameter.iconColor && parameter.iconColor}
+                          />
+                        )}
+                        {parameter.text}
+                      </Button>
+                    </Col>
+                  );
+                case "checkbox":
+                  return (
+                    <Col xs={12} key={name} className="py-1">
+                      <Label className="text-dark" check>
+                        <Input
+                          key={name}
+                          id={name}
+                          type="checkbox"
+                          className={"filter-button"}
+                          color="dark"
+                          onClick={
+                            parameter.handler
+                              ? parameter.handler
+                              : (event) => handleFilterClick(event, group)
+                          }
+                          checked={
+                            parameter.isSelected
+                              ? parameter.isSelected
+                              : isFilterSet(name)
+                          }
+                        />{" "}
+                        <span className="ml-3">
+                          {parameter.icon && (
+                            <FontAwesomeIcon
+                              icon={parameter.icon}
+                              className="mr-1 fa-fw"
+                              color={parameter.iconColor && parameter.iconColor}
+                            />
+                          )}{" "}
+                          {name[0].toUpperCase() + name.slice(1)}
+                        </span>
+                      </Label>
+                    </Col>
+                  );
+                default:
+                  return null;
+              }
             })}
           </Row>
         ))}

--- a/atd-vzv/src/views/nav/SideMapControl.js
+++ b/atd-vzv/src/views/nav/SideMapControl.js
@@ -8,7 +8,7 @@ import { trackPageEvent } from "../../constants/nav";
 import InfoPopover from "../../Components/Popover/InfoPopover";
 import { popoverConfig } from "../../Components/Popover/popoverConfig";
 import { colors } from "../../constants/colors";
-import { Button, Card, Label, Row, Col, Input } from "reactstrap";
+import { Button, Card, Label, Row, Col } from "reactstrap";
 import styled from "styled-components";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
@@ -19,7 +19,9 @@ import {
   faHeartbeat,
   faMedkit,
   faEllipsisH,
+  faCheckSquare,
 } from "@fortawesome/free-solid-svg-icons";
+import { faSquare } from "@fortawesome/free-regular-svg-icons";
 
 // Keep type buttons from wrapping on Windows (scroll bar takes extra width)
 const typeFilterTextSize = navigator.appVersion.indexOf("Win") !== -1 ? 12 : 14;
@@ -59,6 +61,27 @@ const StyledCard = styled.div`
   [class^="DateInput_"] {
     text-align: center;
   }
+
+  .outlined {
+    border: 1px solid ${colors.dark};
+    border-radius: 4px;
+  }
+
+  .dark-checkbox {
+    cursor: pointer;
+
+    .active,
+    .inactive {
+      color: ${colors.dark} !important;
+    }
+  }
+
+  .dark-checkbox:hover {
+    .active,
+    .inactive {
+      color: ${colors.secondary} !important;
+    }
+  }
 `;
 
 const SideMapControl = ({ type }) => {
@@ -94,7 +117,7 @@ const SideMapControl = ({ type }) => {
   const mapButtonFilters = {
     type: {
       shared: {
-        buttonClass: `type-button`,
+        eachClass: `type-button`,
         uiType: "button",
       },
       each: {
@@ -126,7 +149,11 @@ const SideMapControl = ({ type }) => {
       },
     },
     mode: {
-      shared: { uiType: "checkbox" },
+      shared: {
+        uiType: "checkbox",
+        allClass: "outlined py-2 px-0",
+        eachClass: "dark-checkbox",
+      },
       each: {
         pedestrian: {
           icon: faWalking, // Font Awesome icon object
@@ -136,7 +163,7 @@ const SideMapControl = ({ type }) => {
           operator: `OR`, // Logical operator for joining multiple query strings
           default: true, // Apply filter as default on render
         },
-        pedalcyclist: {
+        bicyclist: {
           icon: faBiking,
           fatalSyntax: `bicycle_death_count > 0`,
           injurySyntax: `bicycle_serious_injury_count > 0`,
@@ -144,7 +171,7 @@ const SideMapControl = ({ type }) => {
           operator: `OR`,
           default: true,
         },
-        motor: {
+        motorist: {
           icon: faCar,
           fatalSyntax: `motor_vehicle_death_count > 0`,
           injurySyntax: `motor_vehicle_serious_injury_count > 0`,
@@ -152,7 +179,7 @@ const SideMapControl = ({ type }) => {
           operator: `OR`,
           default: true,
         },
-        motorcycle: {
+        motorcyclist: {
           icon: faMotorcycle,
           fatalSyntax: `motorcycle_death_count > 0`,
           injurySyntax: `motorcycle_serious_injury_count > 0`,
@@ -285,13 +312,14 @@ const SideMapControl = ({ type }) => {
         </Label>
         {/* Create a button group for each group of mapFilters */}
         {Object.entries(mapButtonFilters).map(([group, groupParameters], i) => (
-          <Row className="mx-0 mb-3" key={`${group}-buttons`}>
+          <Row
+            className={`mx-0 mb-3 ${groupParameters.shared.allClass || ""}`}
+            key={`${group}-buttons`}
+          >
             {/* Create buttons for each filter within a group of mapFilters */}
             {Object.entries(groupParameters.each).map(
               ([name, parameter], i) => {
-                const uiClassName =
-                  groupParameters.shared.buttonClass &&
-                  groupParameters.shared.buttonClass;
+                const eachClassName = groupParameters.shared.eachClass || "";
 
                 switch (groupParameters.shared.uiType) {
                   case "button":
@@ -305,7 +333,7 @@ const SideMapControl = ({ type }) => {
                           key={name}
                           id={name}
                           color="dark"
-                          className={`p-1 filter-button ${uiClassName}`}
+                          className={`p-1 filter-button ${eachClassName}`}
                           onClick={
                             parameter.handler
                               ? parameter.handler
@@ -336,37 +364,37 @@ const SideMapControl = ({ type }) => {
                   case "checkbox":
                     return (
                       <Col xs={12} key={name} className="py-1">
-                        <Label className="text-dark" check>
-                          <Input
-                            key={name}
-                            id={name}
-                            type="checkbox"
-                            className={"filter-button"}
-                            color="dark"
-                            onClick={
-                              parameter.handler
-                                ? parameter.handler
-                                : (event) => handleFilterClick(event, group)
-                            }
-                            checked={
-                              parameter.isSelected
-                                ? parameter.isSelected
-                                : isFilterSet(name)
-                            }
-                          />{" "}
-                          <span className="ml-3">
-                            {parameter.icon && (
-                              <FontAwesomeIcon
-                                icon={parameter.icon}
-                                className="mr-1 fa-fw"
-                                color={
-                                  parameter.iconColor && parameter.iconColor
-                                }
-                              />
-                            )}{" "}
-                            {name[0].toUpperCase() + name.slice(1)}
-                          </span>
-                        </Label>
+                        <span
+                          id={name}
+                          className={`text-dark ${
+                            groupParameters.shared.eachClass || ""
+                          }`}
+                          onClick={
+                            parameter.handler
+                              ? parameter.handler
+                              : (event) => handleFilterClick(event, group)
+                          }
+                        >
+                          {parameter.isSelected || isFilterSet(name) ? (
+                            <FontAwesomeIcon
+                              icon={faCheckSquare}
+                              className="mr-1 active far"
+                            />
+                          ) : (
+                            <FontAwesomeIcon
+                              icon={faSquare}
+                              className="mr-1 inactive far"
+                            />
+                          )}
+                          {parameter.icon && (
+                            <FontAwesomeIcon
+                              icon={parameter.icon}
+                              className="mr-1 ml-2 fa-fw"
+                              color={parameter.iconColor && parameter.iconColor}
+                            />
+                          )}{" "}
+                          {name[0].toUpperCase() + name.slice(1)}
+                        </span>
                       </Col>
                     );
                   default:

--- a/atd-vzv/src/views/nav/SideMapControl.js
+++ b/atd-vzv/src/views/nav/SideMapControl.js
@@ -93,83 +93,81 @@ const SideMapControl = ({ type }) => {
   // Define groups of map button filters
   const mapButtonFilters = {
     type: {
-      all: {
-        text: `All`,
-        colSize: "auto",
-        handler: () => handleTypeFilterClick(["injury", "fatal"]),
-        isSelected: isMapTypeSet.injury && isMapTypeSet.fatal,
-        default: false,
+      shared: {
         buttonClass: `type-button`,
         uiType: "button",
       },
-      fatal: {
-        text: `Fatal`,
-        colSize: "auto",
-        icon: faHeartbeat,
-        iconColor: colors.fatalities,
-        handler: () => handleTypeFilterClick(["fatal"]),
-        isSelected: isMapTypeSet.fatal && !isMapTypeSet.injury,
-        default: false,
-        buttonClass: `type-button`,
-        uiType: "button",
-      },
-      seriousInjury: {
-        text: `Serious Injuries`,
-        colSize: "auto",
-        icon: faMedkit,
-        iconColor: colors.seriousInjuries,
-        handler: () => handleTypeFilterClick(["injury"]),
-        isSelected: isMapTypeSet.injury && !isMapTypeSet.fatal,
-        default: false,
-        buttonClass: `type-button`,
-        uiType: "button",
+      each: {
+        all: {
+          text: `All`,
+          colSize: "auto",
+          handler: () => handleTypeFilterClick(["injury", "fatal"]),
+          isSelected: isMapTypeSet.injury && isMapTypeSet.fatal,
+          default: false,
+        },
+        fatal: {
+          text: `Fatal`,
+          colSize: "auto",
+          icon: faHeartbeat,
+          iconColor: colors.fatalities,
+          handler: () => handleTypeFilterClick(["fatal"]),
+          isSelected: isMapTypeSet.fatal && !isMapTypeSet.injury,
+          default: false,
+        },
+        seriousInjury: {
+          text: `Serious Injuries`,
+          colSize: "auto",
+          icon: faMedkit,
+          iconColor: colors.seriousInjuries,
+          handler: () => handleTypeFilterClick(["injury"]),
+          isSelected: isMapTypeSet.injury && !isMapTypeSet.fatal,
+          default: false,
+        },
       },
     },
     mode: {
-      pedestrian: {
-        icon: faWalking, // Font Awesome icon object
-        fatalSyntax: `pedestrian_death_count > 0`, // Fatality query string
-        injurySyntax: `pedestrian_serious_injury_count > 0`, // Injury query string
-        type: `where`, // Socrata SoQL query type
-        operator: `OR`, // Logical operator for joining multiple query strings
-        default: true, // Apply filter as default on render
-        uiType: "checkbox",
-      },
-      pedalcyclist: {
-        icon: faBiking,
-        fatalSyntax: `bicycle_death_count > 0`,
-        injurySyntax: `bicycle_serious_injury_count > 0`,
-        type: `where`,
-        operator: `OR`,
-        default: true,
-        uiType: "checkbox",
-      },
-      motor: {
-        icon: faCar,
-        fatalSyntax: `motor_vehicle_death_count > 0`,
-        injurySyntax: `motor_vehicle_serious_injury_count > 0`,
-        type: `where`,
-        operator: `OR`,
-        default: true,
-        uiType: "checkbox",
-      },
-      motorcycle: {
-        icon: faMotorcycle,
-        fatalSyntax: `motorcycle_death_count > 0`,
-        injurySyntax: `motorcycle_serious_injury_count > 0`,
-        type: `where`,
-        operator: `OR`,
-        default: true,
-        uiType: "checkbox",
-      },
-      other: {
-        icon: faEllipsisH,
-        fatalSyntax: `other_death_count > 0`,
-        injurySyntax: `other_serious_injury_count > 0`,
-        type: `where`,
-        operator: `OR`,
-        default: true,
-        uiType: "checkbox",
+      shared: { uiType: "checkbox" },
+      each: {
+        pedestrian: {
+          icon: faWalking, // Font Awesome icon object
+          fatalSyntax: `pedestrian_death_count > 0`, // Fatality query string
+          injurySyntax: `pedestrian_serious_injury_count > 0`, // Injury query string
+          type: `where`, // Socrata SoQL query type
+          operator: `OR`, // Logical operator for joining multiple query strings
+          default: true, // Apply filter as default on render
+        },
+        pedalcyclist: {
+          icon: faBiking,
+          fatalSyntax: `bicycle_death_count > 0`,
+          injurySyntax: `bicycle_serious_injury_count > 0`,
+          type: `where`,
+          operator: `OR`,
+          default: true,
+        },
+        motor: {
+          icon: faCar,
+          fatalSyntax: `motor_vehicle_death_count > 0`,
+          injurySyntax: `motor_vehicle_serious_injury_count > 0`,
+          type: `where`,
+          operator: `OR`,
+          default: true,
+        },
+        motorcycle: {
+          icon: faMotorcycle,
+          fatalSyntax: `motorcycle_death_count > 0`,
+          injurySyntax: `motorcycle_serious_injury_count > 0`,
+          type: `where`,
+          operator: `OR`,
+          default: true,
+        },
+        other: {
+          icon: faEllipsisH,
+          fatalSyntax: `other_death_count > 0`,
+          injurySyntax: `other_serious_injury_count > 0`,
+          type: `where`,
+          operator: `OR`,
+          default: true,
+        },
       },
     },
   };
@@ -191,7 +189,7 @@ const SideMapControl = ({ type }) => {
     if (Object.keys(buttonFilters).length === 0) {
       const initialFiltersArray = Object.entries(mapButtonFilters).reduce(
         (allFiltersAccumulator, [type, filtersGroup]) => {
-          const groupFilters = Object.entries(filtersGroup).reduce(
+          const groupFilters = Object.entries(filtersGroup.each).reduce(
             (groupFiltersAccumulator, [name, filterConfig]) => {
               // Apply filter only if set as a default on render
               if (filterConfig.default) {
@@ -266,7 +264,7 @@ const SideMapControl = ({ type }) => {
         : filters;
       setButtonFilters(updatedFiltersArray);
     } else {
-      const filter = mapButtonFilters[filterGroup][filterName];
+      const filter = mapButtonFilters[filterGroup].each[filterName];
       // Add filterName and group to object for IDing and grouping
       filter["name"] = filterName;
       filter["group"] = filterGroup;
@@ -289,87 +287,93 @@ const SideMapControl = ({ type }) => {
         {Object.entries(mapButtonFilters).map(([group, groupParameters], i) => (
           <Row className="mx-0 mb-3" key={`${group}-buttons`}>
             {/* Create buttons for each filter within a group of mapFilters */}
-            {Object.entries(groupParameters).map(([name, parameter], i) => {
-              switch (parameter.uiType) {
-                case "button":
-                  return (
-                    <Col
-                      xs={parameter.colSize && parameter.colSize}
-                      className="px-0"
-                      key={name}
-                    >
-                      <Button
+            {Object.entries(groupParameters.each).map(
+              ([name, parameter], i) => {
+                const uiClassName =
+                  groupParameters.shared.buttonClass &&
+                  groupParameters.shared.buttonClass;
+
+                switch (groupParameters.shared.uiType) {
+                  case "button":
+                    return (
+                      <Col
+                        xs={parameter.colSize && parameter.colSize}
+                        className="px-0"
                         key={name}
-                        id={name}
-                        color="dark"
-                        className={`p-1 filter-button ${
-                          parameter.buttonClass && parameter.buttonClass
-                        }`}
-                        onClick={
-                          parameter.handler
-                            ? parameter.handler
-                            : (event) => handleFilterClick(event, group)
-                        }
-                        active={
-                          parameter.isSelected
-                            ? parameter.isSelected
-                            : isFilterSet(name)
-                        }
-                        outline={
-                          parameter.isSelected
-                            ? !parameter.isSelected
-                            : !isFilterSet(name)
-                        }
                       >
-                        {parameter.icon && (
-                          <FontAwesomeIcon
-                            icon={parameter.icon}
-                            className="mr-1 ml-1"
-                            color={parameter.iconColor && parameter.iconColor}
-                          />
-                        )}
-                        {parameter.text}
-                      </Button>
-                    </Col>
-                  );
-                case "checkbox":
-                  return (
-                    <Col xs={12} key={name} className="py-1">
-                      <Label className="text-dark" check>
-                        <Input
+                        <Button
                           key={name}
                           id={name}
-                          type="checkbox"
-                          className={"filter-button"}
                           color="dark"
+                          className={`p-1 filter-button ${uiClassName}`}
                           onClick={
                             parameter.handler
                               ? parameter.handler
                               : (event) => handleFilterClick(event, group)
                           }
-                          checked={
+                          active={
                             parameter.isSelected
                               ? parameter.isSelected
                               : isFilterSet(name)
                           }
-                        />{" "}
-                        <span className="ml-3">
+                          outline={
+                            parameter.isSelected
+                              ? !parameter.isSelected
+                              : !isFilterSet(name)
+                          }
+                        >
                           {parameter.icon && (
                             <FontAwesomeIcon
                               icon={parameter.icon}
-                              className="mr-1 fa-fw"
+                              className="mr-1 ml-1"
                               color={parameter.iconColor && parameter.iconColor}
                             />
-                          )}{" "}
-                          {name[0].toUpperCase() + name.slice(1)}
-                        </span>
-                      </Label>
-                    </Col>
-                  );
-                default:
-                  return null;
+                          )}
+                          {parameter.text}
+                        </Button>
+                      </Col>
+                    );
+                  case "checkbox":
+                    return (
+                      <Col xs={12} key={name} className="py-1">
+                        <Label className="text-dark" check>
+                          <Input
+                            key={name}
+                            id={name}
+                            type="checkbox"
+                            className={"filter-button"}
+                            color="dark"
+                            onClick={
+                              parameter.handler
+                                ? parameter.handler
+                                : (event) => handleFilterClick(event, group)
+                            }
+                            checked={
+                              parameter.isSelected
+                                ? parameter.isSelected
+                                : isFilterSet(name)
+                            }
+                          />{" "}
+                          <span className="ml-3">
+                            {parameter.icon && (
+                              <FontAwesomeIcon
+                                icon={parameter.icon}
+                                className="mr-1 fa-fw"
+                                color={
+                                  parameter.iconColor && parameter.iconColor
+                                }
+                              />
+                            )}{" "}
+                            {name[0].toUpperCase() + name.slice(1)}
+                          </span>
+                        </Label>
+                      </Col>
+                    );
+                  default:
+                    return null;
+                }
               }
-            })}
+            )}
           </Row>
         ))}
         <SideMapControlDateRange type={type} />

--- a/atd-vzv/src/views/nav/SideMapControl.js
+++ b/atd-vzv/src/views/nav/SideMapControl.js
@@ -18,6 +18,7 @@ import {
   faMotorcycle,
   faHeartbeat,
   faMedkit,
+  faEllipsisH,
 } from "@fortawesome/free-solid-svg-icons";
 
 const StyledCard = styled.div`
@@ -163,7 +164,7 @@ const SideMapControl = ({ type }) => {
         uiType: "checkbox",
       },
       other: {
-        text: "Other",
+        icon: faEllipsisH,
         fatalSyntax: `other_death_count > 0`,
         injurySyntax: `other_serious_injury_count > 0`,
         type: `where`,
@@ -330,20 +331,20 @@ const SideMapControl = ({ type }) => {
                   </Button>
                 </Col>
               ) : (
-                <Col xs={12} key={name}>
+                <Col xs={12} key={name} className="py-1">
                   <Label className="text-dark" check>
                     <Input
                       key={name}
                       id={name}
                       type="checkbox"
-                      className={"py-1 filter-button "}
+                      className={"filter-button"}
                       color="dark"
                       onClick={
                         parameter.handler
                           ? parameter.handler
                           : (event) => handleFilterClick(event, group)
                       }
-                      active={
+                      checked={
                         parameter.isSelected
                           ? parameter.isSelected
                           : isFilterSet(name)
@@ -353,7 +354,7 @@ const SideMapControl = ({ type }) => {
                       {parameter.icon && (
                         <FontAwesomeIcon
                           icon={parameter.icon}
-                          className="mr-1"
+                          className="mr-1 fa-fw"
                           color={parameter.iconColor && parameter.iconColor}
                         />
                       )}{" "}

--- a/atd-vzv/src/views/nav/SideMapControl.js
+++ b/atd-vzv/src/views/nav/SideMapControl.js
@@ -8,7 +8,7 @@ import { trackPageEvent } from "../../constants/nav";
 import InfoPopover from "../../Components/Popover/InfoPopover";
 import { popoverConfig } from "../../Components/Popover/popoverConfig";
 import { colors } from "../../constants/colors";
-import { Button, Card, Label, Row, Col, Input, FormGroup } from "reactstrap";
+import { Button, Card, Label, Row, Col, Input } from "reactstrap";
 import styled from "styled-components";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
@@ -54,6 +54,10 @@ const StyledCard = styled.div`
   }
   [class^="DateInput_"] {
     text-align: center;
+  }
+
+  .icon-container {
+    min-width: 24px;
   }
 `;
 
@@ -129,7 +133,6 @@ const SideMapControl = ({ type }) => {
         type: `where`, // Socrata SoQL query type
         operator: `OR`, // Logical operator for joining multiple query strings
         default: true, // Apply filter as default on render
-        buttonClass: `type-button`,
         uiType: "checkbox",
       },
       pedalcyclist: {
@@ -139,7 +142,6 @@ const SideMapControl = ({ type }) => {
         type: `where`,
         operator: `OR`,
         default: true,
-        buttonClass: `type-button`,
         uiType: "checkbox",
       },
       motor: {
@@ -328,23 +330,26 @@ const SideMapControl = ({ type }) => {
                   </Button>
                 </Col>
               ) : (
-                <Col xs={12} className="px-0" key={name}>
-                  <FormGroup check>
-                    <Label check>
-                      <Input
-                        type="checkbox"
-                        className={"py-1 filter-button dark"}
-                        onClick={
-                          parameter.handler
-                            ? parameter.handler
-                            : (event) => handleFilterClick(event, group)
-                        }
-                        active={
-                          parameter.isSelected
-                            ? parameter.isSelected
-                            : isFilterSet(name)
-                        }
-                      />{" "}
+                <Col xs={12} key={name}>
+                  <Label className="text-dark" check>
+                    <Input
+                      key={name}
+                      id={name}
+                      type="checkbox"
+                      className={"py-1 filter-button "}
+                      color="dark"
+                      onClick={
+                        parameter.handler
+                          ? parameter.handler
+                          : (event) => handleFilterClick(event, group)
+                      }
+                      active={
+                        parameter.isSelected
+                          ? parameter.isSelected
+                          : isFilterSet(name)
+                      }
+                    />{" "}
+                    <span className="ml-3">
                       {parameter.icon && (
                         <FontAwesomeIcon
                           icon={parameter.icon}
@@ -353,40 +358,8 @@ const SideMapControl = ({ type }) => {
                         />
                       )}{" "}
                       {name[0].toUpperCase() + name.slice(1)}
-                    </Label>
-                  </FormGroup>
-                  {/* <Button
-                    key={name}
-                    id={name}
-                    color="dark"
-                    className={`p-1 filter-button ${
-                      parameter.buttonClass && parameter.buttonClass
-                    }`}
-                    onClick={
-                      parameter.handler
-                        ? parameter.handler
-                        : (event) => handleFilterClick(event, group)
-                    }
-                    active={
-                      parameter.isSelected
-                        ? parameter.isSelected
-                        : isFilterSet(name)
-                    }
-                    outline={
-                      parameter.isSelected
-                        ? !parameter.isSelected
-                        : !isFilterSet(name)
-                    }
-                  >
-                    {parameter.icon && (
-                      <FontAwesomeIcon
-                        icon={parameter.icon}
-                        className="mr-1 ml-1"
-                        color={parameter.iconColor && parameter.iconColor}
-                      />
-                    )}
-                    {parameter.text}
-                  </Button> */}
+                    </span>
+                  </Label>
                 </Col>
               );
             })}

--- a/atd-vzv/src/views/nav/SideMapControl.js
+++ b/atd-vzv/src/views/nav/SideMapControl.js
@@ -8,7 +8,7 @@ import { trackPageEvent } from "../../constants/nav";
 import InfoPopover from "../../Components/Popover/InfoPopover";
 import { popoverConfig } from "../../Components/Popover/popoverConfig";
 import { colors } from "../../constants/colors";
-import { Button, Card, Label, Row, Col } from "reactstrap";
+import { Button, Card, Label, Row, Col, Input, FormGroup } from "reactstrap";
 import styled from "styled-components";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
@@ -96,6 +96,7 @@ const SideMapControl = ({ type }) => {
         isSelected: isMapTypeSet.injury && isMapTypeSet.fatal,
         default: false,
         buttonClass: `type-button`,
+        uiType: "button",
       },
       fatal: {
         text: `Fatal`,
@@ -106,6 +107,7 @@ const SideMapControl = ({ type }) => {
         isSelected: isMapTypeSet.fatal && !isMapTypeSet.injury,
         default: false,
         buttonClass: `type-button`,
+        uiType: "button",
       },
       seriousInjury: {
         text: `Serious Injuries`,
@@ -116,6 +118,7 @@ const SideMapControl = ({ type }) => {
         isSelected: isMapTypeSet.injury && !isMapTypeSet.fatal,
         default: false,
         buttonClass: `type-button`,
+        uiType: "button",
       },
     },
     mode: {
@@ -126,6 +129,8 @@ const SideMapControl = ({ type }) => {
         type: `where`, // Socrata SoQL query type
         operator: `OR`, // Logical operator for joining multiple query strings
         default: true, // Apply filter as default on render
+        buttonClass: `type-button`,
+        uiType: "checkbox",
       },
       pedalcyclist: {
         icon: faBiking,
@@ -134,6 +139,8 @@ const SideMapControl = ({ type }) => {
         type: `where`,
         operator: `OR`,
         default: true,
+        buttonClass: `type-button`,
+        uiType: "checkbox",
       },
       motor: {
         icon: faCar,
@@ -142,6 +149,7 @@ const SideMapControl = ({ type }) => {
         type: `where`,
         operator: `OR`,
         default: true,
+        uiType: "checkbox",
       },
       motorcycle: {
         icon: faMotorcycle,
@@ -150,6 +158,7 @@ const SideMapControl = ({ type }) => {
         type: `where`,
         operator: `OR`,
         default: true,
+        uiType: "checkbox",
       },
       other: {
         text: "Other",
@@ -158,6 +167,7 @@ const SideMapControl = ({ type }) => {
         type: `where`,
         operator: `OR`,
         default: true,
+        uiType: "checkbox",
       },
     },
   };
@@ -277,46 +287,109 @@ const SideMapControl = ({ type }) => {
         {Object.entries(mapButtonFilters).map(([group, groupParameters], i) => (
           <Row className="mx-0 mb-3" key={`${group}-buttons`}>
             {/* Create buttons for each filter within a group of mapFilters */}
-            {Object.entries(groupParameters).map(([name, parameter], i) => (
-              <Col
-                xs={parameter.colSize && parameter.colSize}
-                className="px-0"
-                key={name}
-              >
-                <Button
+            {Object.entries(groupParameters).map(([name, parameter], i) => {
+              return parameter.uiType === "button" ? (
+                <Col
+                  xs={parameter.colSize && parameter.colSize}
+                  className="px-0"
                   key={name}
-                  id={name}
-                  color="dark"
-                  className={`p-1 filter-button ${
-                    parameter.buttonClass && parameter.buttonClass
-                  }`}
-                  onClick={
-                    parameter.handler
-                      ? parameter.handler
-                      : (event) => handleFilterClick(event, group)
-                  }
-                  active={
-                    parameter.isSelected
-                      ? parameter.isSelected
-                      : isFilterSet(name)
-                  }
-                  outline={
-                    parameter.isSelected
-                      ? !parameter.isSelected
-                      : !isFilterSet(name)
-                  }
                 >
-                  {parameter.icon && (
-                    <FontAwesomeIcon
-                      icon={parameter.icon}
-                      className="mr-1 ml-1"
-                      color={parameter.iconColor && parameter.iconColor}
-                    />
-                  )}
-                  {parameter.text}
-                </Button>
-              </Col>
-            ))}
+                  <Button
+                    key={name}
+                    id={name}
+                    color="dark"
+                    className={`p-1 filter-button ${
+                      parameter.buttonClass && parameter.buttonClass
+                    }`}
+                    onClick={
+                      parameter.handler
+                        ? parameter.handler
+                        : (event) => handleFilterClick(event, group)
+                    }
+                    active={
+                      parameter.isSelected
+                        ? parameter.isSelected
+                        : isFilterSet(name)
+                    }
+                    outline={
+                      parameter.isSelected
+                        ? !parameter.isSelected
+                        : !isFilterSet(name)
+                    }
+                  >
+                    {parameter.icon && (
+                      <FontAwesomeIcon
+                        icon={parameter.icon}
+                        className="mr-1 ml-1"
+                        color={parameter.iconColor && parameter.iconColor}
+                      />
+                    )}
+                    {parameter.text}
+                  </Button>
+                </Col>
+              ) : (
+                <Col xs={12} className="px-0" key={name}>
+                  <FormGroup check>
+                    <Label check>
+                      <Input
+                        type="checkbox"
+                        className={"py-1 filter-button dark"}
+                        onClick={
+                          parameter.handler
+                            ? parameter.handler
+                            : (event) => handleFilterClick(event, group)
+                        }
+                        active={
+                          parameter.isSelected
+                            ? parameter.isSelected
+                            : isFilterSet(name)
+                        }
+                      />{" "}
+                      {parameter.icon && (
+                        <FontAwesomeIcon
+                          icon={parameter.icon}
+                          className="mr-1"
+                          color={parameter.iconColor && parameter.iconColor}
+                        />
+                      )}{" "}
+                      {name[0].toUpperCase() + name.slice(1)}
+                    </Label>
+                  </FormGroup>
+                  {/* <Button
+                    key={name}
+                    id={name}
+                    color="dark"
+                    className={`p-1 filter-button ${
+                      parameter.buttonClass && parameter.buttonClass
+                    }`}
+                    onClick={
+                      parameter.handler
+                        ? parameter.handler
+                        : (event) => handleFilterClick(event, group)
+                    }
+                    active={
+                      parameter.isSelected
+                        ? parameter.isSelected
+                        : isFilterSet(name)
+                    }
+                    outline={
+                      parameter.isSelected
+                        ? !parameter.isSelected
+                        : !isFilterSet(name)
+                    }
+                  >
+                    {parameter.icon && (
+                      <FontAwesomeIcon
+                        icon={parameter.icon}
+                        className="mr-1 ml-1"
+                        color={parameter.iconColor && parameter.iconColor}
+                      />
+                    )}
+                    {parameter.text}
+                  </Button> */}
+                </Col>
+              );
+            })}
           </Row>
         ))}
         <SideMapControlDateRange type={type} />


### PR DESCRIPTION
Closes https://github.com/cityofaustin/atd-data-tech/issues/2640

This PR replaces the existing map view mode buttons with checkboxes to make the UI more intuitive. A new property in the filter config called `uiType` was added to start enabling the addition of more than just buttons in the side bar. I also split out properties that are common to a set of filters (crash type, mode, etc.) and created an idea of `each` and `all` configs for each type for properties that need to be set for each button/checkbox/etc. or for the whole set.

I also added the same Windows fix that @sergiogcx added to the date picker so that the type filter buttons font size only changes when necessary.

Still reviewing this work with @JaceDeloney, but that require small changes to this updated code.

#### Updated mode UI
<img width="523" alt="Screen Shot 2020-08-20 at 3 28 01 PM" src="https://user-images.githubusercontent.com/37249039/90822335-e5e5d400-e2f9-11ea-8c5d-75b11b1af6d7.png">
