### PR TITLE
5020 by pop 2020 ratio feb 1

### DIFF
--- a/atd-vzv/src/constants/time.js
+++ b/atd-vzv/src/constants/time.js
@@ -60,7 +60,6 @@ export const fiveYearAvgStartDate = dataEndDate
   .startOf("year")
   .subtract(5, "year")
   .format("YYYY-MM-DD");
-
 export const fiveYearAvgEndDate = dataEndDate
   .clone()
   .add(1, "month")

--- a/atd-vzv/src/constants/time.js
+++ b/atd-vzv/src/constants/time.js
@@ -62,6 +62,13 @@ export const fiveYearAvgStartDate = dataEndDate
   .format("YYYY-MM-DD");
 export const fiveYearAvgEndDate = dataEndDate
   .clone()
+  .subtract(1, "year")
+  .endOf("year")
+  .format("YYYY-MM-DD");
+// Unique variable for the byPop chart that prevents the edge case
+// where the Feb. 1 query ends a year earlier than intended
+export const fiveYearAvgEndDateByPop = dataEndDate
+  .clone()
   .add(1, "month")
   .subtract(1, "year")
   .endOf("year")

--- a/atd-vzv/src/constants/time.js
+++ b/atd-vzv/src/constants/time.js
@@ -5,8 +5,8 @@ import moment from "moment";
 export const ROLLING_YEARS_OF_DATA = 4;
 // Number of months window slides in the past (to display most accurate data)
 // Accommodate for a preview instance that provide and extra month of data
-export const MONTHS_AGO =
-  process.env.REACT_APP_VZV_ENVIRONMENT === "PREVIEW" ? 1 : 2;
+export const MONTHS_AGO = 2;
+// process.env.REACT_APP_VZV_ENVIRONMENT === "PREVIEW" ? 1 : 2;
 
 // Create array of ints of last n years
 export const yearsArray = () => {
@@ -60,8 +60,10 @@ export const fiveYearAvgStartDate = dataEndDate
   .startOf("year")
   .subtract(5, "year")
   .format("YYYY-MM-DD");
+
 export const fiveYearAvgEndDate = dataEndDate
   .clone()
+  .add(1, "month")
   .subtract(1, "year")
   .endOf("year")
   .format("YYYY-MM-DD");

--- a/atd-vzv/src/constants/time.js
+++ b/atd-vzv/src/constants/time.js
@@ -5,8 +5,8 @@ import moment from "moment";
 export const ROLLING_YEARS_OF_DATA = 4;
 // Number of months window slides in the past (to display most accurate data)
 // Accommodate for a preview instance that provide and extra month of data
-export const MONTHS_AGO = 2;
-// process.env.REACT_APP_VZV_ENVIRONMENT === "PREVIEW" ? 1 : 2;
+export const MONTHS_AGO =
+  process.env.REACT_APP_VZV_ENVIRONMENT === "PREVIEW" ? 1 : 2;
 
 // Create array of ints of last n years
 export const yearsArray = () => {

--- a/atd-vzv/src/views/summary/CrashesByPopulation.js
+++ b/atd-vzv/src/views/summary/CrashesByPopulation.js
@@ -18,6 +18,8 @@ const CrashesByPopulation = () => {
 
   const url = `${crashEndpointUrl}?$query=`;
 
+  console.log(fiveYearAvgEndDate);
+
   useEffect(() => {
     const dateCondition = `crash_date BETWEEN '${dataStartDate.format(
       "YYYY-MM-DD"

--- a/atd-vzv/src/views/summary/CrashesByPopulation.js
+++ b/atd-vzv/src/views/summary/CrashesByPopulation.js
@@ -8,7 +8,7 @@ import CrashTypeSelector from "./Components/CrashTypeSelector";
 import InfoPopover from "../../Components/Popover/InfoPopover";
 import { popoverConfig } from "../../Components/Popover/popoverConfig";
 import { crashEndpointUrl } from "./queries/socrataQueries";
-import { dataStartDate, fiveYearAvgEndDate } from "../../constants/time";
+import { dataStartDate, fiveYearAvgEndDateByPop } from "../../constants/time";
 import { popEsts } from "../../constants/popEsts";
 import { colors } from "../../constants/colors";
 
@@ -21,7 +21,7 @@ const CrashesByPopulation = () => {
   useEffect(() => {
     const dateCondition = `crash_date BETWEEN '${dataStartDate.format(
       "YYYY-MM-DD"
-    )}T00:00:00' and '${fiveYearAvgEndDate}T23:59:59'`;
+    )}T00:00:00' and '${fiveYearAvgEndDateByPop}T23:59:59'`;
     const queryGroupAndOrder = `GROUP BY year ORDER BY year`;
 
     const queries = {

--- a/atd-vzv/src/views/summary/CrashesByPopulation.js
+++ b/atd-vzv/src/views/summary/CrashesByPopulation.js
@@ -18,8 +18,6 @@ const CrashesByPopulation = () => {
 
   const url = `${crashEndpointUrl}?$query=`;
 
-  console.log(fiveYearAvgEndDate);
-
   useEffect(() => {
     const dateCondition = `crash_date BETWEEN '${dataStartDate.format(
       "YYYY-MM-DD"


### PR DESCRIPTION
Fixes https://github.com/cityofaustin/atd-data-tech/issues/5020

Issue was due to time range end constant that feeds the by Pop and By Year & Month charts. It's due to the same edge case we encountered last year where the calculation for Feb. 1 is looking at Jan. 31 minus one month (Dec. 31, 2020) and minus one year (Dec. 31, 2019), so actually setting the end date to December 2019 instead of 2020. Adding a month to the end date solves the problem for both charts.

<img width="668" alt="Screen Shot 2021-01-28 at 5 10 37 PM" src="https://user-images.githubusercontent.com/35410637/106210095-ca75d380-618b-11eb-8cb1-83a6b985e3e2.png">
<img width="656" alt="Screen Shot 2021-01-28 at 5 10 48 PM" src="https://user-images.githubusercontent.com/35410637/106210101-cba70080-618b-11eb-8643-6f89bcc7c903.png">
