### PR TITLE
Fix ETL bug with CRIS v21.0 update

### DIFF
--- a/atd-etl/app/process_cris_request.py
+++ b/atd-etl/app/process_cris_request.py
@@ -85,21 +85,21 @@ wait(10)
 
 print("Selecting Counties to be Included in the Extract")
 browser.find_by_id('rdoCounties').click()
+# Open ng-select dropdown
 browser.find_by_id('requestCounties').click() 
-browser.driver.save_screenshot("screenshot.png")
 
-wait(3)
-browser.execute_script("document.getElementById('acc19a5a0565-226').click()")  # Travis
-wait(1)
-# browser.execute_script("$(\"div#acc19a5a0565-226.ng-option\").click()")  # Travis
-browser.driver.save_screenshot("screenshot_travis.png")
+browser.find_by_text('TRAVIS').click()
+
+# Reopen dropdown
 browser.find_by_id('requestCounties').click() 
-browser.execute_script("$(\"div[data-value='227']\").click()")  # Williamson
-browser.execute_script("$(\"div[data-value='246']\").click()")  # Hays
+browser.find_by_text('WILLIAMSON').click()
+
+# Reopen dropdown
+browser.find_by_id('requestCounties').click() 
+browser.find_by_text('HAYS').click()
 wait(3)
 
 browser.find_by_text("Next").click()
-browser.driver.save_screenshot("screenshot1.png")
 wait(10)
 
 print("Selecting type IDS PROCESS")

--- a/atd-etl/app/process_cris_request.py
+++ b/atd-etl/app/process_cris_request.py
@@ -76,10 +76,11 @@ print(
     "Selecting data extract request, from '%s' to '%s'"
     % (CRIS_EXTRACT_DATE_START, CRIS_EXTRACT_DATE_END)
 )
-browser.find_by_text("Create Data Extract Request").click()
+start_button = browser.find_by_text("Create Data Extract Request")
+start_button.click()
 wait(10)
 
-browser.find_by_text("Continue").click()
+browser.find_by_text("Next").click()
 wait(10)
 
 print("Selecting Counties to be Included in the Extract")
@@ -88,18 +89,19 @@ browser.execute_script("$(\"div[data-value='105']\").click()")  # Travis
 browser.execute_script("$(\"div[data-value='227']\").click()")  # Williamson
 browser.execute_script("$(\"div[data-value='246']\").click()")  # Hays
 wait(3)
-browser.find_by_text("Continue").click()
+
+browser.find_by_text("Next").click()
 wait(10)
 
 print("Selecting type IDS PROCESS")
 browser.find_by_css('input[ng-value="shareConstants.DATE_TYPE_IDS.PROCESS"]').click()
 browser.find_by_id("requestDateProcessBegin").fill(CRIS_EXTRACT_DATE_START)
 browser.find_by_id("requestDateProcessEnd").fill(CRIS_EXTRACT_DATE_END)
-browser.find_by_text("Continue").click()
+browser.find_by_text("Next").click()
 wait(10)
 
 print("Submit Request")
-browser.find_by_text("Submit").click()
+browser.find_by_text("Submit Extract Request").click()
 
 print("\nProcess done.")
 

--- a/atd-etl/app/process_cris_request.py
+++ b/atd-etl/app/process_cris_request.py
@@ -84,17 +84,27 @@ browser.find_by_text("Next").click()
 wait(10)
 
 print("Selecting Counties to be Included in the Extract")
-browser.find_by_css('input[ng-value="shareConstants.LOCATION_TYPE_IDS.COUNTY"]').click()
-browser.execute_script("$(\"div[data-value='105']\").click()")  # Travis
+browser.find_by_id('rdoCounties').click()
+browser.find_by_id('requestCounties').click() 
+browser.driver.save_screenshot("screenshot.png")
+
+wait(3)
+browser.execute_script("document.getElementById('acc19a5a0565-226').click()")  # Travis
+wait(1)
+# browser.execute_script("$(\"div#acc19a5a0565-226.ng-option\").click()")  # Travis
+browser.driver.save_screenshot("screenshot_travis.png")
+browser.find_by_id('requestCounties').click() 
 browser.execute_script("$(\"div[data-value='227']\").click()")  # Williamson
 browser.execute_script("$(\"div[data-value='246']\").click()")  # Hays
 wait(3)
 
 browser.find_by_text("Next").click()
