### PR TITLE
Script to nudge crashes so the lambda function moves them to a service road location

### DIFF
--- a/atd-toolbox/README.md
+++ b/atd-toolbox/README.md
@@ -1,5 +1,5 @@
 # ATD - Toolbox
-This is a collection of scripts which have been written to serve a one-time or infrequent purpose. They are not intended to be run in an automated fashion, and commonly would be used from the command line when needed. They will each have different parameters and possible environment variables which need to be set for the script to function as intended. 
+This is a collection of scripts which have been written to serve a one-time or infrequent purpose. They are not intended to be run in an automated fashion and commonly would be used from the command line when needed. They will each have different parameters and possible environment variables which need to be set for the script to function as intended. 
 
 ##### `s3_restore_cr3_pdfs/`
 This contains a Python script will take a JSON file of crash ids, and download and check the CR3 file stored in S3 for each crash. It will verify the type of file using the `libmagic` library will restore the most recent `application/pdf` from the S3 version history of the file. 

--- a/atd-toolbox/README.md
+++ b/atd-toolbox/README.md
@@ -1,0 +1,13 @@
+# ATD - Toolbox
+This is a collection of scripts which have been written to serve a one-time or infrequent purpose. They are not intended to be run in an automated fashion, and commonly would be used from the command line when needed. They will each have different parameters and possible environment variables which need to be set for the script to function as intended. 
+
+##### `s3_restore_cr3_pdfs/`
+This contains a Python script will take a JSON file of crash ids, and download and check the CR3 file stored in S3 for each crash. It will verify the type of file using the `libmagic` library will restore the most recent `application/pdf` from the S3 version history of the file. 
+
+##### `reposition_crashes_to_centroid_svrd_locations/`
+This is a Python script which will use a database view to find the set of crashes which:
+* Are on a level 5 centerline,
+* Have CR3 data which indicates that the crash occurred on a service road,
+* Have a directionality which gives a hint which way off the centerline the crash should be moved.
+
+For these crashes, the script will add 0.00000001 decimal degrees to the latitude of the crash, which is an immaterial movement in geographic terms, but it will cause the lambda function tied to crash-updates to execute. It is this lambda function which will figure out what location to move the crash to and will do so.

--- a/atd-toolbox/reposition_crashes_to_centroid_of_svrd_locations/reposition_crashes_to_service_road_location_centroids.py
+++ b/atd-toolbox/reposition_crashes_to_centroid_of_svrd_locations/reposition_crashes_to_service_road_location_centroids.py
@@ -39,7 +39,7 @@ except Exception as e:
     # a stderr log is not needed, argparse croaks verbosly
     sys.exit(1)
 
-# This program will change the state of S3 objects.  Make sure the user is OK with what is about to happen.
+# This program will change crash positions.  Make sure the user is OK with what is about to happen.
 try:
     if not args.i_understand:
         # these do not use the logging functionality to avoid the timestamp on each and increase readability

--- a/atd-toolbox/reposition_crashes_to_centroid_of_svrd_locations/reposition_crashes_to_service_road_location_centroids.py
+++ b/atd-toolbox/reposition_crashes_to_centroid_of_svrd_locations/reposition_crashes_to_service_road_location_centroids.py
@@ -1,0 +1,82 @@
+import os
+import sys
+import json
+import logging
+
+import requests
+
+logging.basicConfig()
+log = logging.getLogger('crashmove')
+log.setLevel(logging.DEBUG)
+
+
+HASURA_ADMIN_KEY = os.getenv('HASURA_ADMIN_KEY')
+HASURA_ENDPOINT = os.getenv('HASURA_ENDPOINT')
+
+HEADERS = {
+          "X-Hasura-Admin-Secret": HASURA_ADMIN_KEY,
+          "Content-Type": "application/json",
+          }
+
+
+# setup and parse arguments
+try:
+    argparse = argparse.ArgumentParser(description = 'Utility to move crashes to service road polygon centroids')
+
+    argparse.add_argument("-p", "--production",
+            help = 'Specify the use of production environment',
+            action = 'store_true')
+
+    argparse.add_argument("--i-understand",
+            help = 'Do not ask the user to acknoledge that this program changes the state of S3 objects and the database.',
+            action = 'store_true')
+
+
+    args = argparse.parse_args()
+except Exception as e:
+    # a stderr log is not needed, argparse croaks verbosly
+    sys.exit(1)
+
+# This program will change the state of S3 objects.  Make sure the user is OK with what is about to happen.
+try:
+    if not args.i_understand:
+        # these do not use the logging functionality to avoid the timestamp on each and increase readability
+        print('')
+        print("This program update crash positions.")
+        print('')
+        print("It will move crashes from level 5 centerlines to the centroids")
+        print("of locations which are believed to better geolocate that crash.")
+        print('')
+        print("Please type 'I understand' to continue.")
+        print('')
+        ack = input()
+        assert(re.match("^i understand$", ack, re.I))
+except Exception as e:
+    log.error("User acknoledgement failed.")
+    log.debug(str(e))
+    sys.exit(1)
+
+
+# verify that environment Hasura variables were available and have populated values
+try:
+    assert(HASURA_ADMIN_KEY is not None and HASURA_ENDPOINT is not None)
+except Exception as e:
+    log.error("Please set environment variables HASURA_ADMIN_KEY and HASURA_ENDPOINT")
+    sys.exit(1)
+
+
+# sanity check the provided hasura endpoint and the assertion from the user about staging/production
+if (args.production):
+    try:
+        assert(not re.search("staging", HASURA_ENDPOINT, re.I))
+    except Exception as e:
+        log.error("Production flag used but staging appears in the Hasura endpoint URL")
+        sys.exit(1)
+else:
+    try:
+        assert(re.search("staging", HASURA_ENDPOINT, re.I))
+    except Exception as e:
+        log.error("Production flag is not used and staging doesn't appear in the Hasura endpoint URL")
+        sys.exit(1)
+
+

