### PR TITLE
Resolves axe library accessibility warnings on summary page

### DIFF
--- a/atd-vzv/package-lock.json
+++ b/atd-vzv/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "atd-vzv",
-  "version": "1.19.1",
+  "version": "1.21.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/atd-vzv/public/index.html
+++ b/atd-vzv/public/index.html
@@ -5,7 +5,7 @@
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
     <meta
       name="viewport"
-      content="width=device-width, initial-scale=1, maximum-scale=1.0, user-scalable=0"
+      content="width=device-width, initial-scale=1, maximum-scale=5"
     />
     <meta name="theme-color" content="#000000" />
 

--- a/atd-vzv/src/Components/Widgets/SummaryWidget.js
+++ b/atd-vzv/src/Components/Widgets/SummaryWidget.js
@@ -101,13 +101,18 @@ const SummaryWidget = ({
         <Row>
           <Col>
             {/* Show spinner while waiting for data, add thousands separator to total */}
-            <h2 className="h1 total">
               {!!totalsObject ? (
-                numberWithCommas(totalsObject[currentYear])
+                <h2 className="h1 total">
+                  {numberWithCommas(totalsObject[currentYear])}
+                </h2>
               ) : (
-                <ColorSpinner color={backgroundColor} />
+                <h2 className="h1 total">
+                  <p className="sr-only">
+                    Data loading
+                  </p>
+                  <ColorSpinner color={backgroundColor} />
+                </h2>
               )}
-            </h2>
           </Col>
         </Row>
         <div className="text-left d-flex flex-row">

--- a/atd-vzv/src/views/nav/Footer.js
+++ b/atd-vzv/src/views/nav/Footer.js
@@ -108,26 +108,28 @@ const Footer = () => {
   ];
 
   return (
-    <StyledFooter>
-      <Container fluid className="mt-5">
-        <img
-          alt="City of Austin seal"
-          className="coa-seal float-left"
-          height="100px"
-          src={logo}
-        />
-        <Row className="col-12 link-table">
-          <Col xs="12" className="link link-title">
-            City of Austin Transportation Department
-          </Col>
-          {footerLinks.map((link, i) => (
-            <Col key={i} xs="12" md="6" className="link">
-              {link.url ? <a href={link.url}>{link.text}</a> : link.text}
+    <footer>
+      <StyledFooter>
+        <Container fluid className="mt-5">
+          <img
+            alt="City of Austin seal"
+            className="coa-seal float-left"
+            height="100px"
+            src={logo}
+          />
+          <Row className="col-12 link-table">
+            <Col xs="12" className="link link-title">
+              City of Austin Transportation Department
             </Col>
-          ))}
-        </Row>
-      </Container>
-    </StyledFooter>
+            {footerLinks.map((link, i) => (
+              <Col key={i} xs="12" md="6" className="link">
+                {link.url ? <a href={link.url}>{link.text}</a> : link.text}
+              </Col>
+            ))}
+          </Row>
+        </Container>
+      </StyledFooter>
+    </footer>
   );
 };
 

--- a/atd-vzv/src/views/nav/Header.js
+++ b/atd-vzv/src/views/nav/Header.js
@@ -90,71 +90,73 @@ const Header = () => {
   } = React.useContext(StoreContext);
 
   return (
-    <StyledNavbar>
-      <Navbar
-        light
-        className="navbar shadow-sm fixed-top header-navbar px-0"
-        expand="md"
-      >
-        <Container
-          fluid
-          // In Summary view, match padding and margins of Summary content below
-          className={`${
-            isSummaryView
-              ? "px-xs-0 mx-xs-0 pl-md-2 pr-md-1 px-lg-3 mx-lg-4"
-              : "px-0"
-          }`}
+    <header role="banner">
+      <StyledNavbar>
+        <Navbar
+          light
+          className="navbar shadow-sm fixed-top header-navbar px-0"
+          expand="md"
         >
-          <Button
-            className="ml-3 sidedrawer-toggle"
-            color="dark"
-            onClick={() => setIsOpen(!isOpen)}
-          >
-            <span className="sr-only">Menu Button</span>
-            <FontAwesomeIcon icon={faBars} />
-          </Button>
-          <div className="vz-logo-wrapper">
-            <h1 className="sr-only">
-              Vision Zero -- Help Austin reach zero traffic deaths
-            </h1>
-            <img
-              className="vz-logo pl-lg-3"
-              // Need to adjust location of public folder to account for /viewer/ basepath
-              src={process.env.PUBLIC_URL + "/vz_logo.svg"}
-              alt="Vision Zero Austin Logo"
-            ></img>
-          </div>
-          <Nav
-            className={`navbar-links ml-auto ${
-              isSummaryView ? "px-lg-3" : "px-3"
+          <Container
+            fluid
+            // In Summary view, match padding and margins of Summary content below
+            className={`${
+              isSummaryView
+                ? "px-xs-0 mx-xs-0 pl-md-2 pr-md-1 px-lg-3 mx-lg-4"
+                : "px-0"
             }`}
-            navbar
           >
-            {navConfig.map(
-              (config, i) =>
-                currentPath !== config.url && (
-                  <NavItem key={i}>
-                    <NavLink
-                      tag={A}
-                      href={config.url}
-                      className="pr-0 pl-2 mr-0 ml-2"
-                    >
-                      <Button
-                        className={`nav-button inactive-nav-button mx-xs-0 mx-lg-2`}
-                        onClick={() => trackPageEvent(config.eventKey)}
-                        active={currentPath === config.url}
+            <Button
+              className="ml-3 sidedrawer-toggle"
+              color="dark"
+              onClick={() => setIsOpen(!isOpen)}
+            >
+              <span className="sr-only">Menu Button</span>
+              <FontAwesomeIcon icon={faBars} />
+            </Button>
+            <div className="vz-logo-wrapper">
+              <h1 className="sr-only">
+                Vision Zero -- Help Austin reach zero traffic deaths
+              </h1>
+              <img
+                className="vz-logo pl-lg-3"
+                // Need to adjust location of public folder to account for /viewer/ basepath
+                src={process.env.PUBLIC_URL + "/vz_logo.svg"}
+                alt="Vision Zero Austin Logo"
+              ></img>
+            </div>
+            <Nav
+              className={`navbar-links ml-auto ${
+                isSummaryView ? "px-lg-3" : "px-3"
+              }`}
+              navbar
+            >
+              {navConfig.map(
+                (config, i) =>
+                  currentPath !== config.url && (
+                    <NavItem key={i}>
+                      <NavLink
+                        tag={A}
+                        href={config.url}
+                        className="pr-0 pl-2 mr-0 ml-2"
                       >
-                        {config.icon}
-                        <span className="pl-2">{config.title}</span>
-                      </Button>
-                    </NavLink>
-                  </NavItem>
-                )
-            )}
-          </Nav>
-        </Container>
-      </Navbar>
-    </StyledNavbar>
+                        <Button
+                          className={`nav-button inactive-nav-button mx-xs-0 mx-lg-2`}
+                          onClick={() => trackPageEvent(config.eventKey)}
+                          active={currentPath === config.url}
+                        >
+                          {config.icon}
+                          <span className="pl-2">{config.title}</span>
+                        </Button>
+                      </NavLink>
+                    </NavItem>
+                  )
+              )}
+            </Nav>
+          </Container>
+        </Navbar>
+      </StyledNavbar>
+    </header>
   );
 };
 

--- a/atd-vzv/src/views/nav/Header.js
+++ b/atd-vzv/src/views/nav/Header.js
@@ -42,12 +42,12 @@ const Header = () => {
 
   .inactive-nav-button {
     color: ${colors.white};
-    background: ${colors.info};
+    background: ${colors.infoDark};
     opacity: 1;
     margin-left: 5px;
     margin-right: 5px;
     :hover {
-      background: ${colors.infoDark};
+      background: ${colors.info};
     }
   }
 

--- a/atd-vzv/src/views/summary/Components/CrashTypeSelector.js
+++ b/atd-vzv/src/views/summary/Components/CrashTypeSelector.js
@@ -7,7 +7,7 @@ import { colors } from "../../../constants/colors";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faHeartbeat, faMedkit } from "@fortawesome/free-solid-svg-icons";
 
-const CrashTypeSelector = ({ setCrashType }) => {
+const CrashTypeSelector = ({ setCrashType, componentName }) => {
   const fatalitiesAndSeriousInjuries = {
     name: "fatalitiesAndSeriousInjuries",
     textString: "Fatalities and Serious Injuries",
@@ -73,7 +73,7 @@ const CrashTypeSelector = ({ setCrashType }) => {
   return (
     <StyledButton>
       <Button
-        id="all-btn"
+        id={`${componentName}-all-btn`}
         type="button"
         className={classnames(
           { active: activeTab.name === "fatalitiesAndSeriousInjuries" },
@@ -86,7 +86,7 @@ const CrashTypeSelector = ({ setCrashType }) => {
         All
       </Button>
       <Button
-        id="fatalities-btn"
+        id={`${componentName}-fatalities-btn`}
         type="button"
         className={classnames(
           { active: activeTab.name === "fatalities" },
@@ -100,7 +100,7 @@ const CrashTypeSelector = ({ setCrashType }) => {
         {fatalitiesIcon} Fatalities
       </Button>
       <Button
-        id="serious-injuries-btn"
+        id={`${componentName}-serious-injuries-btn`}
         type="button"
         className={classnames(
           { active: activeTab.name === "seriousInjuries" },

--- a/atd-vzv/src/views/summary/CrashesByMode.js
+++ b/atd-vzv/src/views/summary/CrashesByMode.js
@@ -201,7 +201,7 @@ const CrashesByMode = () => {
       </Row>
       <Row>
         <Col>
-          <CrashTypeSelector setCrashType={setCrashType} />
+          <CrashTypeSelector setCrashType={setCrashType} componentName="CrashesByMode"/>
         </Col>
       </Row>
       <Row>

--- a/atd-vzv/src/views/summary/CrashesByMode.js
+++ b/atd-vzv/src/views/summary/CrashesByMode.js
@@ -287,7 +287,7 @@ const CrashesByMode = () => {
                                   onClick={customLegendClickHandler}
                                 >
                                   <hr className="my-0"></hr>
-                                  <h3 className="h6 text-center my-0 py-1">
+                                  <p className="h6 text-center my-0 py-1">
                                     <FontAwesomeIcon
                                       aria-hidden="true"
                                       className="block-icon"
@@ -301,7 +301,7 @@ const CrashesByMode = () => {
                                       {" "}
                                       {dataset.label}
                                     </p>
-                                  </h3>
+                                  </p>
                                 </div>
                               );
                             })}
@@ -318,9 +318,9 @@ const CrashesByMode = () => {
                               <StyledDiv>
                                 <div className="year-total-div">
                                   <div>
-                                    <h4 className="h6 text-center my-1 pt-2">
+                                    <p className="h6 text-center my-1 pt-2">
                                       <strong>{year}</strong>
-                                    </h4>
+                                    </p>
                                   </div>
                                   {chart.data.datasets.map(
                                     (mode, modeIterator) => {
@@ -329,11 +329,11 @@ const CrashesByMode = () => {
                                       return (
                                         <div key={modeIterator}>
                                           <hr className="my-0"></hr>
-                                          <h4
+                                          <p
                                             className={`h6 text-center my-1 ${paddingBottom}`}
                                           >
                                             {mode.data[yearIterator]}
-                                          </h4>
+                                          </p>
                                         </div>
                                       );
                                     }

--- a/atd-vzv/src/views/summary/CrashesByMode.js
+++ b/atd-vzv/src/views/summary/CrashesByMode.js
@@ -297,10 +297,10 @@ const CrashesByMode = () => {
                                     <span className="sr-only">
                                       {dataset.label}
                                     </span>
-                                    <p className="mode-label-text">
+                                    <span className="mode-label-text">
                                       {" "}
                                       {dataset.label}
-                                    </p>
+                                    </span>
                                   </p>
                                 </div>
                               );

--- a/atd-vzv/src/views/summary/CrashesByPopulation.js
+++ b/atd-vzv/src/views/summary/CrashesByPopulation.js
@@ -106,11 +106,11 @@ const CrashesByPopulation = () => {
       <Row className="pb-2">
         <Col xs={4} s={2} m={2} l={2} xl={2}>
           <div>
-            <h3 className="h6 text-center pt-2 my-1">
+            <p className="h6 text-center pt-2 my-1">
               <strong>Year</strong>
-            </h3>
+            </p>
             <hr className="my-1"></hr>
-            <h3 className="h6 text-center py-1">Ratio</h3>
+            <p className="h6 text-center py-1">Ratio</p>
           </div>
         </Col>
         {!!chartData &&
@@ -119,13 +119,13 @@ const CrashesByPopulation = () => {
             <Col xs={4} s={2} m={2} l={2} xl={2} key={i}>
               <StyledDiv>
                 <div className="year-total-div">
-                  <h6 className="text-center pt-2 my-1">
+                  <p className="text-center pt-2 my-1">
                     <strong>{year}</strong>
-                  </h6>
+                  </p>
                   <hr className="my-1"></hr>
-                  <h6 className="text-center py-1">
+                  <p className="text-center py-1">
                     {chartData.datasets[0].data[i]}
-                  </h6>
+                  </p>
                 </div>
               </StyledDiv>
             </Col>

--- a/atd-vzv/src/views/summary/CrashesByPopulation.js
+++ b/atd-vzv/src/views/summary/CrashesByPopulation.js
@@ -95,7 +95,7 @@ const CrashesByPopulation = () => {
       </Row>
       <Row>
         <Col>
-          <CrashTypeSelector setCrashType={setCrashType} />
+          <CrashTypeSelector setCrashType={setCrashType} componentName="CrashesByPopulation"/>
         </Col>
       </Row>
       <Row>

--- a/atd-vzv/src/views/summary/CrashesByTimeOfDay.js
+++ b/atd-vzv/src/views/summary/CrashesByTimeOfDay.js
@@ -199,7 +199,7 @@ const CrashesByTimeOfDay = () => {
       </Row>
       <Row>
         <Col>
-          <CrashTypeSelector setCrashType={setCrashType} />
+          <CrashTypeSelector setCrashType={setCrashType} componentName="CrashesByTimeOfDay"/>
         </Col>
       </Row>
       <Row>

--- a/atd-vzv/src/views/summary/CrashesByYear.js
+++ b/atd-vzv/src/views/summary/CrashesByYear.js
@@ -101,7 +101,7 @@ const CrashesByYear = () => {
       </Row>
       <Row>
         <Col>
-          <CrashTypeSelector setCrashType={setCrashType} />
+          <CrashTypeSelector setCrashType={setCrashType} componentName="CrashesByYear"/>
         </Col>
       </Row>
       <Row>

--- a/atd-vzv/src/views/summary/PeopleByDemographics.js
+++ b/atd-vzv/src/views/summary/PeopleByDemographics.js
@@ -286,7 +286,7 @@ const PeopleByDemographics = () => {
       </Row>
       <Row>
         <Col>
-          <CrashTypeSelector setCrashType={setCrashType} />
+          <CrashTypeSelector setCrashType={setCrashType} componentName="PeopleByDemographics"/>
         </Col>
       </Row>
       <Row>

--- a/atd-vzv/src/views/summary/Summary.js
+++ b/atd-vzv/src/views/summary/Summary.js
@@ -69,55 +69,57 @@ const Summary = () => {
   );
 
   return (
-    <Container fluid>
-      {/* Create whitespace on sides of view until mobile */}
-      <Row className="px-xs-0 mx-xs-0 px-lg-3 mx-lg-4 mt-md-3 mt-lg-4">
-        <Col className="px-xs-0">
-          <StyledSummary>
-            {previewDisclaimer}
-            <Row className="summary-child">
-              <Alert className="col-12 mb-0 banner">
-                <div className="mb-2">
-                  Austin is consistently ranked as one of America's best places
-                  to live, but too many of our fellow Austinites are killed or
-                  seriously injured in traffic crashes each year. To learn more
-                  about the City's transportation safety initiatives, visit
-                  Austin Transportation's Vision Zero Program{" "}
-                  <a
-                    href="https://austintexas.gov/page/programs-and-initiatives"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    website
-                  </a>{" "}
-                  and the City's{" "}
-                  <a
-                    href="https://capitalprojects.austintexas.gov/projects?categoryId=Mobility%2520Infrastructure:&tab=projects"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    Capital Projects Explorer
-                  </a>{" "}
-                  tool.
-                </div>
-                <div>
-                  Data through {lastUpdated}. <strong>Crash data</strong>{" "}
-                  <InfoPopover config={popoverConfig.map.trafficCrashes} />{" "}
-                  includes crashes within City of Austin geographic boundaries,
-                  inclusive of all public safety jurisdictions.
-                </div>
-              </Alert>
-            </Row>
-            <SummaryView />
-            <Row>
-              {children.map((child, i) => (
-                <SummaryCard key={i} child={child} />
-              ))}
-            </Row>
-          </StyledSummary>
-        </Col>
-      </Row>
-    </Container>
+    <main>
+      <Container fluid>
+        {/* Create whitespace on sides of view until mobile */}
+        <Row className="px-xs-0 mx-xs-0 px-lg-3 mx-lg-4 mt-md-3 mt-lg-4">
+          <Col className="px-xs-0">
+            <StyledSummary>
+              {previewDisclaimer}
+              <Row className="summary-child">
+                <Alert className="col-12 mb-0 banner">
+                  <div className="mb-2">
+                    Austin is consistently ranked as one of America's best places
+                    to live, but too many of our fellow Austinites are killed or
+                    seriously injured in traffic crashes each year. To learn more
+                    about the City's transportation safety initiatives, visit
+                    Austin Transportation's Vision Zero Program{" "}
+                    <a
+                      href="https://austintexas.gov/page/programs-and-initiatives"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      website
+                    </a>{" "}
+                    and the City's{" "}
+                    <a
+                      href="https://capitalprojects.austintexas.gov/projects?categoryId=Mobility%2520Infrastructure:&tab=projects"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      Capital Projects Explorer
+                    </a>{" "}
+                    tool.
+                  </div>
+                  <div>
+                    Data through {lastUpdated}. <strong>Crash data</strong>{" "}
+                    <InfoPopover config={popoverConfig.map.trafficCrashes} />{" "}
+                    includes crashes within City of Austin geographic boundaries,
+                    inclusive of all public safety jurisdictions.
+                  </div>
+                </Alert>
+              </Row>
+              <SummaryView />
+              <Row>
+                {children.map((child, i) => (
+                  <SummaryCard key={i} child={child} />
+                ))}
+              </Row>
+            </StyledSummary>
+          </Col>
+        </Row>
+      </Container>
+    </main>
   );
 };
 

--- a/atd-vzv/src/views/summary/ViewTheMap.js
+++ b/atd-vzv/src/views/summary/ViewTheMap.js
@@ -95,27 +95,25 @@ const ViewTheMap = () => {
   return (
     <Container className="m-0 p-0">
       <StyledViewTheMap>
-      <A href="/map" className="text-dark text-decoration-none">
-        <Row>
-          <Col>
-              <div className="img-wrapper">
-                <div className={"map-image"}></div>
-              </div>
-          </Col>
-        </Row>
-        <Row className={"justify-content-center map-icon-row"}>
-          <div className={"map-icon-circle"}>
-            <FontAwesomeIcon size="3x" icon={faMap} className={"map-fa-icon"} />
-          </div>
-        </Row>
-        <Row className=" mb-4 justify-content-center">
-          {/* <A href="/map" className="card-link text-decoration-none"> */}
-            <h2 className="text-center card-link">
-              View crash data <br />
-              on interactive map
-            </h2>
-          {/* </A> */}
-        </Row>
+        <A href="/map" className="text-dark text-decoration-none">
+          <Row>
+            <Col>
+                <div className="img-wrapper">
+                  <div className={"map-image"}></div>
+                </div>
+            </Col>
+          </Row>
+          <Row className={"justify-content-center map-icon-row"}>
+            <div className={"map-icon-circle"}>
+              <FontAwesomeIcon size="3x" icon={faMap} className={"map-fa-icon"} />
+            </div>
+          </Row>
+          <Row className="mb-4 justify-content-center">
+              <h2 className="text-center card-link">
+                View crash data <br />
+                on interactive map
+              </h2>
+          </Row>
         </A>
       </StyledViewTheMap>
     </Container>

--- a/atd-vzv/src/views/summary/ViewTheMap.js
+++ b/atd-vzv/src/views/summary/ViewTheMap.js
@@ -95,13 +95,12 @@ const ViewTheMap = () => {
   return (
     <Container className="m-0 p-0">
       <StyledViewTheMap>
+      <A href="/map" className="text-dark text-decoration-none">
         <Row>
           <Col>
-            <A href="/map">
               <div className="img-wrapper">
                 <div className={"map-image"}></div>
               </div>
-            </A>
           </Col>
         </Row>
         <Row className={"justify-content-center map-icon-row"}>
@@ -110,13 +109,14 @@ const ViewTheMap = () => {
           </div>
         </Row>
         <Row className=" mb-4 justify-content-center">
-          <A href="/map" className="card-link text-decoration-none">
-            <h2 className="text-center text-dark text-decoration-none">
+          {/* <A href="/map" className="card-link text-decoration-none"> */}
+            <h2 className="text-center card-link">
               View crash data <br />
               on interactive map
             </h2>
-          </A>
+          {/* </A> */}
         </Row>
+        </A>
       </StyledViewTheMap>
     </Container>
   );


### PR DESCRIPTION
Fixes https://github.com/cityofaustin/atd-data-tech/issues/3355

Fully testable in the deploy [preview environment](https://deploy-preview-1022--atd-vzv-staging.netlify.app/), though I don't think axe warnings are displayed in the environment. Screenshot below shows there are no warnings in the local environment.

- Resolved "critical: Zooming and scaling must not be disabled" by removing `user-scalable=0` and setting `maximum-scale` to `5`
- Resolved "serious: Links must have discernible text " by promoting `A` tag surrounding map image to surround entire `ViewTheMap` component (which includes link text) and adding necessary classes
- Resolved "serious: IDs of active elements must be unique" by passing name of parent component to `CrashTypeSelector` and adding it as a prefix to each button id
- Resolved "serious: Elements must have sufficient color contrast" by setting `infoDark` as the default state and `info` as the hover state (essentially swapping out the default and hover state colors)
- Resolved "moderate: Heading levels should only increase by one" by replacing all h6 tags with p tags and using h6 class to format chart text in By Travel Mode and By Population.
- Resolved "minor: Headings must not be empty" in SummaryWidget by adding screen reader text for total loading spinner.
- Resolved "moderate: landmarks" warnings by wrapping header, main, and footer content in landmark tags.

Important note regarding bullet 5: Not sure if the tables in the By Travel Mode and By Population charts are really accessible, may need to revisit this and consider how a screen reader would move through the charts.

<img width="1440" alt="Screen Shot 2021-08-19 at 3 47 22 PM" src="https://user-images.githubusercontent.com/35410637/130141747-7da63d79-9a58-4f99-b0a2-9a53d49e5fef.png">