+browser.driver.save_screenshot("screenshot1.png")
 wait(10)
 
 print("Selecting type IDS PROCESS")
-browser.find_by_css('input[ng-value="shareConstants.DATE_TYPE_IDS.PROCESS"]').click()
+browser.find_by_id('rdoProcessDates').click()
+# browser.find_by_css('input[ng-value="shareConstants.DATE_TYPE_IDS.PROCESS"]').click()
 browser.find_by_id("requestDateProcessBegin").fill(CRIS_EXTRACT_DATE_START)
 browser.find_by_id("requestDateProcessEnd").fill(CRIS_EXTRACT_DATE_END)
 browser.find_by_text("Next").click()

--- a/atd-etl/app/process_cris_request.py
+++ b/atd-etl/app/process_cris_request.py
@@ -111,7 +111,10 @@ browser.find_by_text("Next").click()
 wait(10)
 
 print("Submit Request")
-browser.find_by_text("Submit Extract Request").click()
+submit_button = browser.find_by_text("Submit Extract Request")
+submit_button.click()
+
+wait(10)
 
 print("\nProcess done.")
 


### PR DESCRIPTION
Closes https://github.com/cityofaustin/atd-data-tech/issues/3982

As described in the issue, a UI update on TXDOT's end broke our Extract request script.

At first the issue was that the script was expecting the buttons to say "Continue", but now they say "Next". There were also updates to the way radio and select option values are selected.

I've tested this on staging and it looks successful. Along with some screenshots before stepping through to the next page.

```
➜  atd-etl git:(3982_fix_etl_bug) ✗ runetl ~/.ssh/atd-etl/etl.staging.env app/process_cris_request.py
Using environment variables in '/Users/mateoclarke/.ssh/atd-etl/etl.staging.env'...


----- ETL RUN ------
Run Environment:        staging
Run File:               app/process_cris_request.py
ATD_CRIS_CONFIG:        /Users/mateoclarke/.ssh/atd-etl/etl.staging.env
ATD_DOCKER_IMAGE:       atddocker/atd-vz-etl:local
--------------------

--------------------------------------------------------------------
--- Running web-pdb debugger at http://localhost:5555 ---
--------------------------------------------------------------------
docker run -it --rm -p 5555:5555/tcp         -v /Users/mateoclarke/Desktop/code/CoA/ATD/atd-vz-data/atd-etl/app:/app -v /Users/mateoclarke/Desktop/code/CoA/ATD/atd-vz-data/atd-etl/data:/data -v /Users/mateoclarke/Desktop/code/CoA/ATD/atd-vz-data/atd-etl/tmp:/app/tmp         --env-file /Users/mateoclarke/.ssh/atd-etl/etl.staging.env atddocker/atd-vz-etl:local /app/process_cris_request.py;
--------------------------------------------------------------------
Initializing browser options.
Initializing Chrome headless browser.
Logging in to 'https://cris.dot.state.tx.us/'
Filling out agency.
Filling out credentials.
Selecting data extract request, from '09/18/2020' to '09/21/2020'
Should wait: 10
Should wait: 10
Selecting Counties to be Included in the Extract
Should wait: 3
Should wait: 10
Selecting type IDS PROCESS
Should wait: 10
Submit Request

Process done.
Finished in: 00:00:53.99
```

![screenshot0](https://user-images.githubusercontent.com/5697474/93735482-9e759080-fba2-11ea-97bd-ea776c532f14.png)
![screenshot](https://user-images.githubusercontent.com/5697474/93735486-a1708100-fba2-11ea-9692-ac88e6bc3e25.png)
![counties](https://user-images.githubusercontent.com/5697474/93735491-a59c9e80-fba2-11ea-912c-c165bc9f160e.png)
![dates](https://user-images.githubusercontent.com/5697474/93735497-a7fef880-fba2-11ea-9737-063e5ccb3129.png)
![submit](https://user-images.githubusercontent.com/5697474/93735754-a8e45a00-fba3-11ea-97bb-6306f67e65a2.png)
![done](https://user-images.githubusercontent.com/5697474/93735762-ad107780-fba3-11ea-82fe-6309f10abf3a.png)


