### PR TITLE
Prevents drawing polygon from crashing VZV

### DIFF
--- a/atd-vzv/src/views/map/InfoBox/InfoCard.js
+++ b/atd-vzv/src/views/map/InfoBox/InfoCard.js
@@ -1,5 +1,4 @@
-import * as React from "react";
-import { PureComponent } from "react";
+import React, { useRef, useState } from "react";
 import {
   Card,
   Table,
@@ -17,56 +16,52 @@ const StyledTableRow = styled.tr`
   }
 `;
 
-export default class InfoCard extends PureComponent {
-  render() {
-    const { content } = this.props;
+const InfoCard = ({ content }) => {
+  const ref = useRef(null);
 
-    return (
-      <Card className="p-2 m-1">
-        <Table borderless size="sm" className="mt-0 mb-0">
-          <tbody>
-            {content.map((item) => (
-              <StyledTableRow key={item.title}>
-                <th className="align" scope="row">
-                  {item.title}
-                </th>
-                <td className="align">{item.content}</td>
-                {item.title === "Crash ID" ? (
-                  <td className="align">
-                    <Button
-                      id="PopoverFocus"
-                      style={{
-                        boxShadow: "none",
-                        width: "30px",
-                        height: "30px",
-                        padding: "6px 0px",
-                        borderRadius: "15px",
-                        textAlign: "center",
-                        fontSize: "12px",
-                        lineHeight: 1.42857,
-                      }}
-                      color="info"
-                      outline={false}
-                      onClick={() => {
-                        navigator.clipboard.writeText(item.content);
-                      }}
-                    >
-                      <FontAwesomeIcon icon={faClipboard} />
-                    </Button>
-                  </td>
-                ) : null}
-              </StyledTableRow>
-            ))}
-          </tbody>
-        </Table>
-        <UncontrolledPopover
-          trigger="focus"
-          placement="top"
-          target="PopoverFocus"
-        >
-          <PopoverBody>Copied</PopoverBody>
-        </UncontrolledPopover>
-      </Card>
-    );
-  }
-}
+  return (
+    <Card className="p-2 m-1">
+      <Table borderless size="sm" className="mt-0 mb-0">
+        <tbody>
+          {content.map((item) => (
+            <StyledTableRow key={item.title}>
+              <th className="align" scope="row">
+                {item.title}
+              </th>
+              <td className="align">{item.content}</td>
+              {item.title === "Crash ID" ? (
+                <td className="align" ref={ref}>
+                  <Button
+                    id="PopoverFocus"
+                    style={{
+                      boxShadow: "none",
+                      width: "30px",
+                      height: "30px",
+                      padding: "6px 0px",
+                      borderRadius: "15px",
+                      textAlign: "center",
+                      fontSize: "12px",
+                      lineHeight: 1.42857,
+                    }}
+                    color="info"
+                    outline={false}
+                    onClick={() => {
+                      navigator.clipboard.writeText(item.content);
+                    }}
+                  >
+                    <FontAwesomeIcon icon={faClipboard} />
+                  </Button>
+                </td>
+              ) : null}
+            </StyledTableRow>
+          ))}
+        </tbody>
+      </Table>
+      <UncontrolledPopover trigger="focus" placement="top" target={ref}>
+        <PopoverBody>Copied</PopoverBody>
+      </UncontrolledPopover>
+    </Card>
+  );
+};
+
+export default InfoCard;

--- a/atd-vzv/src/views/map/InfoBox/InfoCard.js
+++ b/atd-vzv/src/views/map/InfoBox/InfoCard.js
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from "react";
+import React, { useRef } from "react";
 import {
   Card,
   Table,


### PR DESCRIPTION
## Associated issues
fixes https://github.com/cityofaustin/atd-data-tech/issues/9714

The issue was caused by the "copied" popover in the info window trying to attach itself to an element of the DOM that didn't exist. Updated that component to use hooks and a ref and that fixed the issue.

<img width="1440" alt="Screen Shot 2022-07-28 at 3 27 29 PM" src="https://user-images.githubusercontent.com/35410637/181631537-3ee55a80-26bc-410e-9ef1-cf102d61e5b6.png">
<img width="1440" alt="Screen Shot 2022-07-28 at 3 27 58 PM" src="https://user-images.githubusercontent.com/35410637/181631546-09991631-1d33-49eb-9e2d-4c448ea8fd1c.png">


## Testing
**URL to test:** <!-- VZ URL or Netlify -->
https://deploy-preview-1088--atd-vzv-staging.netlify.app/

**Steps to test:**
Go to map view, create a polygon. You should see the analysis and not a wsod.
If you click on a point in the map and then click the copy icon you should see a little "copied" popover pop up.

---
#### Ship list
- [x] Code reviewed
- [ ] Product manager approved
