### PR TITLE
Adds support menu to Vision Zero Editor

### DIFF
--- a/atd-vze/package-lock.json
+++ b/atd-vze/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "atd-vz-data",
-  "version": "1.20.0",
+  "version": "1.21.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/atd-vze/src/containers/DefaultLayout/DefaultHeader.js
+++ b/atd-vze/src/containers/DefaultLayout/DefaultHeader.js
@@ -78,6 +78,28 @@ const DefaultHeader = props => {
             </DropdownItem>
           </DropdownMenu>
         </UncontrolledDropdown>
+        <UncontrolledDropdown nav direction="down">
+            <DropdownToggle nav>
+              <i className="fa fa-question-circle fa-2x" />
+            </DropdownToggle>
+            <DropdownMenu right>
+              <DropdownItem header tag="div" className="text-center">
+                <strong>Help</strong>
+              </DropdownItem>
+              <DropdownItem
+                href="https://atd.knack.com/dts#new-service-request/?view_249_vars=%7B%22field_398%22%3A%22Bug%20Report%20%E2%80%94%20Something%20is%20not%20working%22%2C%22field_399%22%3A%22Vision%20Zero%20(Editor)%22%7D"
+                target="_blank"
+              >
+                <i class="fa fa-bug" /> Report a bug&nbsp;&nbsp; <i className="fa fa-external-link" />
+              </DropdownItem>
+              <DropdownItem
+                href="https://atd.knack.com/dts#new-service-request/?view_249_vars=%7B%22field_398%22%3A%22Feature%20or%20Enhancement%20%E2%80%94%20An%20application%20I%20use%20could%20be%20improved%22%2C%22field_399%22%3A%22Vision%20Zero%20(Editor)%22%7D"
+                target="_blank"
+              >
+                <i class="fa fa-wrench" /> Request an enhancement&nbsp;&nbsp; <i className="fa fa-external-link" />
+              </DropdownItem>
+            </DropdownMenu>
+        </UncontrolledDropdown>
       </Nav>
     </React.Fragment>
   );


### PR DESCRIPTION
Fixes https://github.com/cityofaustin/atd-data-tech/issues/6894

Adds support menu to Vision Zero Editor with Knack links that prefill Vision Zero Editor as application, styled to match the existing Vision Zero Editor Account dropdown menu. Testable [here](https://deploy-preview-1024--atd-vze-staging.netlify.app/#/dashboard).

<img width="1440" alt="Screen Shot 2021-08-31 at 5 09 47 PM" src="https://user-images.githubusercontent.com/35410637/131582344-7da2ba89-9868-4aba-9599-bd75006200c4.png">
