### PR TITLE
Add new `investigator_narrative_ocr` field

### DIFF
--- a/atd-vzd/migrations/migration_crashes_2021_01_08--1946.sql
+++ b/atd-vzd/migrations/migration_crashes_2021_01_08--1946.sql
@@ -1,0 +1,12 @@
+--
+-- Adds column for narratives that won't be automatically overwritten by crash
+-- record updates
+--
+ALTER TABLE "public"."atd_txdot_crashes" ADD COLUMN "investigator_narrative_ocr" text;
+
+UPDATE
+	atd_txdot_crashes
+SET
+	investigator_narrative_ocr = investigator_narrative
+WHERE
+	investigator_narrative IS NOT NULL

--- a/atd-vze/src/queries/crashes.js
+++ b/atd-vze/src/queries/crashes.js
@@ -40,7 +40,7 @@ export const GET_CRASH = gql`
       hwy_sys
       hwy_sys_2
       intrsct_relat_id
-      investigator_narrative
+      investigator_narrative_ocr
       is_retired
       last_update
       latitude

--- a/atd-vze/src/views/Crashes/Crash.js
+++ b/atd-vze/src/views/Crashes/Crash.js
@@ -145,7 +145,7 @@ function Crash(props) {
     temp_record: tempRecord,
     geocode_method: geocodeMethod,
     cr3_file_metadata: cr3FileMetadata,
-    investigator_narrative: investigatorNarrative,
+    investigator_narrative_ocr: investigatorNarrative,
   } = data.atd_txdot_crashes[0];
 
   const mapGeocoderAddress = createGeocoderAddressString(data);

--- a/atd-vze/src/views/Crashes/crashDataMap.js
+++ b/atd-vze/src/views/Crashes/crashDataMap.js
@@ -49,11 +49,6 @@ export const crashDataMap = [
         lookupOptions: "atd_txdot__collsn_lkp",
         lookupPrefix: "collsn", // We need this field so we can reference the collsn_id & collsn_desc fields in the lookup table
       },
-      investigator_narrative: {
-        label: "Investigator Narrative",
-        editable: true,
-        uiType: "text",
-      },
       city_id: {
         label: "City",
         editable: true,


### PR DESCRIPTION
https://github.com/cityofaustin/atd-data-tech/issues/4871

The database updates and permissions have already been added in staging & production Postgres and Hasura. This PR also removes the narrative field from the "Details" section of the crash page since it now has its own dedicated card.