### PR TITLE
Fix ETL bug caused by adding new unit fields

### DIFF
--- a/atd-etl/app/process/helpers_import_fields.py
+++ b/atd-etl/app/process/helpers_import_fields.py
@@ -6,10 +6,7 @@ CRIS_TXDOT_FIELDS = {
         "query_name": "insertCrashQuery",
         "function_name": "insert_atd_txdot_crashes",
         "filters": [
-            [
-              filter_remove_field,
-              []
-            ],
+            [filter_remove_field, []],
             [
                 filter_numeric_field,
                 [
@@ -104,28 +101,23 @@ CRIS_TXDOT_FIELDS = {
                     "est_econ_cost",
                     "apd_confirmed_death_count",
                     "speed_mgmt_points",
-                ]
-            ]
-        ]
-                    "pedestrian_action_id",
-                    "pedalcyclist_action_id",
-                    "pbcat_pedestrian_id",
-                    "pbcat_pedalcyclist_id",
-                    "e_scooter_id",
-                    "autonomous_unit_id",
+                ],
+            ],
+        ],
     },
-
     "charges": {
         "query_name": "insertChargeQuery",
         "function_name": "insert_atd_txdot_charges",
         "filters": [
             [filter_numeric_empty_to_zero, ["charge_cat_id"]],
             [filter_numeric_null_to_zero, ["charge_cat_id"]],
-            [filter_numeric_field, ["charge_id", "crash_id", "unit_nbr", "prsn_nbr", "charge_cat_id"]],
-            [filter_text_null_to_empty, ["citation_nbr"]]
-        ]
+            [
+                filter_numeric_field,
+                ["charge_id", "crash_id", "unit_nbr", "prsn_nbr", "charge_cat_id"],
+            ],
+            [filter_text_null_to_empty, ["citation_nbr"]],
+        ],
     },
-
     "unit": {
         "query_name": "insertUnitQuery",
         "function_name": "insert_atd_txdot_units",
@@ -147,8 +139,8 @@ CRIS_TXDOT_FIELDS = {
                     "trlr_type_id",
                     "trlr_disabling_dmag_id",
                     "cmv_intermodal_container_permit_fl",
-                    "cmv_actual_gross_weight"
-                ]
+                    "cmv_actual_gross_weight",
+                ],
             ],
             [
                 filter_numeric_field,
@@ -210,17 +202,28 @@ CRIS_TXDOT_FIELDS = {
                     "veh_damage_description2_id",
                     "veh_damage_severity2_id",
                     "veh_damage_direction_of_force2_id",
-                ]
+                    "pedestrian_action_id",
+                    "pedalcyclist_action_id",
+                    "pbcat_pedestrian_id",
+                    "pbcat_pedalcyclist_id",
+                    "e_scooter_id",
+                    "autonomous_unit_id",
+                ],
             ],
             [
                 filter_numeric_empty_to_null,
                 [
-                    "cmv_bus_type_id"
-                ]
+                    "cmv_bus_type_id",
+                    "pedestrian_action_id",
+                    "pedalcyclist_action_id",
+                    "pbcat_pedestrian_id",
+                    "pbcat_pedalcyclist_id",
+                    "e_scooter_id",
+                    "autonomous_unit_id",
+                ],
             ],
-        ]
+        ],
     },
-
     "person": {
         "query_name": "insertPersonQuery",
         "function_name": "insert_atd_txdot_person",
@@ -233,7 +236,7 @@ CRIS_TXDOT_FIELDS = {
                     "prsn_first_name",
                     "prsn_mid_name",
                     "prsn_name_sfx",
-                ]
+                ],
             ],
             [
                 filter_numeric_field,
@@ -264,11 +267,10 @@ CRIS_TXDOT_FIELDS = {
                     "death_cnt",
                     "person_id",
                     "years_of_life_lost",
-                ]
+                ],
             ],
-        ]
+        ],
     },
-
     "primaryperson": {
         "query_name": "insertPersonQuery",
         "function_name": "insert_atd_txdot_primaryperson",
@@ -289,7 +291,7 @@ CRIS_TXDOT_FIELDS = {
                     "drvr_street_name",
                     "drvr_street_sfx",
                     "drvr_apt_nbr",
-                ]
+                ],
             ],
             [
                 filter_numeric_field,
@@ -324,10 +326,10 @@ CRIS_TXDOT_FIELDS = {
                     "drvr_state_id",
                     "primaryperson_id",
                     "years_of_life_lost",
-                ]
+                ],
             ],
-        ]
-    }
+        ],
+    },
 }
 
 CRIS_TXDOT_COMPARE_FIELDS_LIST = [

--- a/atd-etl/app/process/helpers_import_fields.py
+++ b/atd-etl/app/process/helpers_import_fields.py
@@ -107,6 +107,12 @@ CRIS_TXDOT_FIELDS = {
                 ]
             ]
         ]
+                    "pedestrian_action_id",
+                    "pedalcyclist_action_id",
+                    "pbcat_pedestrian_id",
+                    "pbcat_pedalcyclist_id",
+                    "e_scooter_id",
+                    "autonomous_unit_id",
     },
 
     "charges": {

--- a/atd-vzd/migrations/migration_units_2021-01-06--1752.sql
+++ b/atd-vzd/migrations/migration_units_2021-01-06--1752.sql
@@ -1,0 +1,6 @@
+ALTER TABLE "public"."atd_txdot_units" ADD COLUMN "pedestrian_action_id" int4;
+ALTER TABLE "public"."atd_txdot_units" ADD COLUMN "pedalcyclist_action_id" int4;
+ALTER TABLE "public"."atd_txdot_units" ADD COLUMN "pbcat_pedestrian_id" int4;
+ALTER TABLE "public"."atd_txdot_units" ADD COLUMN "pbcat_pedalcyclist_id" int4;
+ALTER TABLE "public"."atd_txdot_units" ADD COLUMN "e_scooter_id" int4;
+ALTER TABLE "public"."atd_txdot_units" ADD COLUMN "autonomous_unit_id" int4;

--- a/atd-vze/package.json
+++ b/atd-vze/package.json
@@ -1,6 +1,6 @@
 {
   "name": "atd-vz-data",
-  "version": "1.19.0",
+  "version": "1.19.1",
   "homepage": "./",
   "description": "ATD Vision Zero Editor",
   "author": "ATD Data & Technology Services",

--- a/atd-vzv/package.json
+++ b/atd-vzv/package.json
@@ -1,6 +1,6 @@
 {
   "name": "atd-vzv",
-  "version": "1.19.0",
+  "version": "1.19.1",
   "homepage": "./",
   "description": "ATD Vision Zero Viewer",
   "author": "ATD Data & Technology Services",


### PR DESCRIPTION
Closes https://github.com/cityofaustin/atd-data-tech/issues/4847

TXDOT CRIS Release 21.1 included 6 new field additions to the units table:
```
pedestrian_action_id
pedalcyclist_action_id
pbcat_pedestrian_id
pbcat_pedalcyclist_id
e_scooter_id
autonomous_unit_id
```

This PR updates the database schema and ETL script config to accommodate these new additive fields.

I downloaded a recent raw extract csv file from 01/02/2021 and tested the import in the staging environment and it works.

![Screen Shot 2021-01-06 at 5 51 41 PM](https://user-images.githubusercontent.com/5697474/103834571-627b1400-5049-11eb-8c8e-767ab7c6972e.jpg)