--- a/atd-toolbox/reposition_crashes_to_centroid_of_svrd_locations/reposition_crashes_to_service_road_location_centroids.py
+++ b/atd-toolbox/reposition_crashes_to_centroid_of_svrd_locations/reposition_crashes_to_service_road_location_centroids.py
@@ -140,3 +140,36 @@ for crash in (crashes):
     position[1] = position[1] + delta;
 
     log.info("Updated Position: " + str(position))
+
+    try:
+        # graphql query to get current cr3_file_metadata
+        set_position = """
+        mutation update_crash_position($crashId: Int!, $longitude: float8, $latitude: float8) {
+            update_atd_txdot_crashes(where: {crash_id: {_eq: $crashId}},
+                _set:{latitude_primary:$latitude, longitude_primary: $longitude}) {
+            affected_rows
+            }
+        }
+        """
+        # get the metadata as a dict or None if null in DB
+        update = requests.post(HASURA_ENDPOINT, headers = HEADERS, data = json.dumps(
+            {
+            "query": set_position,
+            "variables": {
+                "crashId": crash_id,
+                "longitude": position[0],
+                "latitude": position[1]
+                }
+            })).json()
+
+    except Exception as e:
+        log.error("Request to set crash position failed.")
+        log.debug(str(e))
+        sys.exit(1)
+
+    log.info("Updated: " + str(update))
+
+    # new line for readability
+    print('');
+
+    break;

--- a/atd-toolbox/reposition_crashes_to_centroid_of_svrd_locations/reposition_crashes_to_service_road_location_centroids.py
+++ b/atd-toolbox/reposition_crashes_to_centroid_of_svrd_locations/reposition_crashes_to_service_road_location_centroids.py
@@ -30,7 +30,7 @@ try:
             action = 'store_true')
 
     argparse.add_argument("--i-understand",
-            help = 'Do not ask the user to acknoledge that this program changes the state of S3 objects and the database.',
+            help = 'Do not ask the user to acknoledge that this program changes the state of the database.',
             action = 'store_true')
 
 

--- a/atd-toolbox/reposition_crashes_to_centroid_of_svrd_locations/requirements.txt
+++ b/atd-toolbox/reposition_crashes_to_centroid_of_svrd_locations/requirements.txt
@@ -1,0 +1,5 @@
+certifi==2021.5.30
+charset-normalizer==2.0.4
+idna==3.2
+requests==2.26.0
+urllib3==1.26.6


### PR DESCRIPTION
This PR contains a one-off script and also includes a README.md file for the atd-toolbox directory. 

The README describes the new script as:

> This is a Python script which will use a database view to find the set of crashes which:
> * Are on a level 5 centerline,
> * Have CR3 data which indicates that the crash occurred on a service road,
> * Have a directionality which gives a hint which way off the centerline the crash should be moved.
> 
> For these crashes, the script will add 0.00000001 decimal degrees to the latitude of the crash, which is an immaterial movement in geographic terms, but it will cause the lambda function tied to crash-updates to execute. It is this lambda function which will figure out what location to move the crash to and will do so.