### PR TITLE
VZV | Show partial year data in By Population visualization

### DIFF
--- a/atd-vzv/src/constants/time.js
+++ b/atd-vzv/src/constants/time.js
@@ -6,7 +6,7 @@ export const ROLLING_YEARS_OF_DATA = 4;
 // Number of months window slides in the past (to display most accurate data)
 // Accommodate for a preview instance that provide and extra month of data
 export const MONTHS_AGO =
-  process.env.REACT_APP_VZV_ENVIRONMENT === "PREVIEW" ? 1 : 1;
+  process.env.REACT_APP_VZV_ENVIRONMENT === "PREVIEW" ? 1 : 2;
 
 // Create array of ints of last n years
 export const yearsArray = () => {

--- a/atd-vzv/src/constants/time.js
+++ b/atd-vzv/src/constants/time.js
@@ -6,7 +6,7 @@ export const ROLLING_YEARS_OF_DATA = 4;
 // Number of months window slides in the past (to display most accurate data)
 // Accommodate for a preview instance that provide and extra month of data
 export const MONTHS_AGO =
-  process.env.REACT_APP_VZV_ENVIRONMENT === "PREVIEW" ? 1 : 2;
+  process.env.REACT_APP_VZV_ENVIRONMENT === "PREVIEW" ? 1 : 1;
 
 // Create array of ints of last n years
 export const yearsArray = () => {
@@ -62,14 +62,6 @@ export const fiveYearAvgStartDate = dataEndDate
   .format("YYYY-MM-DD");
 export const fiveYearAvgEndDate = dataEndDate
   .clone()
-  .subtract(1, "year")
-  .endOf("year")
-  .format("YYYY-MM-DD");
-// Unique variable for the byPop chart that prevents the edge case
-// where the Feb. 1 query ends a year earlier than intended
-export const fiveYearAvgEndDateByPop = dataEndDate
-  .clone()
-  .add(1, "month")
   .subtract(1, "year")
   .endOf("year")
   .format("YYYY-MM-DD");

--- a/atd-vzv/src/views/summary/CrashesByPopulation.js
+++ b/atd-vzv/src/views/summary/CrashesByPopulation.js
@@ -8,7 +8,7 @@ import CrashTypeSelector from "./Components/CrashTypeSelector";
 import InfoPopover from "../../Components/Popover/InfoPopover";
 import { popoverConfig } from "../../Components/Popover/popoverConfig";
 import { crashEndpointUrl } from "./queries/socrataQueries";
-import { dataStartDate, fiveYearAvgEndDateByPop } from "../../constants/time";
+import { dataStartDate, dataEndDate } from "../../constants/time";
 import { popEsts } from "../../constants/popEsts";
 import { colors } from "../../constants/colors";
 
@@ -21,7 +21,7 @@ const CrashesByPopulation = () => {
   useEffect(() => {
     const dateCondition = `crash_date BETWEEN '${dataStartDate.format(
       "YYYY-MM-DD"
-    )}T00:00:00' and '${fiveYearAvgEndDateByPop}T23:59:59'`;
+    )}T00:00:00' and '${dataEndDate.format("YYYY-MM-DD")}T23:59:59'`;
     const queryGroupAndOrder = `GROUP BY year ORDER BY year`;
 
     const queries = {


### PR DESCRIPTION
After some discussion around the By Population visualization, we decided it makes more sense to show the latest data available in this chart and no longer wait until a full year of data is available.

To test how this will look on March 1st, take a look at the deploy preview:

https://deploy-preview-975--atd-vzv-preview.netlify.app/

or update `MONTHS_AGO` in `time.js` in the local environment to:

```js
export const MONTHS_AGO = process.env.REACT_APP_VZV_ENVIRONMENT === "PREVIEW" ? 1 : 1;
```

### Before
![Screen Shot 2021-02-26 at 5 00 51 PM](https://user-images.githubusercontent.com/37249039/109364958-973f6680-7855-11eb-823a-7ca0951feae5.png)

### After
![Screen Shot 2021-02-26 at 5 00 42 PM](https://user-images.githubusercontent.com/37249039/109364961-9c9cb100-7855-11eb-8b7e-c942bb0f6bf1.png)
