### PR TITLE
VZV | Update time of day chart

### DIFF
--- a/atd-vzv/src/views/summary/CrashesByTimeOfDay.js
+++ b/atd-vzv/src/views/summary/CrashesByTimeOfDay.js
@@ -41,6 +41,13 @@ const CrashesByTimeOfDay = () => {
     []
   );
 
+  // Look for the elements within this range and hide them on render (then change to extra row of data that will determine weighting)
+  // When iterating data, find maximum value and use to set max value for last row that will be hidden
+  // Scoot heatmap chart to the right with Col wrapper (Bootstrap class)
+  // Set legend with min 0 and max from data https://github.com/reaviz/reaviz/blob/5fd88e8e8c5bd21572b7b21ffe0ec12df2cc8ba5/src/common/legends/SequentialLegend/SequentialLegend.story.tsx#L15
+  // #demographics-heatmap > div > svg > g > g:nth-child(170)
+  // #demographics-heatmap > div > svg > g > g:nth-child(164)
+
   useEffect(() => {
     const dayOfWeekArray = moment.weekdaysShort();
 
@@ -164,7 +171,7 @@ const CrashesByTimeOfDay = () => {
         </Col>
       </Row>
       <Row className="h-auto">
-        <Col>
+        <Col id="demographics-heatmap">
           <Heatmap
             height={267}
             data={heatmapData}

--- a/atd-vzv/src/views/summary/CrashesByTimeOfDay.js
+++ b/atd-vzv/src/views/summary/CrashesByTimeOfDay.js
@@ -43,12 +43,6 @@ const CrashesByTimeOfDay = () => {
     if (activeTab !== tab) setActiveTab(tab);
   };
 
-  // Look for the elements within this range and hide them on render (then change to extra row of data that will determine weighting)
-  // When iterating data, find maximum value and use to set max value for last row that will be hidden
-  // Scoot heatmap chart to the right with Col wrapper (Bootstrap class)
-  // #demographics-heatmap > div > svg > g > g:nth-child(170)
-  // #demographics-heatmap > div > svg > g > g:nth-child(164)
-
   useEffect(() => {
     const buildDataArray = () => {
       // This array holds weekday totals for each hour window within a day
@@ -159,6 +153,24 @@ const CrashesByTimeOfDay = () => {
       setHeatmapData(updatedWeightingData);
     }
   }, [maxForLegend, heatmapData, crashType]);
+
+  useEffect(() => {
+    const heatmapChildCellNumbers = [171, 172, 173, 174, 175, 176, 177];
+
+    let cellsToHide = heatmapChildCellNumbers.map((num) =>
+      document.querySelector(
+        `#demographics-heatmap > div > svg > g > g:nth-child(${num})`
+      )
+    );
+
+    cellsToHide.forEach((cell) => {
+      if (!!cell) {
+        cell.style.visibility = "hidden";
+      }
+    });
+  }, [heatmapData, crashType]);
+
+  // Scoot heatmap chart to the right with Col wrapper (Bootstrap class)
 
   const formatValue = (d) => {
     const value = d.data.value ? d.data.value : 0;

--- a/atd-vzv/src/views/summary/CrashesByTimeOfDay.js
+++ b/atd-vzv/src/views/summary/CrashesByTimeOfDay.js
@@ -101,9 +101,6 @@ const CrashesByTimeOfDay = () => {
       return queryUrl;
     };
 
-    // Wait for crashType to be passed up from setCrashType component,
-    // then fetch records for selected year
-
     axios.get(getFatalitiesByYearsAgoUrl()).then((res) => {
       const formattedData = calculateHourBlockTotals(res.data);
       setHeatmapData(formattedData);
@@ -138,24 +135,25 @@ const CrashesByTimeOfDay = () => {
     const isPlaceholderArraySet =
       lastRecordInHeatmapData && lastRecordInHeatmapData.key === "";
 
-    if (!!maxForLegend && heatmapData.length > 0 && !isPlaceholderArraySet) {
-      const placeholderArray = heatmapData[0].data.map((data, i) => ({
-        key: dayOfWeekArray[i],
-        data: maxForLegend[crashType.name],
-      }));
+    if (!maxForLegend || heatmapData.length === 0 || isPlaceholderArraySet)
+      return;
 
-      const placeholderObjForChartWeighting = {
-        key: "",
-        data: placeholderArray,
-      };
+    const placeholderArray = heatmapData[0].data.map((data, i) => ({
+      key: dayOfWeekArray[i],
+      data: maxForLegend[crashType.name],
+    }));
 
-      const updatedWeightingData = [
-        ...heatmapData,
-        placeholderObjForChartWeighting,
-      ];
+    const placeholderObjForChartWeighting = {
+      key: "",
+      data: placeholderArray,
+    };
 
-      setHeatmapDataWithPlaceholder(updatedWeightingData);
-    }
+    const updatedWeightingData = [
+      ...heatmapData,
+      placeholderObjForChartWeighting,
+    ];
+
+    setHeatmapDataWithPlaceholder(updatedWeightingData);
   }, [maxForLegend, heatmapData, crashType]);
 
   // Hide placeholder cells

--- a/atd-vzv/src/views/summary/CrashesByTimeOfDay.js
+++ b/atd-vzv/src/views/summary/CrashesByTimeOfDay.js
@@ -21,6 +21,7 @@ import {
   summaryCurrentYearStartDate,
   summaryCurrentYearEndDate,
   yearsArray,
+  dataStartDate,
   dataEndDate,
 } from "../../constants/time";
 import { crashEndpointUrl } from "./queries/socrataQueries";
@@ -118,10 +119,13 @@ const CrashesByTimeOfDay = () => {
   useEffect(() => {
     const maxQuery = `
     SELECT date_extract_dow(crash_date) as day, date_extract_hh(crash_date) as hour, date_extract_y(crash_date) as year, SUM(death_cnt) as death, SUM(sus_serious_injry_cnt) as serious, serious + death as all 
-    WHERE crash_date BETWEEN '2016-01-01' and '2020-06-30' 
-    GROUP BY day, hour, year ORDER BY year 
+    WHERE crash_date BETWEEN '${dataStartDate.format(
+      "YYYY-MM-DD"
+    )}' and '${summaryCurrentYearEndDate}' 
+    GROUP BY day, hour, year 
+    ORDER BY year 
     |> 
-    SELECT max(death) as max_death, max(serious) as max_serious, max(all) as max_all
+    SELECT max(death) as fatalities, max(serious) as seriousInjuries, max(all) as fatalitiesAndSeriousInjuries
     `;
 
     if (!maxForLegend) {
@@ -132,6 +136,15 @@ const CrashesByTimeOfDay = () => {
         });
     }
   }, [maxForLegend, crashType]);
+
+  // useEffect(() => {
+  //   if(!!maxForLegend && !!heatmapData){
+  //     const currentData = heatmapData;
+
+  //     const dummyArray = [];
+
+  //   }
+  // }, [maxForLegend, heatmapData])
 
   const formatValue = (d) => {
     const value = d.data.value ? d.data.value : 0;
@@ -243,16 +256,19 @@ const CrashesByTimeOfDay = () => {
       </Row>
       <Row>
         <Col className="py-2">
-          <SequentialLegend
-            data={heatmapData}
-            orientation="horizontal"
-            colorScheme={[
-              colors.intensity2Of5,
-              colors.intensity3Of5,
-              colors.intensity4Of5,
-              colors.viridis1Of6Highest,
-            ]}
-          />
+          {!!maxForLegend && (
+            <SequentialLegend
+              data={[
+                { key: "Max", data: maxForLegend[crashType.name] },
+                { key: "Min", data: 0 },
+              ]}
+              orientation="horizontal"
+              colorScheme={[
+                colors.intensity1Of5Lowest,
+                colors.viridis1Of6Highest,
+              ]}
+            />
+          )}
         </Col>
       </Row>
     </Container>


### PR DESCRIPTION
Closes https://github.com/cityofaustin/atd-data-tech/issues/3555

This PR updates the Time of Day chart to have the same maximum value across each year for each type of crash (All, Fatalities, Serious Injuries). Since only a single year's data is fetched at once, I added a SoQL query to get hour and days totals across the entire VZ rolling time window for each type and then sub-query for the maximum of each of those hourly, daily totals. This query will be reusable if we decide to refactor the chart data fetch in the future.

The legend is then set with that max and a placeholder column filled with the max value is added to the chart data. That column is then hidden and the left padding is adjusted to center the chart.

Thanks to @mateoclarke for the idea about the extra column with the maximums. Worked like magic!

## Before
<img width="625" alt="Screen Shot 2020-08-26 at 11 17 49 AM" src="https://user-images.githubusercontent.com/37249039/91329503-d51bdf00-e78d-11ea-93ab-d04c4822b1d3.png">
<img width="625" alt="Screen Shot 2020-08-26 at 11 17 53 AM" src="https://user-images.githubusercontent.com/37249039/91329512-d77e3900-e78d-11ea-8f5a-6044fe496f7a.png">

## After
<img width="625" alt="Screen Shot 2020-08-26 at 11 17 59 AM" src="https://user-images.githubusercontent.com/37249039/91329515-da792980-e78d-11ea-8a05-cafaaef71798.png">
<img width="625" alt="Screen Shot 2020-08-26 at 11 18 03 AM" src="https://user-images.githubusercontent.com/37249039/91329520-dc42ed00-e78d-11ea-957f-b1cdc0b18fcf.png">

