### PR TITLE
Add trigger to set austin_full_purpose

### DIFF
--- a/atd-vzd/triggers/atd_txdot_crashes_updates_audit_log.sql
+++ b/atd-vzd/triggers/atd_txdot_crashes_updates_audit_log.sql
@@ -152,11 +152,8 @@ BEGIN
     ------------------------------------------------------------------------------------------
 	-- Set Austin Full Purpose to Y (TRUE) when it has Austin City ID and no coordinates.
     IF (NEW.position IS NULL and NEW.city_id = 22) THEN
-        NEW.austin_full_purpose = 'Y'
-	END IF;
-
-    NEW
-    
+        NEW.austin_full_purpose = 'Y';
+	END IF;    
     --- END OF AUSTIN FULL PURPOSE ---
 END;
 $$;

--- a/atd-vzd/triggers/atd_txdot_crashes_updates_audit_log.sql
+++ b/atd-vzd/triggers/atd_txdot_crashes_updates_audit_log.sql
@@ -144,6 +144,20 @@ BEGIN
     -- Record the current timestamp
     NEW.last_update = current_timestamp;
     RETURN NEW;
+
+    --- END OF MODE CATEGORY DATA ---
+
+    ------------------------------------------------------------------------------------------
+    -- AUSTIN FULL PURPOSE
+    ------------------------------------------------------------------------------------------
+	-- Set Austin Full Purpose to Y (TRUE) when it has Austin City ID and no coordinates.
+    IF (NEW.position IS NULL and NEW.city_id = 22) THEN
+        NEW.austin_full_purpose = 'Y'
+	END IF;
+
+    NEW
+    
+    --- END OF AUSTIN FULL PURPOSE ---
 END;
 $$;
 

--- a/atd-vzd/triggers/atd_txdot_crashes_updates_audit_log.sql
+++ b/atd-vzd/triggers/atd_txdot_crashes_updates_audit_log.sql
@@ -1,4 +1,4 @@
-create function atd_txdot_crashes_updates_audit_log() returns trigger
+create or replace function atd_txdot_crashes_updates_audit_log() returns trigger
     language plpgsql
 as
 $$
@@ -141,12 +141,6 @@ BEGIN
     NEW.atd_mode_category_metadata = get_crash_modes(NEW.crash_id);
     --- END OF MODE CATEGORY DATA ---
 
-    -- Record the current timestamp
-    NEW.last_update = current_timestamp;
-    RETURN NEW;
-
-    --- END OF MODE CATEGORY DATA ---
-
     ------------------------------------------------------------------------------------------
     -- AUSTIN FULL PURPOSE
     ------------------------------------------------------------------------------------------
@@ -155,6 +149,10 @@ BEGIN
         NEW.austin_full_purpose = 'Y';
 	END IF;    
     --- END OF AUSTIN FULL PURPOSE ---
+
+    -- Record the current timestamp
+    NEW.last_update = current_timestamp;
+    RETURN NEW;
 END;
 $$;
 


### PR DESCRIPTION
Closes https://github.com/cityofaustin/atd-data-tech/issues/6351

The intent of this PR is to make the Austin Full Purpose column more accurate for the needs of the VZ team and to include more crashes in the universe that counts towards metrics (like those in VZV).

The logic change is that if crashes have Austin City ID 22 and no coordinations (aka null position), we should assume they are Austin Full Purpose. 

This PR has not yet been tested on staging or implemented in production. First I wanted to make sure this is the right place for the code to live.