### PR TITLE
VZ Events: City_id

### DIFF
--- a/atd-events/crash_update_jurisdiction/app.py
+++ b/atd-events/crash_update_jurisdiction/app.py
@@ -67,6 +67,18 @@ def get_jurisdiction_flag(data: dict) -> str:
         return "N"
 
 
+def get_city_id(data: dict) -> int:
+    """
+    Returns the city id of the record in question
+    :param dict data: The record in question
+    :return int: The city id as an integer, 0 if it can't find it.
+    """
+    try:
+        return data["event"]["data"]["new"]["city_id"]
+    except (TypeError, KeyError):
+        return 0
+
+
 def load_data(record: str) -> dict:
     """
     Attempts to parse the event data

--- a/atd-events/crash_update_jurisdiction/app.py
+++ b/atd-events/crash_update_jurisdiction/app.py
@@ -2,6 +2,8 @@
 # Resolves the location for a crash.
 #
 import json
+from typing import Optional
+
 import requests
 import time
 import os
@@ -67,28 +69,28 @@ def get_jurisdiction_flag(data: dict) -> str:
         return "N"
 
 
-def get_city_id(data: dict) -> int:
+def get_city_id(data: dict) -> Optional[int]:
     """
     Returns the city id of the record in question
     :param dict data: The record in question
-    :return int: The city id as an integer, 0 if it can't find it.
+    :return Optional[int]: The city id as an integer, 0 if it can't find it.
     """
     try:
         return data["event"]["data"]["new"]["city_id"]
     except (TypeError, KeyError):
-        return 0
+        return None
 
 
-def get_original_city_id(data: dict) -> int:
+def get_original_city_id(data: dict) -> Optional[int]:
     """
     Returns the original city id of the record in question
     :param dict data: The record in question
-    :return int: The city id as an integer, 0 if it can't find it.
+    :return Optional[int]: The city id as an integer, 0 if it can't find it.
     """
     try:
         return data["event"]["data"]["new"]["original_city_id"]
     except (TypeError, KeyError):
-        return 0
+        return None
 
 
 def load_data(record: str) -> dict:

--- a/atd-events/crash_update_jurisdiction/app.py
+++ b/atd-events/crash_update_jurisdiction/app.py
@@ -2,7 +2,7 @@
 # Resolves the location for a crash.
 #
 import json
-from typing import Optional
+from typing import Optional, Set, List
 
 import requests
 import time
@@ -91,6 +91,22 @@ def get_original_city_id(data: dict) -> Optional[int]:
         return data["event"]["data"]["new"]["original_city_id"]
     except (TypeError, KeyError):
         return None
+
+
+def get_jurisdiction_common_members(a: List[int], b: List[int]) -> Set[int]:
+    """
+    Compares two arrays of integers, and returns a set of unique common members
+    :param List[int] a: An array you want to compare against
+    :param List[int] b: The other array you want to compare against
+    :return Set[int]:
+    """
+    a_set = set(a)
+    b_set = set(b)
+
+    if a_set & b_set:
+        return a_set & b_set
+    else:
+        return set()
 
 
 def load_data(record: str) -> dict:

--- a/atd-events/crash_update_jurisdiction/app.py
+++ b/atd-events/crash_update_jurisdiction/app.py
@@ -294,8 +294,6 @@ def update_city_id(crash_id: int, city_id: int) -> dict:
             message=f"Invalid city_id provided to update the city_id",
         )
 
-    print(f"Hello, new value: {city_id}")
-
     # Output
     mutation_response = {}
     # Prepare the query body
@@ -319,7 +317,6 @@ def update_city_id(crash_id: int, city_id: int) -> dict:
             data=json.dumps(mutation_json_body),
             headers=HEADERS
         )
-        print(f"Response: {mutation_response.json()}")
     except Exception as e:
         raise_critical_error(
             message=f"Unable to update crash_id '{crash_id}' city_id {city_id}: {str(e)}"

--- a/atd-events/crash_update_jurisdiction/app.py
+++ b/atd-events/crash_update_jurisdiction/app.py
@@ -79,6 +79,18 @@ def get_city_id(data: dict) -> int:
         return 0
 
 
+def get_original_city_id(data: dict) -> int:
+    """
+    Returns the original city id of the record in question
+    :param dict data: The record in question
+    :return int: The city id as an integer, 0 if it can't find it.
+    """
+    try:
+        return data["event"]["data"]["new"]["original_city_id"]
+    except (TypeError, KeyError):
+        return 0
+
+
 def load_data(record: str) -> dict:
     """
     Attempts to parse the event data

