### PR TITLE
Comply with TXDOT CRIS data retention policy (10 years) (#5764)

### DIFF
--- a/atd-etl/app/process/helpers_socrata.py
+++ b/atd-etl/app/process/helpers_socrata.py
@@ -329,6 +329,16 @@ def get_date_limit():
             day=1
         ).strftime("%Y-%m-%d")
 
+def get_initial_date_limit():
+    """
+    Returns a string with the date ten years ago in iso format: yyyy-mm-dd
+    :return str:
+    """
+    d = date.today()
+    return d.replace(
+        year=d.year - 10 
+    ).strftime("%Y-%m-%d")
+
 
 def is_no_time_constraint():
     """

--- a/atd-etl/app/process/socrata_queries.py
+++ b/atd-etl/app/process/socrata_queries.py
@@ -19,7 +19,7 @@ crashes_query_template = Template(
                 offset: $offset,
                 order_by: {crash_id: asc},
                 where: {
-                    crash_date: { _lt: "$date_limit" }
+                    crash_date: { _lt: "$date_limit", _gte: "$initial_date_limit" }
                     private_dr_fl: { _eq: "N" },
                     _and: [
                       { crash_date: { _is_null: false }},

--- a/atd-etl/app/process/socrata_queries.py
+++ b/atd-etl/app/process/socrata_queries.py
@@ -93,7 +93,7 @@ people_query_template = Template(
                     {prsn_injry_sev_id: {_eq: 4}}
                 ],
                 _and: {
-                    crash: {crash_date: {_lt: "$date_limit"}}
+                    crash: {crash_date: {_lt: "$date_limit", _gte: "$initial_date_limit" }}
                     _or: [
                         {crash: {austin_full_purpose: {_eq: "Y"}}},
                         {
@@ -131,7 +131,7 @@ people_query_template = Template(
                 crash: { private_dr_fl: { _eq: "N" }},
                 _or: [{prsn_injry_sev_id: {_eq: 1}}, {prsn_injry_sev_id: {_eq: 4}}],
                 _and: {
-                    crash: {crash_date: {_lt: "$date_limit"}}
+                    crash: {crash_date: {_lt: "$date_limit", _gte: "$initial_date_limit"}}
                     _or: [
                         {crash: {austin_full_purpose: {_eq: "Y"}}}, 
                         {

--- a/atd-etl/app/process_socrata_export.py
+++ b/atd-etl/app/process_socrata_export.py
@@ -79,7 +79,8 @@ for config in query_configs:
         query = config["template"].substitute(
             limit=limit,
             offset=offset,
-            date_limit=get_date_limit()
+            date_limit=get_date_limit(),
+            initial_date_limit=get_initial_date_limit()
         )
         offset += limit
         data = run_hasura_query(query)

--- a/atd-etl/runetl.sh
+++ b/atd-etl/runetl.sh
@@ -60,7 +60,7 @@ function runetl {
         echo "Using environment variables in '${ATD_CRIS_CONFIG}'...";
     else
         echo "Error: The ATD_CRIS_CONFIG variable is not set because it cannot find the file '${ATD_CRIS_CONFIG}'";
-        echo "Please refer to the documentation to create and env file.";
+        echo "Please refer to the documentation to create an env file.";
         return;
     fi;
 

--- a/atd-vze/src/Components/GridDateRange.js
+++ b/atd-vze/src/Components/GridDateRange.js
@@ -75,6 +75,9 @@ const GridDateRange = ({ setDateRangeFilter, initStartDate, initEndDate, uniqueK
    * @type {Date}
    */
   const maxDate = new Date();
+  const minDate = moment(new Date())
+      .subtract(10, "year")
+      .toDate();
 
   const [startDate, setStartDate] = useState(parseDate(initStartDate));
   const [endDate, setEndDate] = useState(parseDate(initEndDate));
@@ -105,6 +108,7 @@ const GridDateRange = ({ setDateRangeFilter, initStartDate, initEndDate, uniqueK
           endDate={endDate}
           // Prevent user from selecting start date after current date
           maxDate={maxDate}
+          minDate={minDate}
         />
         <span>{" to "}</span>
         <DatePicker

--- a/atd-vze/src/Components/GridDateRange.js
+++ b/atd-vze/src/Components/GridDateRange.js
@@ -47,14 +47,14 @@ const StyledDatePicker = styled.div`
   }
 `;
 
-const GridDateRange = ({ setDateRangeFilter, initStartDate, initEndDate, uniqueKey }) => {
+const GridDateRange = ({ setDateRangeFilter, initStartDate, initEndDate, uniqueKey, minDate }) => {
   /**
    * Parses a string into proper format
    * @param {string} date - date string to be formatted
    * @returns {Date}
    */
   const parseDate = date => new Date(moment(date).format());
-
+  //debugger;
   /**
    * Returns a date in a valid SQL format.
    * @param {string} date - The string to be transformed
@@ -75,9 +75,6 @@ const GridDateRange = ({ setDateRangeFilter, initStartDate, initEndDate, uniqueK
    * @type {Date}
    */
   const maxDate = new Date();
-  const minDate = moment(new Date())
-      .subtract(10, "year")
-      .toDate();
 
   const [startDate, setStartDate] = useState(parseDate(initStartDate));
   const [endDate, setEndDate] = useState(parseDate(initEndDate));
@@ -95,6 +92,8 @@ const GridDateRange = ({ setDateRangeFilter, initStartDate, initEndDate, uniqueK
     setStartDate(parseDate(initStartDate));
     setEndDate(parseDate(initEndDate));
   }, [initStartDate, initEndDate]);
+
+  //debugger;
 
   return (
     <>

--- a/atd-vze/src/Components/GridDateRange.js
+++ b/atd-vze/src/Components/GridDateRange.js
@@ -54,7 +54,7 @@ const GridDateRange = ({ setDateRangeFilter, initStartDate, initEndDate, uniqueK
    * @returns {Date}
    */
   const parseDate = date => new Date(moment(date).format());
-  //debugger;
+
   /**
    * Returns a date in a valid SQL format.
    * @param {string} date - The string to be transformed
@@ -92,8 +92,6 @@ const GridDateRange = ({ setDateRangeFilter, initStartDate, initEndDate, uniqueK
     setStartDate(parseDate(initStartDate));
     setEndDate(parseDate(initEndDate));
   }, [initStartDate, initEndDate]);
-
-  //debugger;
 
   return (
     <>

--- a/atd-vze/src/Components/GridTable.js
+++ b/atd-vze/src/Components/GridTable.js
@@ -376,7 +376,7 @@ const GridTable = ({
   query.offset = offset;
 
   // Show us the current state of the query in the console!
-  console.log(query.query);
+  // console.log(query.query);
 
   /**
    *

--- a/atd-vze/src/Components/GridTable.js
+++ b/atd-vze/src/Components/GridTable.js
@@ -40,6 +40,7 @@ const GridTable = ({
   chartConfig,
   widgetsConfig,
   helperText,
+  minDate,
 }) => {
   // Load table filters from localStorage by title
   const savedFilterState = JSON.parse(
@@ -504,6 +505,7 @@ const GridTable = ({
                       setDateRangeFilter={setDateRangeFilter}
                       initStartDate={dateRangeFilter.startDate}
                       initEndDate={dateRangeFilter.endDate}
+                      minDate={minDate}
                       uniqueKey={query.table}
                     />
                   </ButtonGroup>

--- a/atd-vze/src/views/Crashes/Crashes.js
+++ b/atd-vze/src/views/Crashes/Crashes.js
@@ -1,6 +1,7 @@
 import React from "react";
 import { withApollo } from "react-apollo";
 
+import moment from "moment";
 import GridTable from "../../Components/GridTable";
 import gqlAbstract from "../../queries/gqlAbstract";
 import { crashQueryExportFields } from "../../queries/crashes";
@@ -25,12 +26,17 @@ let crashesQuery = new gqlAbstract(queryConf);
 
 let customFilters = crashGridTableAdvancedFilters;
 
+const minDate = moment(new Date())
+.subtract(10, "year")
+.toDate();
+
 const Crashes = () => (
   <GridTable
     query={crashesQuery}
     title={"Crashes"}
     filters={customFilters}
     columnsToExport={crashQueryExportFields}
+    minDate ={minDate}
   />
 );
 

--- a/atd-vze/src/views/Locations/LocationCrashes.js
+++ b/atd-vze/src/views/Locations/LocationCrashes.js
@@ -1,6 +1,7 @@
 import React from "react";
 import { withApollo } from "react-apollo";
 
+import moment from 'moment';
 import GridTable from "../../Components/GridTable";
 import gqlAbstract from "../../queries/gqlAbstract";
 import { crashQueryExportFields } from "../../queries/crashes";
@@ -247,6 +248,10 @@ function LocationCrashes(props) {
     },
   ];
 
+  const minDate = moment(new Date())
+  .subtract(10, "year")
+  .toDate();
+  
   return (
     <GridTable
       query={crashesQuery}
@@ -256,6 +261,7 @@ function LocationCrashes(props) {
       aggregateQueryConfig={aggregateQueryConfig}
       widgetsConfig={widgetsConfig}
       chartConfig={chartConfig}
+      minDate={minDate}
     />
   );
 }


### PR DESCRIPTION
This pull request intends to close cityofaustin/atd-data-tech/issues/5764. 

Included are changes to the VZE which direct the GridRangePicker's component to use the DatePicker's `minDate` functionality to limit the age which the UI will allow searches for crashes to be performed. 

Also included are change to the Socrata export process which limits the data being inserted into the open data set to crashes 10 years old or less. 