### PR TITLE
#1965: Handle js object in crash changelog output

### DIFF
--- a/atd-vze/src/views/Crashes/CrashChangeLog.js
+++ b/atd-vze/src/views/Crashes/CrashChangeLog.js
@@ -116,7 +116,21 @@ class CrashChangeLog extends Component {
     }
 
     // For each entry created in the diff array, generate an HTML table row.
-    let modalItems = diff.map(item => (
+    let modalItems = diff.map(item => {
+      // The following two conditions check if an the current or archived value to
+      // to be shown in the crach's changelog are objects, such as found when a jsonb
+      // field is pulled from the database. In this case, they are stringified for 
+      // human-readble output.
+      
+      if (typeof item.original_record_value === 'object') {
+        item.original_record_value = JSON.stringify(item.original_record_value);
+      }
+
+      if (typeof item.archived_record_value === 'object') {
+        item.archived_record_value = JSON.stringify(item.archived_record_value);
+      }
+
+      return (
       <tr key={`recordHistory-${record.id}`}>
         <td>{item.original_record_key}</td>
         <td>
@@ -126,7 +140,8 @@ class CrashChangeLog extends Component {
           <Badge color="danger">{String(item.archived_record_value)}</Badge>
         </td>
       </tr>
-    ));
+      )
+    });
 
     // Generate the body of the modal box
     modalBody = (

--- a/atd-vze/src/views/Crashes/CrashChangeLog.js
+++ b/atd-vze/src/views/Crashes/CrashChangeLog.js
@@ -115,28 +115,27 @@ class CrashChangeLog extends Component {
       }
     }
 
+    // Define a function to pass to JSON.stringify which will skip over
+    // the __typename key in the JS object being stringified.
+    const stringifyReplacer = (key, value) => {
+      if (key === '__typename') {
+        return undefined;
+      }
+      return value;
+    }
+
     // For each entry created in the diff array, generate an HTML table row.
     let modalItems = diff.map(item => {
-
-      // Define a function to pass to JSON.stringify which will skip over
-      // the __typename key in the JS object being stringified.
-      const stringify_replacer = (key, value) => {
-        if (key === '__typename') {
-          return undefined;
-        }
-        return value;
-      }
-      
       // The following two conditions check if an the current or archived value to
       // to be shown in the crach's changelog are objects, such as found when a jsonb
       // field is pulled from the database. In this case, they are stringified for 
       // human-readble output.
       if (typeof item.original_record_value === 'object') {
-        item.original_record_value = JSON.stringify(item.original_record_value, stringify_replacer);
+        item.original_record_value = JSON.stringify(item.original_record_value, stringifyReplacer);
       }
 
       if (typeof item.archived_record_value === 'object') {
-        item.archived_record_value = JSON.stringify(item.archived_record_value, stringify_replacer);
+        item.archived_record_value = JSON.stringify(item.archived_record_value, stringifyReplacer);
       }
 
       return (

--- a/atd-vze/src/views/Crashes/CrashChangeLog.js
+++ b/atd-vze/src/views/Crashes/CrashChangeLog.js
@@ -117,17 +117,26 @@ class CrashChangeLog extends Component {
 
     // For each entry created in the diff array, generate an HTML table row.
     let modalItems = diff.map(item => {
+
+      // Define a function to pass to JSON.stringify which will skip over
+      // the __typename key in the JS object being stringified.
+      const stringify_replacer = (key, value) => {
+        if (key === '__typename') {
+          return undefined;
+        }
+        return value;
+      }
+      
       // The following two conditions check if an the current or archived value to
       // to be shown in the crach's changelog are objects, such as found when a jsonb
       // field is pulled from the database. In this case, they are stringified for 
       // human-readble output.
-      
       if (typeof item.original_record_value === 'object') {
-        item.original_record_value = JSON.stringify(item.original_record_value);
+        item.original_record_value = JSON.stringify(item.original_record_value, stringify_replacer);
       }
 
       if (typeof item.archived_record_value === 'object') {
-        item.archived_record_value = JSON.stringify(item.archived_record_value);
+        item.archived_record_value = JSON.stringify(item.archived_record_value, stringify_replacer);
       }
 
       return (


### PR DESCRIPTION
This pull request intends to close cityofaustin/atd-data-tech/issues/1965.

The changes include the detection of a JS object when printing a crash change log and using the JSON.stringify method on it to make it human readable.