--- a/atd-events/tests/README.md
+++ b/atd-events/tests/README.md
@@ -1,0 +1,32 @@
+# ATD - VZ Events - Testing
+
+We are following a very basic pattern to write and make tests. We use pytest
+with a combination of whatever packages you are running in your SQS event.
+
+To get started:
+
+1. Create a virtual environment:
+    ```
+    $ virtualenv venv
+    $ source venv/bin/activate
+    ```
+2. Install your app packages (if needed):
+    ```
+    $ pip install pytest
+    $ pip install -r your_sqs_folder/requirements.txt
+    ```
+3. (Optional) Some of the tests already written will require you
+to set up additional environment variables. This is because some of
+the code interacts with the HASURA api and that code needs to be tested
+too. These are the environment variables needed, be sure to provide
+variables for the staging environment only: 
+   ```
+   export HASURA_ADMIN_SECRET="..."
+   export HASURA_ENDPOINT="..."
+   export HASURA_EVENT_API="..."
+   ```
+4. Run your tests:
+   ```
+   # Run a specific test:
+   $ pytest -v tests/your_test.py
+   ```

--- a/atd-events/tests/README.md
+++ b/atd-events/tests/README.md
@@ -29,4 +29,5 @@ variables for the staging environment only:
    ```
    # Run a specific test:
    $ pytest -v tests/your_test.py
+   $ pytest -v tests/your_tests.py::TestClass::test_method
    ```

--- a/atd-events/tests/data/data_cr3_insertion_valid.json
+++ b/atd-events/tests/data/data_cr3_insertion_valid.json
@@ -7,6 +7,7 @@
         "data": {
             "old": null,
             "new": {
+                "city_id": 22,
                 "crash_id": 1000,
                 "case_id": "987654321",
                 "location_id": "SCRAMBLED1234"

--- a/atd-events/tests/data/data_cr3_insertion_valid.json
+++ b/atd-events/tests/data/data_cr3_insertion_valid.json
@@ -10,7 +10,8 @@
                 "city_id": 22,
                 "crash_id": 1000,
                 "case_id": "987654321",
-                "location_id": "SCRAMBLED1234"
+                "location_id": "SCRAMBLED1234",
+                "original_city_id": 123
             }
         }
     },

--- a/atd-events/tests/test_crash_update_jurisdiction.py
+++ b/atd-events/tests/test_crash_update_jurisdiction.py
@@ -112,7 +112,7 @@ class TestCrashUpdateJurisdiction:
         """
         Tests if the city id is being returned as expected
         """
-        assert get_city_id(data_cr3_insertion_invalid) == 0
+        assert get_city_id(data_cr3_insertion_invalid) is None
 
     def test_get_original_city_id_success(self):
         """
@@ -124,7 +124,7 @@ class TestCrashUpdateJurisdiction:
         """
         Tests if the city id is being returned as expected
         """
-        assert get_original_city_id(data_cr3_insertion_invalid) == 0
+        assert get_original_city_id(data_cr3_insertion_invalid) is None
 
 
     def test_load_data_success(self):

--- a/atd-events/tests/test_crash_update_jurisdiction.py
+++ b/atd-events/tests/test_crash_update_jurisdiction.py
@@ -126,6 +126,20 @@ class TestCrashUpdateJurisdiction:
         """
         assert get_original_city_id(data_cr3_insertion_invalid) is None
 
