### PR TITLE
Update to lambda function to associate SVRD, directional crashes to polygons

### DIFF
--- a/atd-events/crash_update_location/app.py
+++ b/atd-events/crash_update_location/app.py
@@ -11,7 +11,7 @@ from typing import Optional
 HASURA_ADMIN_SECRET = os.getenv("HASURA_ADMIN_SECRET", "")
 HASURA_ENDPOINT = os.getenv("HASURA_ENDPOINT", "")
 HASURA_EVENT_API = os.getenv("HASURA_EVENT_API", "")
-HASURA_SSL_VERIFY = True# Set False for local hasura with self-generated SSL cert
+HASURA_SSL_VERIFY = True # Set False for local hasura with self-generated SSL cert
 
 # Prep Hasura query
 HEADERS = {
@@ -374,7 +374,7 @@ def handler(event, context):
 
 
 
-# Work-around to test easily on the command line
+# Mechanism to test easily on the command line
 
 #if __name__ == "__main__":
     #event = {'Records': [{'body': """ { "event": { "data": { "old": null, "new": {

--- a/atd-events/crash_update_location/requirements.txt
+++ b/atd-events/crash_update_location/requirements.txt
@@ -1,5 +1,5 @@
 certifi==2020.4.5.1
 chardet==3.0.4
 idna==2.9
-requests==2.23.0
+requests==2.26.0
 urllib3==1.26.5

--- a/atd-vzd/views/view_cr3_nonproper_crashes_on_mainlane.sql
+++ b/atd-vzd/views/view_cr3_nonproper_crashes_on_mainlane.sql
@@ -1,0 +1,71 @@
+CREATE OR REPLACE VIEW public.cr3_nonproper_crashes_on_mainlane
+AS WITH cr3_mainlanes AS (
+         SELECT st_transform(st_buffer(st_transform(st_union(cr3_mainlanes.geometry), 2277), 1::double precision), 4326) AS geometry
+           FROM public.cr3_mainlanes
+        ), seek_direction AS (
+         SELECT c_1.crash_id,
+                CASE
+                    WHEN "substring"(lower(c_1.rpt_street_name::text), '\s?([nsew])[arthous]*\s??b(oun)?d?'::text) ~* 'w'::text OR "substring"(lower(c_1.rpt_sec_street_name::text), '\s?([nsew])[arthous]*\s??b(oun)?d?'::text) ~* 'w'::text THEN 0
+                    WHEN "substring"(lower(c_1.rpt_street_name::text), '\s?([nsew])[arthous]*\s??b(oun)?d?'::text) ~* 'n'::text OR "substring"(lower(c_1.rpt_sec_street_name::text), '\s?([nsew])[arthous]*\s??b(oun)?d?'::text) ~* 'n'::text THEN 90
+                    WHEN "substring"(lower(c_1.rpt_street_name::text), '\s?([nsew])[arthous]*\s??b(oun)?d?'::text) ~* 'e'::text OR "substring"(lower(c_1.rpt_sec_street_name::text), '\s?([nsew])[arthous]*\s??b(oun)?d?'::text) ~* 'e'::text THEN 180
+                    WHEN "substring"(lower(c_1.rpt_street_name::text), '\s?([nsew])[arthous]*\s??b(oun)?d?'::text) ~* 's'::text OR "substring"(lower(c_1.rpt_sec_street_name::text), '\s?([nsew])[arthous]*\s??b(oun)?d?'::text) ~* 's'::text THEN 270
+                    ELSE NULL::integer
+                END AS seek_direction
+           FROM atd_txdot_crashes c_1
+        )
+ SELECT
+    c.*,
+        CASE
+            WHEN c.rpt_street_name::text ~* '\s?([nsew])[arthous]*\s??b(oun)?d?'::text OR c.rpt_sec_street_name::text ~* '\s?([nsew])[arthous]*\s??b(oun)?d?'::text THEN true
+            ELSE false
+        END AS has_directionality,
+    d.seek_direction,
+    ( SELECT p.location_id
+           FROM atd_txdot_locations p
+          WHERE
+                CASE
+                    WHEN
+                    CASE
+                        WHEN (d.seek_direction - 65) < 0 THEN d.seek_direction - 65 + 360
+                        ELSE d.seek_direction - 65
+                    END < ((d.seek_direction + 65) % 360) THEN (st_azimuth(c."position", st_centroid(p.shape)) * 180::double precision / pi()) >=
+                    CASE
+                        WHEN (d.seek_direction - 65) < 0 THEN d.seek_direction - 65 + 360
+                        ELSE d.seek_direction - 65
+                    END::double precision AND (st_azimuth(c."position", st_centroid(p.shape)) * 180::double precision / pi()) <= ((d.seek_direction + 65) % 360)::double precision
+                    ELSE (st_azimuth(c."position", st_centroid(p.shape)) * 180::double precision / pi()) >=
+                    CASE
+                        WHEN (d.seek_direction - 65) < 0 THEN d.seek_direction - 65 + 360
+                        ELSE d.seek_direction - 65
+                    END::double precision OR (st_azimuth(c."position", st_centroid(p.shape)) * 180::double precision / pi()) <= ((d.seek_direction + 65) % 360)::double precision
+                END AND st_intersects(st_transform(st_buffer(st_transform(c."position", 2277), 750::double precision), 4326), p.shape) AND p.description ~~* '%SVRD%'::text
+          ORDER BY (st_distance(st_centroid(p.shape), c."position"))
+         LIMIT 1) AS surface_street_polygon,
+    st_makeline(st_centroid(( SELECT p.shape
+           FROM atd_txdot_locations p
+          WHERE
+                CASE
+                    WHEN
+                    CASE
+                        WHEN (d.seek_direction - 65) < 0 THEN d.seek_direction - 65 + 360
+                        ELSE d.seek_direction - 65
+                    END < ((d.seek_direction + 65) % 360) THEN (st_azimuth(c."position", st_centroid(p.shape)) * 180::double precision / pi()) >=
+                    CASE
+                        WHEN (d.seek_direction - 65) < 0 THEN d.seek_direction - 65 + 360
+                        ELSE d.seek_direction - 65
+                    END::double precision AND (st_azimuth(c."position", st_centroid(p.shape)) * 180::double precision / pi()) <= ((d.seek_direction + 65) % 360)::double precision
+                    ELSE (st_azimuth(c."position", st_centroid(p.shape)) * 180::double precision / pi()) >=
+                    CASE
+                        WHEN (d.seek_direction - 65) < 0 THEN d.seek_direction - 65 + 360
+                        ELSE d.seek_direction - 65
+                    END::double precision OR (st_azimuth(c."position", st_centroid(p.shape)) * 180::double precision / pi()) <= ((d.seek_direction + 65) % 360)::double precision
+                END AND st_intersects(st_transform(st_buffer(st_transform(c."position", 2277), 750::double precision), 4326), p.shape) AND p.description ~~* '%SVRD%'::text
+          ORDER BY (st_distance(st_centroid(p.shape), c."position"))
+         LIMIT 1)), c."position") AS visualization
+   FROM atd_txdot_crashes c,
+    cr3_mainlanes l,
+    seek_direction d
+     JOIN atd_jurisdictions aj ON aj.id = 5
+  WHERE 1 = 1 AND c.location_id IS NULL AND d.crash_id = c.crash_id AND st_contains(aj.geometry, c."position") AND c.private_dr_fl::text = 'N'::text AND (c.rpt_road_part_id = ANY (ARRAY[2, 3, 4, 5, 7])) AND st_contains(l.geometry, c."position");
+
+-- Ensure that this view is tracked in Hasura and that it has at least, surface_street_polygon & crash_id exposed for SELECT.

--- a/atd-vzd/views/view_cr3_nonproper_crashes_on_mainlane.sql
+++ b/atd-vzd/views/view_cr3_nonproper_crashes_on_mainlane.sql
@@ -66,6 +66,6 @@ AS WITH cr3_mainlanes AS (
     cr3_mainlanes l,
     seek_direction d
      JOIN atd_jurisdictions aj ON aj.id = 5
-  WHERE 1 = 1 AND c.location_id IS NULL AND d.crash_id = c.crash_id AND st_contains(aj.geometry, c."position") AND c.private_dr_fl::text = 'N'::text AND (c.rpt_road_part_id = ANY (ARRAY[2, 3, 4, 5, 7])) AND st_contains(l.geometry, c."position");
+  WHERE 1 = 1 AND d.crash_id = c.crash_id AND st_contains(aj.geometry, c."position") AND c.private_dr_fl::text = 'N'::text AND (c.rpt_road_part_id = ANY (ARRAY[2, 3, 4, 5, 7])) AND st_contains(l.geometry, c."position");
 
 -- Ensure that this view is tracked in Hasura and that it has at least, surface_street_polygon & crash_id exposed for SELECT.


### PR DESCRIPTION
This PR includes the creation of a new view (cr3_nonproper_crashes_on_mainlane) which can be used to determine if and which polygon a crash should be associated to if it fits the following criteria:

- Incorrectly geocoded to be on the main-lane of a level 5 road
- Correctly tagged in the CRIS data to indicate that it's on a SVRD
- Contains a directionality indicator in the user provided name of the service road `/\s?([nsew])[arthous]*\s??b(oun)?d?/`
- Has a polygon such that that polygon can be found within a 130 degree cone emanating in the cardinal direction 90 degrees out of phase of the direction of travel within 500 linear feet under SRID 2277

This table needs to be exposed for SELECT via Hasura.

Also, the changed to the python code uses the := assignment (walrus) operator which was introduced in python 3.8 (Oct-2019). Its use eliminates a Hasura call, but I can code it out if that's too recent a python version for the lambda call.

Closes cityofaustin/atd-data-tech#6700