### PR TITLE
Resolve comprehensive cost sum for locations

### DIFF
--- a/atd-vzd/triggers/get_location_totals.sql
+++ b/atd-vzd/triggers/get_location_totals.sql
@@ -35,7 +35,10 @@ WITH
   -- for CR3 crashes. 
   cr3 AS (
     SELECT COUNT(atc.crash_id) AS total_crashes,
-      SUM(est_comp_cost) AS est_comp_cost
+      -- In the case of no CR3 crashes, the SUM() returns null,
+      -- which in turn causes 'total_est_comp_cost' to be null
+      -- in the main query, as INT + null = null.
+      COALESCE(SUM(est_comp_cost),0) AS est_comp_cost
     FROM atd_txdot_crashes atc
     WHERE atc.location_id = cr3_location
       AND atc.crash_date >= cr3_crash_date

--- a/atd-vzd/triggers/get_location_totals.sql
+++ b/atd-vzd/triggers/get_location_totals.sql
@@ -2,8 +2,7 @@ CREATE OR REPLACE FUNCTION public.get_location_totals(
   cr3_crash_date    date, 
   noncr3_crash_date date, 
   cr3_location      character varying, 
-  noncr3_location   character varying, 
-  cost_per_crash    numeric
+  noncr3_location   character varying
   ) RETURNS SETOF atd_location_crash_and_cost_totals
  LANGUAGE sql STABLE
   AS $function$
@@ -25,7 +24,9 @@ WITH
   -- only return a single row under any circumstances.
   noncr3 AS (
     SELECT COUNT(aab.case_id) AS total_crashes,
-      COUNT(aab.case_id) * cost_per_crash AS est_comp_cost
+      COUNT(aab.case_id) *
+        (select est_comp_cost_amount from atd_txdot__est_comp_cost where est_comp_cost_id = 6)
+      AS est_comp_cost
     FROM atd_apd_blueform aab
     WHERE aab.location_id = noncr3_location
       AND aab.date >= noncr3_crash_date

--- a/atd-vze/src/queries/Locations.js
+++ b/atd-vze/src/queries/Locations.js
@@ -1,7 +1,7 @@
 import { gql } from "apollo-boost";
 
 export const GET_LOCATION = gql`
-  query GetLocation($id: String, $yearsAgoDate: date, $costPerCrash: numeric) {
+  query GetLocation($id: String, $yearsAgoDate: date) {
     atd_txdot_locations(where: { location_id: { _eq: $id } }) {
       location_id
       address
@@ -24,17 +24,11 @@ export const GET_LOCATION = gql`
         noncr3_location: $id
         noncr3_crash_date: $yearsAgoDate
         cr3_location: $id
-        cost_per_crash: $costPerCrash
       }
     ) {
       total_crashes
       total_est_comp_cost
       noncr3_est_comp_cost
-    }
-    nonCr3EstCompCost: atd_txdot__est_comp_cost(
-      where: { est_comp_cost_id: { _eq: 6 } }
-    ) {
-      est_comp_cost_amount
     }
   }
 `;

--- a/atd-vze/src/views/Locations/Location.js
+++ b/atd-vze/src/views/Locations/Location.js
@@ -24,24 +24,12 @@ function Location(props) {
 
   const [variables, setVariables] = useState({
     id: locationId,
-    yearsAgoDate: fiveYearsAgo,
-    costPerCrash: parseFloat(0),
+    yearsAgoDate: fiveYearsAgo
   });
 
   const { loading, error, data, refetch } = useQuery(GET_LOCATION, {
     variables,
   });
-
-  // Retrieve est_comp_cost_amount of Non-CR3 crashes from DB and set updated variable
-  useEffect(() => {
-    if (
-      Object.entries(data).length !== 0 &&
-      data.locationTotals[0].noncr3_est_comp_cost === 0
-    ) {
-      const costPerNonCr3Crash = data.nonCr3EstCompCost[0].est_comp_cost_amount;
-      setVariables({ ...variables, costPerCrash: costPerNonCr3Crash });
-    }
-  }, [data, variables]);
 
   // On variable change, refetch to get calculated Non-CR3 total_est_comp_cost
   useEffect(() => {


### PR DESCRIPTION
Borrowing from the commit message which contains the bulk of this work:

This PR aims to resolve a complex interplay between the Location component
and its useEffect hooks, the get_location_totals() function in the database,
and the comprehensive cost value assigned to non-CR3 crashes.

The get_location_totals() function was reworked recently in an attempt
to address the fact that locations without any non-CR3 crashes were
being allocated one non-CR3 crash's comprehensive cost to the total comp
cost. At the time of writing, this behavior can be seen in production
here: https://visionzero.austin.gov/editor/#/locations/7D3D1117E9.

The change to the function referenced above introduced a performance
issue for the database, and in hind-sight, should not have been merged
into master. To fix this new problem, I proposed a rewrite of the
function which eliminated table joins by using two simple CTE functions.

This rewrite corrected the misbehavior of always returning at least one
non-CR3 crash's worth of comprehensive cost, however, in doing so, it
exposed an issue with one of the useEffect() hooks in the Location
component.

The first useEffect() hook, which is removed by this commit,
was intended to catch the case when the non-CR3 total comp cost was 0, such as
is the case when the function argument for non-cr3 crash comp cost was
set to 0, and augment the variables to include the correct non-CR3 comp
cost per crash to be the value received from the initial query to the
function. However, in the case when a location does not have any non-CR3
crashes, combined with the rewritten function no longer returning
at least one crash's worth of non-CR3 comprehensive cost, the
useEffect() hook would infinitely loop, yielding a WSOD.

This commit's intended resolution is to entirely remove the non-CR3 crash
comp cost argument from the function in lieu of a inline subquery in the
function which retrieves the correct amount out of the
atd_txdot__est_comp_cost table. This removes the need to requery the
database a second time and eliminates the need for this useEffect() hook,
allowing it to be removed which also solves the infinite loop issue it
exhibits for non-CR3 crash bearing locations.

Because the app no longer needs to know the non-CR3 crash
comp cost value, the portion of the GET_LOCATION query which previously
delivered that value can be removed as well from queries/Locations.js.
Essentially this database specific hard-coding of ID 6 has been pushed
down into the database function and out of the application code.

Useful locations for testing this code:

1BD8B11685: 1 CR3 Crash   and 1 Non-CR3 Crashes
7D3D1117E9: 2 CR3 Crashes and 0 Non-CR3 Crashes
95204CB2C7: 0 CR3 Crashes and 1 Non-CR3 Crash