+    def test_get_jurisdiction_common_members_success(self):
+        array_a = [0, 1, 2]
+        array_b = [1, 2, 3]
+        assert get_jurisdiction_common_members(array_a, array_b) == {1, 2}
+
+    def test_get_jurisdiction_common_members_success_b(self):
+        array_a = [0, 1, 2]
+        array_b = [3, 4]
+        assert get_jurisdiction_common_members(array_a, array_b) == set()
+
+    def test_get_jurisdiction_common_members_success_c(self):
+        array_a = [1000, 1008, 1010]
+        array_b = [1000, 1008, 1010]
+        assert get_jurisdiction_common_members(array_a, array_b) == {1000, 1008, 1010}
 
     def test_load_data_success(self):
         """
@@ -487,20 +501,50 @@ class TestCrashUpdateJurisdiction:
         )
         update_jurisdiction_flag.assert_not_called()
 
-    @patch("crash_update_jurisdiction.app.update_jurisdiction_flag")
-    def test_hasura_request_is_crash_in_jurisdiction_false(self, update_jurisdiction_flag):
+    # @patch("crash_update_jurisdiction.app.update_jurisdiction_flag")
+    # def test_hasura_request_is_crash_in_jurisdiction_false(self, update_jurisdiction_flag):
+    #     """
+    #     Makes sure the update function does not get called if the conditions are not met
+    #     """
+    #     data = load_file("tests/data/data_cr3_insertion_invalid.json")
+    #     data["event"]["data"] = {
+    #         "old": None,
+    #         "new": {
+    #             "crash_id": -9000,
+    #             "austin_full_purpose": "Y"
+    #         },
+    #     }
+    #     hasura_request(
+    #         record=json.dumps(data)
+    #     )
+    #     update_jurisdiction_flag.assert_not_called()
+
+    def test_is_crash_in_jurisdictions_success(self):
         """
-        Makes sure the update function does not get called if the conditions are not met
+        Checks whether a crash falls is part of any jurisdictions
         """
-        data = load_file("tests/data/data_cr3_insertion_invalid.json")
-        data["event"]["data"] = {
-            "old": None,
-            "new": {
-                "crash_id": 1000,
-                "austin_full_purpose": "Y"
-            },
-        }
-        hasura_request(
-            record=json.dumps(data)
-        )
-        update_jurisdiction_flag.assert_not_called()
+        assert is_crash_in_jurisdictions(1020)
+
+    def test_is_crash_in_jurisdictions_success_b(self):
+        """
+        Checks whether a crash falls is part of any jurisdictions with a string
+        """
+        assert is_crash_in_jurisdictions("1020")
+
+    def test_is_crash_in_jurisdictions_fail_a(self):
+        """
+        Makes sure only numeric values work
+        """
+        assert is_crash_in_jurisdictions(False) is False
+
+    def test_is_crash_in_jurisdictions_fail_b(self):
+        """
+        Makes sure only numeric integer values work
+        """
+        assert is_crash_in_jurisdictions("-1230") is False
+
+    def test_is_crash_in_jurisdictions_fail_c(self):
+        """
+        Makes sure only positive integer values work
+        """
+        assert is_crash_in_jurisdictions("1230.0") is False

--- a/atd-events/tests/test_crash_update_jurisdiction.py
+++ b/atd-events/tests/test_crash_update_jurisdiction.py
@@ -548,3 +548,57 @@ class TestCrashUpdateJurisdiction:
         Makes sure only positive integer values work
         """
         assert is_crash_in_jurisdictions("1230.0") is False
+
+    def test_get_city_id_from_db_success_a(self):
+        """
+        Makes sure it can find the city id for a crash
+        """
+        get_city_id_from_db(17211142) == 9999
+
+    def test_get_city_id_from_db_success_b(self):
+        """
+        Makes sure it can find the city id for a crash
+        """
+        get_city_id_from_db("15830818") == 99999
+
+    def test_get_city_id_from_db_fail_a(self):
+        """
+        Makes sure it can find the city id for a crash
+        """
+        get_city_id_from_db(False) is None
+
+    def test_get_city_id_from_db_fail_b(self):
+        """
+        Makes sure it can find the city id for a crash
+        """
+        get_city_id_from_db("123.2") is None
+
+    def test_get_city_id_from_db_fail_c(self):
+        """
+        Makes sure it can find the city id for a crash
+        """
+        get_city_id_from_db(2072423140) is None
+
+    def test_update_city_id_success_a(self):
+        """
+        Makes sure it can update the city id of a record
+        """
+        crash_id = 17211142
+        city_id = 9999
+        assert get_city_id_from_db(crash_id) == city_id
+        assert isinstance(update_city_id(crash_id=crash_id, city_id=None), dict)
+        assert get_city_id_from_db(crash_id) is None
+        assert isinstance(update_city_id(crash_id=crash_id, city_id=city_id), dict)
+        assert get_city_id_from_db(crash_id) == city_id
+
+    def test_update_city_id_success_b(self):
+        """
+        Makes sure it can update the city id of a record
+        """
+        crash_id = 17211142
+        city_id = 9999
+        assert get_city_id_from_db(crash_id) == city_id
+        assert isinstance(update_city_id(crash_id=crash_id, city_id=1), dict)
+        assert get_city_id_from_db(crash_id) == 1
+        assert isinstance(update_city_id(crash_id=crash_id, city_id=city_id), dict)
+        assert get_city_id_from_db(crash_id) == city_id

--- a/atd-events/tests/test_crash_update_jurisdiction.py
+++ b/atd-events/tests/test_crash_update_jurisdiction.py
@@ -102,6 +102,12 @@ class TestCrashUpdateJurisdiction:
         """
         assert get_jurisdiction_flag(None) == "N"
 
