### PR TITLE
Make list order of travel modes consistent

### DIFF
--- a/atd-vzv/src/views/summary/CrashesByMode.js
+++ b/atd-vzv/src/views/summary/CrashesByMode.js
@@ -136,19 +136,14 @@ const CrashesByMode = () => {
 
   // Sort mode order in stack and apply colors by averaging total mode fatalities across all years in chart
   const sortAndColorModeData = (modeData) => {
-    const averageModeFatalities = (modeDataArray) =>
-      modeDataArray.reduce((a, b) => a + b) / modeDataArray.length;
-    const modeDataSorted = modeData.sort(
-      (a, b) => averageModeFatalities(b.data) - averageModeFatalities(a.data)
-    );
-    modeDataSorted.forEach((category, i) => {
+    modeData.forEach((category, i) => {
       const color = chartColors[i];
       category.backgroundColor = color;
       category.borderColor = color;
       category.hoverBackgroundColor = color;
       category.hoverBorderColor = color;
     });
-    return modeDataSorted;
+    return modeData;
   };
 
   // Create dataset for each mode type, data property is an array of fatality sums sorted chronologically


### PR DESCRIPTION
- Closes https://github.com/cityofaustin/atd-data-tech/issues/6391
- Displays consistent list order for All, Fatalities, and Serious Injuries categories in By Travel Mode chart.