### PR TITLE
Production Patch: Upgrade python runtime to 3.8 for SQS

### DIFF
--- a/atd-events/README.md
+++ b/atd-events/README.md
@@ -2,7 +2,8 @@
 
 An event handler is basically a python script that
 will run every time we submit a message to AWS Simple
-Queue Service (SQS).
+Queue Service (SQS). Currently, the Python 3.8 runtime
+is being used in AWS Lambda.
 
 A message is basically any trivial text with a limit
 of 256kb, as well as 10 metadata optional attributes.

--- a/atd-vze/package.json
+++ b/atd-vze/package.json
@@ -1,6 +1,6 @@
 {
   "name": "atd-vz-data",
-  "version": "1.21.0",
+  "version": "1.21.1",
   "homepage": "./",
   "description": "ATD Vision Zero Editor",
   "author": "ATD Data & Technology Services",


### PR DESCRIPTION
One of the event handlers is having problems with the walrus operator, as referenced in this bug report:

https://github.com/cityofaustin/atd-data-tech/issues/6759

Rather than refactoring the code and re-testing it is easier to upgrade the runtime version to python's 3.8 which is currently supported in AWS Lambda:

<img width="742" alt="2021-07-23_13-12-57" src="https://user-images.githubusercontent.com/5282430/126821729-d3117f9c-5174-411c-b6df-a382cac5f0ba.png">