+    def test_get_city_id_success(self):
+        """
+        Tests if the city id is being returned as expected
+        """
+        assert get_city_id(data_cr3_insertion_valid) == 22
+
     def test_load_data_success(self):
         """
         Tests whether load_data can parse a string into a dictionary

--- a/atd-events/tests/test_crash_update_jurisdiction.py
+++ b/atd-events/tests/test_crash_update_jurisdiction.py
@@ -108,6 +108,12 @@ class TestCrashUpdateJurisdiction:
         """
         assert get_city_id(data_cr3_insertion_valid) == 22
 
+    def test_get_city_id_invalid(self):
+        """
+        Tests if the city id is being returned as expected
+        """
+        assert get_city_id(data_cr3_insertion_invalid) == 0
+
     def test_load_data_success(self):
         """
         Tests whether load_data can parse a string into a dictionary

--- a/atd-events/tests/test_crash_update_jurisdiction.py
+++ b/atd-events/tests/test_crash_update_jurisdiction.py
@@ -114,6 +114,19 @@ class TestCrashUpdateJurisdiction:
         """
         assert get_city_id(data_cr3_insertion_invalid) == 0
 
+    def test_get_original_city_id_success(self):
+        """
+        Tests if the city id is being returned as expected
+        """
+        assert get_original_city_id(data_cr3_insertion_valid) == 123
+
+    def test_get_original_city_id_invalid(self):
+        """
+        Tests if the city id is being returned as expected
+        """
+        assert get_original_city_id(data_cr3_insertion_invalid) == 0
+
+
     def test_load_data_success(self):
         """
         Tests whether load_data can parse a string into a dictionary

--- a/atd-events/tests/test_crash_update_jurisdiction.py
+++ b/atd-events/tests/test_crash_update_jurisdiction.py
@@ -501,23 +501,23 @@ class TestCrashUpdateJurisdiction:
         )
         update_jurisdiction_flag.assert_not_called()
 
-    # @patch("crash_update_jurisdiction.app.update_jurisdiction_flag")
-    # def test_hasura_request_is_crash_in_jurisdiction_false(self, update_jurisdiction_flag):
-    #     """
-    #     Makes sure the update function does not get called if the conditions are not met
-    #     """
-    #     data = load_file("tests/data/data_cr3_insertion_invalid.json")
-    #     data["event"]["data"] = {
-    #         "old": None,
-    #         "new": {
-    #             "crash_id": -9000,
-    #             "austin_full_purpose": "Y"
-    #         },
-    #     }
-    #     hasura_request(
-    #         record=json.dumps(data)
-    #     )
-    #     update_jurisdiction_flag.assert_not_called()
+    @patch("crash_update_jurisdiction.app.update_jurisdiction_flag")
+    def test_hasura_request_is_crash_in_jurisdiction_false(self, update_jurisdiction_flag):
+        """
+        Makes sure the update function does not get called if the conditions are not met
+        """
+        data = load_file("tests/data/data_cr3_insertion_invalid.json")
+        data["event"]["data"] = {
+            "old": None,
+            "new": {
+                "crash_id": -9000,
+                "austin_full_purpose": "Y"
+            },
+        }
+        hasura_request(
+            record=json.dumps(data)
+        )
+        update_jurisdiction_flag.assert_not_called()
 
     def test_is_crash_in_jurisdictions_success(self):
         """


### PR DESCRIPTION
Closes https://github.com/cityofaustin/atd-data-tech/issues/3689

This is currently hooked up with VZD-Staging, to test on your end:
1. Find a crash that  is full purpose and has coordinates, copy the coordinates. And keep them in a safe notepad for later.
2. Find a crash that is not city_id 22 and is not full purpose, NOTE THE OLD CITY ID paste the coordinates and save.
3. Wait 10-20 seconds, see the magic happen (the city id will magically be updated to 22)
