### PR TITLE
prevent movement with id = 0 from being counted as null

### DIFF
--- a/atd-vze/src/views/Crashes/RelatedRecordsTable.js
+++ b/atd-vze/src/views/Crashes/RelatedRecordsTable.js
@@ -69,7 +69,7 @@ const RelatedRecordsTable = ({
 
   const formatValue = (data, field) => {
     let fieldValue = data[field];
-    
+
     if (typeof data[field] === "object") {
       fieldValue =
         data[field] && data[field][fieldConfig.fields[field].lookup_desc];

--- a/atd-vze/src/views/Crashes/RelatedRecordsTable.js
+++ b/atd-vze/src/views/Crashes/RelatedRecordsTable.js
@@ -69,7 +69,6 @@ const RelatedRecordsTable = ({
 
   const formatValue = (data, field) => {
     let fieldValue = data[field];
-
     if (typeof data[field] === "object") {
       fieldValue =
         data[field] && data[field][fieldConfig.fields[field].lookup_desc];
@@ -142,7 +141,7 @@ const RelatedRecordsTable = ({
                                 defaultValue={
                                   // Check for null values and display as blank
                                   row[field] &&
-                                  row[field][`${fieldLookupPrefix}_id`]
+                                  row[field][`${fieldLookupPrefix}_id`] !== null
                                     ? row[field][`${fieldLookupPrefix}_id`]
                                     : ""
                                 }

--- a/atd-vze/src/views/Crashes/RelatedRecordsTable.js
+++ b/atd-vze/src/views/Crashes/RelatedRecordsTable.js
@@ -69,6 +69,7 @@ const RelatedRecordsTable = ({
 
   const formatValue = (data, field) => {
     let fieldValue = data[field];
+    
     if (typeof data[field] === "object") {
       fieldValue =
         data[field] && data[field][fieldConfig.fields[field].lookup_desc];


### PR DESCRIPTION
Fixes https://github.com/cityofaustin/atd-data-tech/issues/5063

Prevents movements with id = 0 from being counted as null. I don't think this will break the initial intent of this logical statement of checking for null values and displaying them as blank, but would like to confirm that.

Now behaves as expected for unit records with movement of "Unknown":

https://user-images.githubusercontent.com/35410637/105905088-a6798d00-5fe7-11eb-978a-546314e3d641.mov


