### PR TITLE
Address issue in get_location_totals() function

### DIFF
--- a/atd-vzd/triggers/get_location_totals.sql
+++ b/atd-vzd/triggers/get_location_totals.sql
@@ -38,7 +38,7 @@ FROM
     SELECT
       atdl.location_id AS location_id,
       count(atdbf) AS total_crashes,
-      coalesce((count(1) * cost_per_crash), 0) AS est_comp_cost
+      coalesce((count(atdbf) * cost_per_crash), 0) AS est_comp_cost
     FROM
       atd_txdot_locations AS atdl
       LEFT JOIN atd_apd_blueform AS atdbf ON (


### PR DESCRIPTION
The subquery used to count the number of Non-CR3 crashes
was using count(1) to count the number of crashes, but was
used in the context of a set of aggregate results, therefore
always coming up with 1 or the number of non-CR3 crashes, which
ever was higher.