### PR TITLE
VZV | Update Socrata queries with times

### DIFF
--- a/atd-vzv/src/constants/time.js
+++ b/atd-vzv/src/constants/time.js
@@ -5,7 +5,8 @@ import moment from "moment";
 export const ROLLING_YEARS_OF_DATA = 4;
 // Number of months window slides in the past (to display most accurate data)
 // Accommodate for a preview instance that provide and extra month of data
-export const MONTHS_AGO = process.env.REACT_APP_VZV_ENVIRONMENT === "PREVIEW" ? 1 : 2;
+export const MONTHS_AGO =
+  process.env.REACT_APP_VZV_ENVIRONMENT === "PREVIEW" ? 1 : 2;
 
 // Create array of ints of last n years
 export const yearsArray = () => {

--- a/atd-vzv/src/views/summary/CrashesByPopulation.js
+++ b/atd-vzv/src/views/summary/CrashesByPopulation.js
@@ -21,7 +21,7 @@ const CrashesByPopulation = () => {
   useEffect(() => {
     const dateCondition = `crash_date BETWEEN '${dataStartDate.format(
       "YYYY-MM-DD"
-    )}' and '${fiveYearAvgEndDate}'`;
+    )}T00:00:00' and '${fiveYearAvgEndDate}T23:59:59'`;
     const queryGroupAndOrder = `GROUP BY year ORDER BY year`;
 
     const queries = {

--- a/atd-vzv/src/views/summary/CrashesByYear.js
+++ b/atd-vzv/src/views/summary/CrashesByYear.js
@@ -29,8 +29,8 @@ const CrashesByYear = () => {
 
   // Fetch data for By Month Average and Cumulative visualizations
   useEffect(() => {
-    const avgDateCondition = `crash_date BETWEEN '${fiveYearAvgStartDate}' and '${fiveYearAvgEndDate}'`;
-    const currentYearDateCondition = `crash_date BETWEEN '${summaryCurrentYearStartDate}' and '${summaryCurrentYearEndDate}'`;
+    const avgDateCondition = `crash_date BETWEEN '${fiveYearAvgStartDate}T00:00:00' and '${fiveYearAvgEndDate}T23:59:59'`;
+    const currentYearDateCondition = `crash_date BETWEEN '${summaryCurrentYearStartDate}T00:00:00' and '${summaryCurrentYearEndDate}T23:59:59'`;
     const queryGroupAndOrder = `GROUP BY month ORDER BY month`;
 
     const avgQueries = {

--- a/atd-vzv/src/views/summary/PeopleByDemographics.js
+++ b/atd-vzv/src/views/summary/PeopleByDemographics.js
@@ -16,7 +16,7 @@ const url = `${personEndpointUrl}?$query=`;
 
 const dateCondition = `crash_date BETWEEN '${dataStartDate.format(
   "YYYY-MM-DD"
-)}' and '${dataEndDate.format("YYYY-MM-DD")}'`;
+)}T00:00:00' and '${dataEndDate.format("YYYY-MM-DD")}T23:59:59'`;
 
 const chartColors = [
   colors.viridis1Of6Highest,


### PR DESCRIPTION
This PR patches a bug where Socrata queries had a date range that was exclusive of the first and last date in the range. I updated these queries with time parameters. Below is a screenshot of the fatalities By Race/Ethnicity for start of January to end of October 2020 that now matches the overall total (78).

<img width="619" alt="Screen Shot 2020-11-30 at 6 24 18 PM" src="https://user-images.githubusercontent.com/37249039/100681431-4ba21d00-3339-11eb-917a-0494eb56d853.png">
