### PR TITLE
Refactor lambda function to find service road polygons via a function instead of a view

### DIFF
--- a/atd-events/crash_update_location/app.py
+++ b/atd-events/crash_update_location/app.py
@@ -71,11 +71,12 @@ def is_crash_nonproper_and_directional(crash_id: int) -> str:
         return False
 
     check_nonproper_polygon_query = """
-        query has_alt_polygon($crash_id: Int) {
-          cr3_nonproper_crashes_on_mainlane(where: {crash_id: {_eq: $crash_id}}) {
-            surface_street_polygon
-          }
-        }
+    query find_service_road_location($crashId: Int!) {
+      find_service_road_location_for_centerline_crash(args: {input_crash_id: $crashId})
+      {
+        location_id
+      }
+    }
     """
 
     try:
@@ -89,17 +90,17 @@ def is_crash_nonproper_and_directional(crash_id: int) -> str:
                 {
                     "query": check_nonproper_polygon_query,
                     "variables": {
-                        "crash_id": crash_id
+                        "crashId": crash_id
                     }
                 }
             ),
             headers=HEADERS,
             verify=HASURA_SSL_VERIFY
         )
-        if (response.json()["data"]["cr3_nonproper_crashes_on_mainlane"][0]["surface_street_polygon"] is None):
+        if (response.json()["data"]["find_service_road_location_for_centerline_crash"][0]["location_id"] is None):
             return ''
         else:
-            return response.json()["data"]["cr3_nonproper_crashes_on_mainlane"][0]["surface_street_polygon"]
+            return response.json()["data"]["find_service_road_location_for_centerline_crash"][0]["location_id"]
     except:
         """
             In case the response is broken or invalid, we need to:
@@ -382,7 +383,7 @@ def handler(event, context):
 
 #if __name__ == "__main__":
     #event = {'Records': [{'body': """ { "event": { "data": { "old": null, "new": {
-                #"crash_id": 15359199,
+                #"crash_id": 17797640,
               #"location_id": null } } } } """}]}
     #context = {}
     #handler(event, context)

--- a/atd-events/crash_update_location/app.py
+++ b/atd-events/crash_update_location/app.py
@@ -13,7 +13,6 @@ HASURA_ENDPOINT = os.getenv("HASURA_ENDPOINT", "")
 HASURA_EVENT_API = os.getenv("HASURA_EVENT_API", "")
 HASURA_SSL_VERIFY = True # Set False for local hasura with self-generated SSL cert
 
-HASURA_SSL_VERIFY = False # Set False for local hasura with self-generated SSL cert
 if not HASURA_SSL_VERIFY:
     requests.packages.urllib3.disable_warnings()
 

--- a/atd-events/crash_update_location/app.py
+++ b/atd-events/crash_update_location/app.py
@@ -13,6 +13,10 @@ HASURA_ENDPOINT = os.getenv("HASURA_ENDPOINT", "")
 HASURA_EVENT_API = os.getenv("HASURA_EVENT_API", "")
 HASURA_SSL_VERIFY = True # Set False for local hasura with self-generated SSL cert
 
+HASURA_SSL_VERIFY = False # Set False for local hasura with self-generated SSL cert
+if not HASURA_SSL_VERIFY:
+    requests.packages.urllib3.disable_warnings()
+
 # Prep Hasura query
 HEADERS = {
     "Content-Type": "application/json",

--- a/atd-vzd/triggers/find_service_road_location_for_centerline_crash.sql
+++ b/atd-vzd/triggers/find_service_road_location_for_centerline_crash.sql
@@ -1,0 +1,55 @@
+create or replace function find_service_road_location_for_centerline_crash(input_crash_id integer)
+returns setof atd_txdot_locations
+language 'sql'
+stable
+as $QUERY$
+with crash as (
+  -- this query will return a crash_id and seek direction iff the crash supplied lies within a mainlane strip
+  WITH cr3_mainlanes AS (
+    SELECT st_transform(st_buffer(st_transform(st_union(cr3_mainlanes.geometry), 2277), 1), 4326) AS geometry
+      FROM cr3_mainlanes
+      )
+  select c.crash_id, position,
+    CASE
+      WHEN "substring"(lower(c.rpt_street_name), '\s?([nsew])[arthous]*\s??b(oun)?d?') ~* 'w' OR "substring"(lower(c.rpt_sec_street_name), '\s?([nsew])[arthous]*\s??b(oun)?d?') ~* 'w' THEN 0
+      WHEN "substring"(lower(c.rpt_street_name), '\s?([nsew])[arthous]*\s??b(oun)?d?') ~* 'n' OR "substring"(lower(c.rpt_sec_street_name), '\s?([nsew])[arthous]*\s??b(oun)?d?') ~* 'n' THEN 90
+      WHEN "substring"(lower(c.rpt_street_name), '\s?([nsew])[arthous]*\s??b(oun)?d?') ~* 'e' OR "substring"(lower(c.rpt_sec_street_name), '\s?([nsew])[arthous]*\s??b(oun)?d?') ~* 'e' THEN 180
+      WHEN "substring"(lower(c.rpt_street_name), '\s?([nsew])[arthous]*\s??b(oun)?d?') ~* 's' OR "substring"(lower(c.rpt_sec_street_name), '\s?([nsew])[arthous]*\s??b(oun)?d?') ~* 's' THEN 270
+      ELSE NULL
+    END AS seek_direction
+  from atd_txdot_crashes c
+  join atd_jurisdictions aj on (aj.id = 5)
+  join cr3_mainlanes on (ST_Contains(cr3_mainlanes.geometry, c.position))
+  where 1 = 1
+  and st_contains(aj.geometry, c.position) and c.private_dr_fl = 'N'
+  and c.rpt_road_part_id = ANY (ARRAY[2, 3, 4, 5, 7])
+  and c.crash_id = input_crash_id
+  limit 1
+)
+select l.*
+from atd_txdot_locations l
+join crash c on (1 = 1)
+where
+CASE
+  WHEN
+  CASE
+    WHEN (c.seek_direction - 65) < 0 THEN c.seek_direction - 65 + 360
+    ELSE c.seek_direction - 65
+  END < ((c.seek_direction + 65) % 360) THEN (st_azimuth(c.position, st_centroid(l.shape)) * 180 / pi()) >=
+    CASE
+      WHEN (c.seek_direction - 65) < 0 THEN c.seek_direction - 65 + 360
+      ELSE c.seek_direction - 65
+    END 
+    AND (st_azimuth(c.position, st_centroid(l.shape)) * 180 / pi()) <= ((c.seek_direction + 65) % 360)
+ELSE (st_azimuth(c.position, st_centroid(l.shape)) * 180 / pi()) >=
+    CASE
+      WHEN (c.seek_direction - 65) < 0 THEN c.seek_direction - 65 + 360
+      ELSE c.seek_direction - 65
+    END 
+    OR (st_azimuth(c.position, st_centroid(l.shape)) * 180 / pi()) <= ((c.seek_direction + 65) % 360)
+end
+AND st_intersects(st_transform(st_buffer(st_transform(c.position, 2277), 750), 4326), l.shape) 
+AND l.description ~~* '%SVRD%'::text
+ORDER BY (st_distance(st_centroid(l.shape), c.position))
+limit 1
+$QUERY$;

--- a/atd-vzd/triggers/find_service_road_location_for_centerline_crash.sql
+++ b/atd-vzd/triggers/find_service_road_location_for_centerline_crash.sql
@@ -1,3 +1,8 @@
+-- This function is intended to be called via Hasura when the AWS lambda function, crash_update_location/app.py, 
+-- when a crash is found to be on a main-lane. It will return the location_id of a VZ location which belongs
+-- to the closest location that was formed from a service road and has its centroid lie within a cone
+-- eminating from the crash location in a direction 90 degrees out of phase of the direction of travel
+-- notated in the 'rpt_street_name' field or the 'rpt_sec_street_name' field of the crash.
 create or replace function find_service_road_location_for_centerline_crash(input_crash_id integer)
 returns setof atd_txdot_locations
 language 'sql'

--- a/atd-vzd/triggers/find_service_road_location_for_centerline_crash.sql
+++ b/atd-vzd/triggers/find_service_road_location_for_centerline_crash.sql
@@ -3,18 +3,23 @@ returns setof atd_txdot_locations
 language 'sql'
 stable
 as $QUERY$
+-- this CTE will setup a in-memory table containing one crash_id, its position, 
+-- and the seek direction if and only if the crash supplied lies within a mainlane strip
 with crash as (
-  -- this query will return a crash_id and seek direction iff the crash supplied lies within a mainlane strip
   WITH cr3_mainlanes AS (
     SELECT st_transform(st_buffer(st_transform(st_union(cr3_mainlanes.geometry), 2277), 1), 4326) AS geometry
       FROM cr3_mainlanes
       )
   select c.crash_id, position,
     CASE
-      WHEN "substring"(lower(c.rpt_street_name), '\s?([nsew])[arthous]*\s??b(oun)?d?') ~* 'w' OR "substring"(lower(c.rpt_sec_street_name), '\s?([nsew])[arthous]*\s??b(oun)?d?') ~* 'w' THEN 0
-      WHEN "substring"(lower(c.rpt_street_name), '\s?([nsew])[arthous]*\s??b(oun)?d?') ~* 'n' OR "substring"(lower(c.rpt_sec_street_name), '\s?([nsew])[arthous]*\s??b(oun)?d?') ~* 'n' THEN 90
-      WHEN "substring"(lower(c.rpt_street_name), '\s?([nsew])[arthous]*\s??b(oun)?d?') ~* 'e' OR "substring"(lower(c.rpt_sec_street_name), '\s?([nsew])[arthous]*\s??b(oun)?d?') ~* 'e' THEN 180
-      WHEN "substring"(lower(c.rpt_street_name), '\s?([nsew])[arthous]*\s??b(oun)?d?') ~* 's' OR "substring"(lower(c.rpt_sec_street_name), '\s?([nsew])[arthous]*\s??b(oun)?d?') ~* 's' THEN 270
+      WHEN "substring"(lower(c.rpt_street_name), '\s?([nsew])[arthous]*\s??b(oun)?d?') ~* 'w' 
+        OR "substring"(lower(c.rpt_sec_street_name), '\s?([nsew])[arthous]*\s??b(oun)?d?') ~* 'w' THEN 0
+      WHEN "substring"(lower(c.rpt_street_name), '\s?([nsew])[arthous]*\s??b(oun)?d?') ~* 'n' 
+        OR "substring"(lower(c.rpt_sec_street_name), '\s?([nsew])[arthous]*\s??b(oun)?d?') ~* 'n' THEN 90
+      WHEN "substring"(lower(c.rpt_street_name), '\s?([nsew])[arthous]*\s??b(oun)?d?') ~* 'e' 
+        OR "substring"(lower(c.rpt_sec_street_name), '\s?([nsew])[arthous]*\s??b(oun)?d?') ~* 'e' THEN 180
+      WHEN "substring"(lower(c.rpt_street_name), '\s?([nsew])[arthous]*\s??b(oun)?d?') ~* 's' 
+        OR "substring"(lower(c.rpt_sec_street_name), '\s?([nsew])[arthous]*\s??b(oun)?d?') ~* 's' THEN 270
       ELSE NULL
     END AS seek_direction
   from atd_txdot_crashes c
@@ -26,6 +31,8 @@ with crash as (
   and c.crash_id = input_crash_id
   limit 1
 )
+-- this query joins the crash found in the CTE with the polygon layer to find the closest 
+-- polygon centroid in the cone eminating from the crash location in the seek_direction defined in the CTE
 select l.*
 from atd_txdot_locations l
 join crash c on (1 = 1)
@@ -49,7 +56,7 @@ ELSE (st_azimuth(c.position, st_centroid(l.shape)) * 180 / pi()) >=
     OR (st_azimuth(c.position, st_centroid(l.shape)) * 180 / pi()) <= ((c.seek_direction + 65) % 360)
 end
 AND st_intersects(st_transform(st_buffer(st_transform(c.position, 2277), 750), 4326), l.shape) 
-AND l.description ~~* '%SVRD%'::text
+AND l.description ~~* '%SVRD%'
 ORDER BY (st_distance(st_centroid(l.shape), c.position))
 limit 1
 $QUERY$;


### PR DESCRIPTION
This PR intends to close cityofaustin/atd-data-tech/issues/6763. 

It contains a new SQL function based on the logic contained in the existing view `cr3_nonproper_crashes_on_mainlane` but is reworked to only evaluate a single crash, as specified as an argument, instead of many crashes which occurs when the view was used. This optimization allows a crashes' potential location_id to be found much quicker so the lambda function doesn't get terminated.

The python cProfile module reports that the function which makes the call to Hasura to see if a service road polygon is appropriate and to retrieve its id now takes .6 seconds, when tested against the staging database.