### PR TITLE
Modify the message related to unavailable CR3 diagrams/narratives

### DIFF
--- a/atd-vze/src/views/Crashes/CrashDiagram.js
+++ b/atd-vze/src/views/Crashes/CrashDiagram.js
@@ -118,9 +118,8 @@ const CrashDiagram = props => {
           </div>
         ) : (
           <div className="mt-2">
-            The CR-3 file for this crash has not been imported, so there is no
-            PDF, diagram or narrative available. Use Brazos to search for the
-            associated CR-3 Crash Report.
+            The crash diagram and investigator narrative are not available
+            at this time.
           </div>
         )}
       </CardBody>


### PR DESCRIPTION
The intent is to not imply that a CR3 is not available when it just
may not have been processed yet. The message is made more general
to try to cover both when a CR3 is just not processed yet, or when
it was not possible for a diagram / narrative to have been extracted.