### PR TITLE
VZV | Map | Mode filters reset after changing type filter on touch devices

### DIFF
--- a/atd-vzv/src/utils/store.js
+++ b/atd-vzv/src/utils/store.js
@@ -7,7 +7,6 @@ export const StoreContext = React.createContext(null);
 
 export default ({ children }) => {
   const [isOpen, setIsOpen] = useState(false);
-  // const [mapFilters, setMapFilters] = useState([]);
   const [mapFilters, mapFilterDispatch] = useReducer(mapFilterReducer, []);
   const [isMapTypeSet, setIsMapTypeSet] = useState({
     fatal: true,
@@ -29,8 +28,6 @@ export default ({ children }) => {
   useEffect(() => {
     !isTablet && setIsOpen(false);
   }, [isTablet, setIsOpen]);
-
-  console.log("Context updated", mapFilters);
 
   const store = {
     mapFilters: [mapFilters, mapFilterDispatch],

--- a/atd-vzv/src/utils/store.js
+++ b/atd-vzv/src/utils/store.js
@@ -1,12 +1,14 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useReducer } from "react";
 import { mapStartDate, mapEndDate } from "../constants/time";
 import { useIsTablet } from "../constants/responsive";
+import { mapFilterReducer } from "../views/nav/SideMapControl";
 
 export const StoreContext = React.createContext(null);
 
 export default ({ children }) => {
   const [isOpen, setIsOpen] = useState(false);
-  const [mapFilters, setMapFilters] = useState([]);
+  // const [mapFilters, setMapFilters] = useState([]);
+  const [mapFilters, mapFilterDispatch] = useReducer(mapFilterReducer, []);
   const [isMapTypeSet, setIsMapTypeSet] = useState({
     fatal: true,
     injury: true,
@@ -31,7 +33,7 @@ export default ({ children }) => {
   console.log("Context updated", mapFilters);
 
   const store = {
-    mapFilters: [mapFilters, setMapFilters],
+    mapFilters: [mapFilters, mapFilterDispatch],
     mapFilterType: [isMapTypeSet, setIsMapTypeSet],
     mapDateRange,
     setMapDateRange,

--- a/atd-vzv/src/utils/store.js
+++ b/atd-vzv/src/utils/store.js
@@ -28,6 +28,8 @@ export default ({ children }) => {
     !isTablet && setIsOpen(false);
   }, [isTablet, setIsOpen]);
 
+  console.log("Context updated", mapFilters);
+
   const store = {
     mapFilters: [mapFilters, setMapFilters],
     mapFilterType: [isMapTypeSet, setIsMapTypeSet],

--- a/atd-vzv/src/views/map/helpers.js
+++ b/atd-vzv/src/views/map/helpers.js
@@ -47,6 +47,7 @@ export const createMapDataUrl = (
   if (dateRange.start === null || dateRange.end === null) return null;
   const startDate = convertDateToSocrataFormat(dateRange.start, "T00:00:00");
   const endDate = convertDateToSocrataFormat(dateRange.end, "T23:59:59");
+  console.log(filters, "in Map");
 
   // Return null to prevent populating map with unfiltered data
   return filterCount === 0

--- a/atd-vzv/src/views/map/helpers.js
+++ b/atd-vzv/src/views/map/helpers.js
@@ -47,7 +47,6 @@ export const createMapDataUrl = (
   if (dateRange.start === null || dateRange.end === null) return null;
   const startDate = convertDateToSocrataFormat(dateRange.start, "T00:00:00");
   const endDate = convertDateToSocrataFormat(dateRange.end, "T23:59:59");
-  console.log(filters, "in Map");
 
   // Return null to prevent populating map with unfiltered data
   return filterCount === 0

--- a/atd-vzv/src/views/nav/SideMapControl.js
+++ b/atd-vzv/src/views/nav/SideMapControl.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useReducer, useMemo } from "react";
+import React, { useEffect } from "react";
 import { StoreContext } from "../../utils/store";
 
 import SideMapControlDateRange from "./SideMapControlDateRange";
@@ -95,7 +95,6 @@ const createModeFilterSyntax = (isMapTypeSet, config) => {
 };
 
 export const mapFilterReducer = (mapFilters, action) => {
-  // TODO: Action - set mode filter
   const { type, payload } = action;
 
   switch (type) {
@@ -111,10 +110,6 @@ export const mapFilterReducer = (mapFilters, action) => {
       }));
       return updatedModeFilters;
     case "updateModeFilters":
-      // Payload - filter config
-      // If filter config present, remove (if it isn't the last filter)
-      // If filter config not present, add
-      // return array
       const updatedFiltersArray = payload;
       return updatedFiltersArray;
     default:
@@ -128,12 +123,8 @@ const SideMapControl = ({ type }) => {
     mapFilterType: [isMapTypeSet, setIsMapTypeSet],
   } = React.useContext(StoreContext);
 
-  // const [buttonFilters, setButtonFilters] = useState({});
-  // const [filterGroupCounts, setFilterGroupCounts] = useState({});
-
   const setTypeFilters = (typeArray) => {
     // Set types in array as true and others as false
-    console.log(typeArray);
     const updatedState = Object.keys(isMapTypeSet).reduce((acc, type) => {
       if (typeArray.includes(type)) {
         acc = { ...acc, [type]: true };
@@ -255,10 +246,6 @@ const SideMapControl = ({ type }) => {
     },
   };
 
-  // TODO: Set initial state in useReducer (default filters)
-  // TODO: Create reducer
-  // TODO: Create initial mode filters
-
   // Set initial filters
   useEffect(() => {
     if (filters.length !== 0) return;
@@ -297,82 +284,10 @@ const SideMapControl = ({ type }) => {
     });
   }, [mapButtonFiltersConfig, dispatchFilters, filters, isMapTypeSet]);
 
-  // useEffect(() => {
-  //   if (filters.length !== 0) return;
-
-  //   dispatchFilters({
-  //     type: "setInitialModeFilters",
-  //     payload: initialFiltersArray,
-  //   });
-  // }, [initialFiltersArray, filters, dispatchFilters]);
-
-  // // On inital render, reduce all default filters and apply to map data
-  // useEffect(() => {
-  //   if (Object.keys(buttonFilters).length === 0) {
-  //     const initialFiltersArray = Object.entries(mapButtonFilters).reduce(
-  //       (allFiltersAccumulator, [type, filtersGroup]) => {
-  //         const groupFilters = Object.entries(filtersGroup.each).reduce(
-  //           (groupFiltersAccumulator, [name, filterConfig]) => {
-  //             // Apply filter only if set as a default on render
-  //             if (filterConfig.default) {
-  //               filterConfig["name"] = name;
-  //               filterConfig["group"] = type;
-  //               groupFiltersAccumulator.push(filterConfig);
-  //             }
-  //             return groupFiltersAccumulator;
-  //           },
-  //           []
-  //         );
-  //         allFiltersAccumulator = [...allFiltersAccumulator, ...groupFilters];
-  //         return allFiltersAccumulator;
-  //       },
-  //       []
-  //     );
-  //     setButtonFilters(initialFiltersArray);
-  //   }
-  // }, [mapButtonFilters, setButtonFilters, buttonFilters]);
-
-  // After inital render, create mode syntax and set filters state for map data
-  // useEffect(() => {
-  //   if (Object.keys(buttonFilters).length !== 0) {
-  //     const filterModeSyntaxByType = (filtersArray) =>
-  //       filtersArray.map((filter) => {
-  //         // Set syntax for generateWhereFilters() map helper
-  //         if (isMapTypeSet.fatal && isMapTypeSet.injury) {
-  //           filter.syntax = `${filter.fatalSyntax} ${filter.operator} ${filter.injurySyntax}`;
-  //         } else if (isMapTypeSet.fatal) {
-  //           filter.syntax = filter.fatalSyntax;
-  //         } else if (isMapTypeSet.injury) {
-  //           filter.syntax = filter.injurySyntax;
-  //         }
-  //         return filter;
-  //       });
-
-  //     const updatedFiltersArray = filterModeSyntaxByType(buttonFilters);
-  //     setFilters(updatedFiltersArray);
-  //   }
-  // }, [buttonFilters, isMapTypeSet, setFilters]);
-
-  // Set count of filters applied per type
-  // useEffect(() => {
-  //   const filtersCount = filters.reduce((accumulator, filter) => {
-  //     if (accumulator[filter.group]) {
-  //       accumulator = {
-  //         ...accumulator,
-  //         [filter.group]: accumulator[filter.group] + 1,
-  //       };
-  //     } else {
-  //       accumulator = { ...accumulator, [filter.group]: 1 };
-  //     }
-  //     return accumulator;
-  //   }, {});
-  //   setFilterGroupCounts(filtersCount);
-  // }, [filters]);
-
   const isFilterSet = (filterName) =>
     filters.find((setFilter) => setFilter.name === filterName);
 
-  // // Set filter or remove if already set
+  // Set filter or remove if already set
   const handleFilterClick = (event, filterGroup) => {
     const filterName = event.currentTarget.id;
     let updatedFiltersArray;
@@ -385,7 +300,7 @@ const SideMapControl = ({ type }) => {
           : filters;
     } else {
       const filter = mapButtonFiltersConfig[filterGroup].each[filterName];
-      // Add filterName and group to object for IDing and grouping
+      // Add filterName and group to object for IDing and grouping and create query syntax
       filter["name"] = filterName;
       filter["group"] = filterGroup;
       filter["syntax"] = createModeFilterSyntax(isMapTypeSet, filter);

--- a/atd-vzv/src/views/nav/SideMapControl.js
+++ b/atd-vzv/src/views/nav/SideMapControl.js
@@ -408,10 +408,10 @@ const SideMapControl = ({ type }) => {
                           {parameter.icon && (
                             <FontAwesomeIcon
                               icon={parameter.icon}
-                              className="mr-1 ml-2 fa-fw"
+                              className="mr-2 ml-2 fa-fw"
                               color={parameter.iconColor && parameter.iconColor}
                             />
-                          )}{" "}
+                          )}
                           {title}
                         </Button>
                       </Col>

--- a/atd-vzv/src/views/nav/SideMapControl.js
+++ b/atd-vzv/src/views/nav/SideMapControl.js
@@ -95,20 +95,23 @@ const SideMapControl = ({ type }) => {
 
   const setTypeFilters = (typeArray) => {
     // Set types in array as true and others as false
-    const updatedState = Object.keys(isMapTypeSet).reduce((acc, type) => {
-      if (typeArray.includes(type)) {
-        acc = { ...acc, [type]: true };
-      } else {
-        acc = { ...acc, [type]: false };
-      }
-      return acc;
-    }, {});
+    const updatedState = Object.keys({ ...isMapTypeSet }).reduce(
+      (acc, type) => {
+        if (typeArray.includes(type)) {
+          acc = { ...acc, [type]: true };
+        } else {
+          acc = { ...acc, [type]: false };
+        }
+        return acc;
+      },
+      {}
+    );
 
     setIsMapTypeSet(updatedState);
   };
 
   const handleTypeFilterClick = (filterArr) => {
-    setTypeFilters(filterArr);
+    setTypeFilters([...filterArr]);
     // Track single filter clicks with GA
     filterArr.length === 1 && trackPageEvent(filterArr[0]);
   };
@@ -234,6 +237,7 @@ const SideMapControl = ({ type }) => {
         []
       );
       setButtonFilters(initialFiltersArray);
+      //  TODO: Not here!
     }
   }, [mapButtonFilters, setButtonFilters, buttonFilters]);
 
@@ -242,25 +246,27 @@ const SideMapControl = ({ type }) => {
     if (Object.keys(buttonFilters).length !== 0) {
       const filterModeSyntaxByType = (filtersArray) =>
         filtersArray.map((filter) => {
+          const updatedFilter = { ...filter };
           // Set syntax for generateWhereFilters() map helper
           if (isMapTypeSet.fatal && isMapTypeSet.injury) {
-            filter.syntax = `${filter.fatalSyntax} ${filter.operator} ${filter.injurySyntax}`;
+            updatedFilter.syntax = `${filter.fatalSyntax} ${filter.operator} ${filter.injurySyntax}`;
           } else if (isMapTypeSet.fatal) {
-            filter.syntax = filter.fatalSyntax;
+            updatedFilter.syntax = filter.fatalSyntax;
           } else if (isMapTypeSet.injury) {
-            filter.syntax = filter.injurySyntax;
+            updatedFilter.syntax = filter.injurySyntax;
           }
-          return filter;
+          return updatedFilter;
         });
 
-      const updatedFiltersArray = filterModeSyntaxByType(buttonFilters);
+      const updatedFiltersArray = filterModeSyntaxByType([...buttonFilters]);
+      console.log("Filters updated", updatedFiltersArray);
       setFilters(updatedFiltersArray);
     }
   }, [buttonFilters, isMapTypeSet, setFilters]);
 
   // Set count of filters applied per type
   useEffect(() => {
-    const filtersCount = filters.reduce((accumulator, filter) => {
+    const filtersCount = [...filters].reduce((accumulator, { ...filter }) => {
       if (accumulator[filter.group]) {
         accumulator = {
           ...accumulator,

--- a/atd-vzv/src/views/nav/SideMapControl.js
+++ b/atd-vzv/src/views/nav/SideMapControl.js
@@ -110,6 +110,13 @@ export const mapFilterReducer = (mapFilters, action) => {
         syntax: createModeFilterSyntax(isMapTypeSet, filter),
       }));
       return updatedModeFilters;
+    case "updateModeFilters":
+      // Payload - filter config
+      // If filter config present, remove (if it isn't the last filter)
+      // If filter config not present, add
+      // return array
+      const updatedFiltersArray = payload;
+      return updatedFiltersArray;
     default:
       return null;
   }
@@ -252,6 +259,7 @@ const SideMapControl = ({ type }) => {
   // TODO: Create reducer
   // TODO: Create initial mode filters
 
+  // Set initial filters
   useEffect(() => {
     if (filters.length !== 0) return;
 
@@ -288,30 +296,6 @@ const SideMapControl = ({ type }) => {
       payload: namedAndGroupedFilters,
     });
   }, [mapButtonFiltersConfig, dispatchFilters, filters, isMapTypeSet]);
-
-  // useEffect(() => {
-  //   if (filters.length === 0) return;
-
-  //   const filterModeSyntaxByType = (filtersArray) =>
-  //     filtersArray.map((filter) => {
-  //       // Set syntax for generateWhereFilters() map helper
-  //       if (isMapTypeSet.fatal && isMapTypeSet.injury) {
-  //         filter.syntax = `${filter.fatalSyntax} ${filter.operator} ${filter.injurySyntax}`;
-  //       } else if (isMapTypeSet.fatal) {
-  //         filter.syntax = filter.fatalSyntax;
-  //       } else if (isMapTypeSet.injury) {
-  //         filter.syntax = filter.injurySyntax;
-  //       }
-  //       return filter;
-  //     });
-
-  //   const syntaxSetFilters = filterModeSyntaxByType(filters);
-
-  //   dispatchFilters({
-  //     type: "updateModeFilters",
-  //     payload: syntaxSetFilters,
-  //   });
-  // }, [filters, isMapTypeSet, dispatchFilters]);
 
   // useEffect(() => {
   //   if (filters.length !== 0) return;
@@ -385,33 +369,33 @@ const SideMapControl = ({ type }) => {
   //   setFilterGroupCounts(filtersCount);
   // }, [filters]);
 
-  const isFilterSet = (filterName) => {
-    return (
-      filters.length > 0 &&
-      filters.find((setFilter) => setFilter.name === filterName)
-    );
-  };
-
-  // const isOneFilterOfGroupApplied = (group) => filterGroupCounts[group] > 1;
+  const isFilterSet = (filterName) =>
+    filters.find((setFilter) => setFilter.name === filterName);
 
   // // Set filter or remove if already set
   const handleFilterClick = (event, filterGroup) => {
     const filterName = event.currentTarget.id;
+    let updatedFiltersArray;
 
-    // if (isFilterSet(filterName)) {
-    //   // Always leave one filter applied per group
-    //   let updatedFiltersArray = isOneFilterOfGroupApplied(filterGroup)
-    //     ? filters.filter((setFilter) => setFilter.name !== filterName)
-    //     : filters;
-    //   setButtonFilters(updatedFiltersArray);
-    // } else {
-    //   const filter = mapButtonFilters[filterGroup].each[filterName];
-    //   // Add filterName and group to object for IDing and grouping
-    //   filter["name"] = filterName;
-    //   filter["group"] = filterGroup;
-    //   const filtersArray = [...filters, filter];
-    //   setButtonFilters(filtersArray);
-    // }
+    if (isFilterSet(filterName)) {
+      // Always leave one filter applied per group
+      updatedFiltersArray =
+        filters.length > 1
+          ? filters.filter((setFilter) => setFilter.name !== filterName)
+          : filters;
+    } else {
+      const filter = mapButtonFiltersConfig[filterGroup].each[filterName];
+      // Add filterName and group to object for IDing and grouping
+      filter["name"] = filterName;
+      filter["group"] = filterGroup;
+      filter["syntax"] = createModeFilterSyntax(isMapTypeSet, filter);
+      updatedFiltersArray = [...filters, filter];
+    }
+
+    dispatchFilters({
+      type: "updateModeFilters",
+      payload: updatedFiltersArray,
+    });
   };
 
   return (


### PR DESCRIPTION
Closes https://github.com/cityofaustin/atd-data-tech/issues/3812

This PR updates the `SideMapControl` component and Context store with `useReducer` to handle the state of the mode filters. The bug where filters would reset stemmed from inconsistencies between local state in `SideMapControl` called `buttonFilters` and state in the Context store called `mapFilters`. `useEffect` was used to push changes from `buttonFilters` to `mapFilters`, but I noticed that, in certain conditions, they became out of sync. 

To fix this, I merged these two states and used a reducer to update the query syntax of the filters. `mapFilters` state managed by `useReducer` in the Context store is now the single source of truth for mode filters. This code was tested on my iPhone and multiple Android and iOS devices in BrowserStack.

I also changed the `span` wrappers around the mode filter buttons to `reactstrap` button links to make them keyboard accessible just like all of the other map controls.

![fillterResetBugFix](https://user-images.githubusercontent.com/37249039/92026993-7fb07680-ed27-11ea-9a36-9fd35d6e4363.gif)
