### PR TITLE
Re-write get_location_totals()

### DIFF
--- a/atd-vzd/triggers/get_location_totals.sql
+++ b/atd-vzd/triggers/get_location_totals.sql
@@ -1,30 +1,61 @@
-CREATE OR REPLACE FUNCTION public.get_location_totals(cr3_crash_date date, noncr3_crash_date date, cr3_location character varying, noncr3_location character varying, cost_per_crash numeric)
- RETURNS SETOF atd_location_crash_and_cost_totals
- LANGUAGE sql
- STABLE
-AS $function$
-with
-  noncr3 as (
-    select count(aab.case_id) as total_crashes,
-    count(aab.case_id) * cost_per_crash as est_comp_cost
-    from atd_apd_blueform aab
-    where aab.location_id = noncr3_location
-    and aab.date >= noncr3_crash_date
+CREATE OR REPLACE FUNCTION public.get_location_totals(
+  cr3_crash_date    date, 
+  noncr3_crash_date date, 
+  cr3_location      character varying, 
+  noncr3_location   character varying, 
+  cost_per_crash    numeric
+  ) RETURNS SETOF atd_location_crash_and_cost_totals
+ LANGUAGE sql STABLE
+  AS $function$
+WITH
+  -- This CTE+join mechanism is a way to pack two, simple
+  -- queries together into one larger query and compute 
+  -- derived results from their results. 
+  --
+  -- In our first CTE, we'll count up the number of 
+  -- non-CR3 crashes and their sum of their comprehensive 
+  -- cost which are associated to a given location occuring 
+  -- after a given date.
+  -- 
+  -- All non-CR3 crashes are given a standard
+  -- comprehensive cost, and this value is provided as
+  -- an argument to this query.
+  -- 
+  -- An important thing to note is that this CTE query will
+  -- only return a single row under any circumstances.
+  noncr3 AS (
+    SELECT COUNT(aab.case_id) AS total_crashes,
+      COUNT(aab.case_id) * cost_per_crash AS est_comp_cost
+    FROM atd_apd_blueform aab
+    WHERE aab.location_id = noncr3_location
+      AND aab.date >= noncr3_crash_date
   ),
-  cr3 as (
-    select count(atc.crash_id) as total_crashes,
-    sum(est_comp_cost) as est_comp_cost
-    from atd_txdot_crashes atc
-    where atc.location_id = cr3_location
-    and atc.crash_date >= cr3_crash_date
+  -- A very similar query, again returning a single row,
+  -- to compute the count and aggregate comprehensive cost
+  -- for CR3 crashes. 
+  cr3 AS (
+    SELECT COUNT(atc.crash_id) AS total_crashes,
+      SUM(est_comp_cost) AS est_comp_cost
+    FROM atd_txdot_crashes atc
+    WHERE atc.location_id = cr3_location
+      AND atc.crash_date >= cr3_crash_date
   )
-select cr3_location as location_id,
-       cr3.total_crashes + noncr3.total_crashes as total_crashes,
-       cr3.est_comp_cost + noncr3.est_comp_cost as total_est_comp_cost,
-       cr3.total_crashes as cr3_total_crashes,
-       cr3.est_comp_cost as cr3_est_comp_cost,
-       noncr3.total_crashes as noncr3_total_crashes,
-       noncr3.est_comp_cost as noncr3_est_comp_cost
-from noncr3, cr3
-  $function$
-;
+-- Add the two crash types respective values together to 
+-- get values for all crashes for the location. Also, 
+-- pass through the individual crash type values in the final
+-- result.
+SELECT cr3_location AS location_id,
+       cr3.total_crashes + noncr3.total_crashes AS total_crashes,
+       cr3.est_comp_cost + noncr3.est_comp_cost AS total_est_comp_cost,
+       cr3.total_crashes AS cr3_total_crashes,
+       cr3.est_comp_cost AS cr3_est_comp_cost,
+       noncr3.total_crashes AS noncr3_total_crashes,
+       noncr3.est_comp_cost AS noncr3_est_comp_cost
+-- This is an implicit join of the two CTE tables. Because each
+-- table is known to have only a single row, the result will also
+-- be a single row, 1 * 1 = 1. This is why we have no need for a WHERE
+-- clause, as we narroed down to the actual data we need in the CTEs.
+-- Joining a table of a single row to another talbe of a single row
+-- essentaily performs a concatenation of the two rows.
+FROM noncr3, cr3
+  $function$;

--- a/atd-vzd/triggers/get_location_totals.sql
+++ b/atd-vzd/triggers/get_location_totals.sql
@@ -13,7 +13,7 @@ with
   ),
   cr3 as (
     select count(atc.crash_id) as total_crashes,
-    sum(est_crash_based_comp_cost) as est_comp_cost
+    sum(est_comp_cost) as est_comp_cost
     from atd_txdot_crashes atc
     where atc.location_id = cr3_location
     and atc.crash_date >= cr3_crash_date

--- a/atd-vzd/triggers/get_location_totals.sql
+++ b/atd-vzd/triggers/get_location_totals.sql
@@ -1,55 +1,30 @@
-CREATE
-OR REPLACE FUNCTION public.get_location_totals(
-  cr3_crash_date date,
-  noncr3_crash_date date,
-  cr3_location character varying,
-  noncr3_location character varying,
-  cost_per_crash numeric
-) RETURNS SETOF atd_location_crash_and_cost_totals AS $$
-SELECT
-  cr3.location_id,
-  (cr3.total_crashes + noncr3.total_crashes) AS total_crashes,
-  (cr3.est_comp_cost + noncr3.est_comp_cost) AS total_est_comp_cost,
-  cr3.total_crashes AS cr3_total_crashes,
-  cr3.est_comp_cost AS cr3_est_comp_cost,
-  noncr3.total_crashes AS noncr3_total_crashes,
-  noncr3.est_comp_cost AS noncr3_est_comp_cost
-FROM
-  (
-    SELECT
-      atdl.location_id AS location_id,
-      count(atdc) AS total_crashes,
-      coalesce(sum(atdc.est_comp_cost), 0) AS est_comp_cost
-    FROM
-      atd_txdot_locations AS atdl
-      LEFT JOIN atd_txdot_crashes AS atdc ON (
-        atdl.location_id = atdc.location_id
-        AND atdc.city_id = 22
-        AND atdc.crash_date >= cr3_crash_date :: date
-      )
-    WHERE
-      atdl.location_id = cr3_location :: text
-      AND atdl.location_id IS NOT NULL
-      AND atdl.location_id :: text <> 'None' :: text
-    GROUP BY
-      atdl.location_id
-  ) cr3
-  JOIN (
-    SELECT
-      atdl.location_id AS location_id,
-      count(atdbf) AS total_crashes,
-      coalesce((count(atdbf) * cost_per_crash), 0) AS est_comp_cost
-    FROM
-      atd_txdot_locations AS atdl
-      LEFT JOIN atd_apd_blueform AS atdbf ON (
-        atdl.location_id = atdbf.location_id
-        AND atdbf.date >= noncr3_crash_date :: date
-      )
-    WHERE
-      atdl.location_id IS NOT NULL
-      AND atdl.location_id :: text <> 'None' :: text
-      AND atdl.location_id = noncr3_location :: text
-    GROUP BY
-      atdl.location_id
-  ) noncr3 on cr3.location_id = noncr3.location_id
-  $$ LANGUAGE sql STABLE;
+CREATE OR REPLACE FUNCTION public.get_location_totals(cr3_crash_date date, noncr3_crash_date date, cr3_location character varying, noncr3_location character varying, cost_per_crash numeric)
+ RETURNS SETOF atd_location_crash_and_cost_totals
+ LANGUAGE sql
+ STABLE
+AS $function$
+with
+  noncr3 as (
+    select count(aab.case_id) as total_crashes,
+    count(aab.case_id) * cost_per_crash as est_comp_cost
+    from atd_apd_blueform aab
+    where aab.location_id = noncr3_location
+    and aab.date >= noncr3_crash_date
+  ),
+  cr3 as (
+    select count(atc.crash_id) as total_crashes,
+    sum(est_crash_based_comp_cost) as est_comp_cost
+    from atd_txdot_crashes atc
+    where atc.location_id = cr3_location
+    and atc.crash_date >= cr3_crash_date
+  )
+select cr3_location as location_id,
+       cr3.total_crashes + noncr3.total_crashes as total_crashes,
+       cr3.est_comp_cost + noncr3.est_comp_cost as total_est_comp_cost,
+       cr3.total_crashes as cr3_total_crashes,
+       cr3.est_comp_cost as cr3_est_comp_cost,
+       noncr3.total_crashes as noncr3_total_crashes,
+       noncr3.est_comp_cost as noncr3_est_comp_cost
+from noncr3, cr3
+  $function$
+;


### PR DESCRIPTION
Sergio and I were talking about this function earlier, and I wanted to see if I could offer another framing of the query to see if it could be made easier on the database and also correct the problem I had introduced earlier. What do you all think of this implementation?    

>     My earlier commit today introduced a behavior where the use of the
>     query as submitted was very expensive for the DB. It is not suitable for
>     production.
> 
>     I would like to propose this re-write of the function. This is,
>     essentially, two very simply queries which can each use the indexes in
>     place for atd_apd_blueform and atd_txdot_crashes. Both queries only can
>     return a single row, as all of the selected items are aggregate function
>     results. These two queries are defined as CTE tables containing one row
>     each, so the primary query can simply JOIN the two "tables", which
>     concatenates the fields into one row. Here, you can add the columns you
>     need to add and simply pass through the others.
> 
>     One thing to note, this version does allow the invocation of different
>     locations for CR3 crashes vs. non-CR3 crashes, where the previous query
>     would return nothing in that case. Since the arguments are both
>     specified, I think this is the intended behavior. Also, like the
>     previous query, a location_id is returned in the results, and this query
>     returns the CR3 location_id and not the non-cr3 one.