### PR TITLE
VZE: Fix CR3 for temp records

### DIFF
--- a/atd-vze/src/queries/crashes.js
+++ b/atd-vze/src/queries/crashes.js
@@ -95,6 +95,7 @@ export const GET_CRASH = gql`
       updated_by
       wthr_cond_id
       location_id
+      temp_record
     }
     atd_txdot_charges(where: { crash_id: { _eq: $crashId } }) {
       citation_nbr

--- a/atd-vze/src/views/Crashes/CR3Record.js
+++ b/atd-vze/src/views/Crashes/CR3Record.js
@@ -26,7 +26,7 @@ function CR3Record(props) {
         {props.isTempRecord ? (
           <Alert color="warning">
             <strong>CR3 PDFs are not available for temporary records.</strong><br />
-            Using the crash id, check the{" "}
+            Using the case id, check the{" "}
             <a href={"https://cris.dot.state.tx.us/"} target={"_new"}>
               CRIS website
             </a>{" "}

--- a/atd-vze/src/views/Crashes/CR3Record.js
+++ b/atd-vze/src/views/Crashes/CR3Record.js
@@ -23,7 +23,16 @@ function CR3Record(props) {
     <Card>
       <CardHeader>Crash Report</CardHeader>
       <CardBody>
-        {props.isCr3Stored ? (
+        {props.isTempRecord ? (
+          <Alert color="warning">
+            <strong>CR3 PDFs are not available for temporary records.</strong><br />
+            Using the crash id, check the{" "}
+            <a href={"https://cris.dot.state.tx.us/"} target={"_new"}>
+              CRIS website
+            </a>{" "}
+            for the latest status of this crash.
+          </Alert>
+        ) : props.isCr3Stored ? (
           <Button color="primary" onClick={requestCR3}>
             Download CR-3 PDF
           </Button>

--- a/atd-vze/src/views/Crashes/Crash.js
+++ b/atd-vze/src/views/Crashes/Crash.js
@@ -142,6 +142,7 @@ function Crash(props) {
     address_confirmed_primary: primaryAddress,
     address_confirmed_secondary: secondaryAddress,
     cr3_stored_flag: cr3StoredFlag,
+    temp_record: tempRecord,
     geocode_method: geocodeMethod,
   } = data.atd_txdot_crashes[0];
 
@@ -265,7 +266,7 @@ function Crash(props) {
           </div>
         </Col>
         <Col xs="12" md="6">
-          <CR3Record crashId={crashId} isCr3Stored={cr3StoredFlag === "Y"} />
+          <CR3Record crashId={crashId} isCr3Stored={cr3StoredFlag === "Y"} isTempRecord={tempRecord} />
         </Col>
         <Col xs="12">
           <CrashCollapses data={data} props={props} />


### PR DESCRIPTION
For temp records, it shows an alert instead of a download button, even if there is a PDF available:

<img width="1442" alt="2020-09-04_17-14-56" src="https://user-images.githubusercontent.com/5282430/92288313-2b95c580-eed2-11ea-863a-7bb2290db038.png">

To test:
1. Find any temp record in the staging database. You should see the above Alert.
2. Change the cr3_stored_flag to 'N', which indicates there is a PDF in S3.
3. Change the temp_record flag to false, which indicates the record is considered temporary. You show see the download button.
4. Revert temp_record to true, the button will disappear, even if he cr3_stored_flag is set to 'Y'.
