### PR TITLE
Change formatting for comp-cost and economic-cost to currency

### DIFF
--- a/atd-vze/src/views/Crashes/crashGridTableParameters.js
+++ b/atd-vze/src/views/Crashes/crashGridTableParameters.js
@@ -116,14 +116,14 @@ export const nonCR3CrashGridTableColumns = {
     searchable: false,
     sortable: true,
     label_table: "Est Comprehensive Cost",
-    type: "Int",
+    type: "Currency",
   },
   est_econ_cost: {
     primary_key: false,
     searchable: false,
     sortable: true,
     label_table: "Est Economic Cost",
-    type: "Int",
+    type: "Currency",
   },
 };
 


### PR DESCRIPTION
These value are shown in the GridTable for Non-CR3 crashes on the
location view.