### PR TITLE
update users can only edit notes if they created it

### DIFF
--- a/atd-vze/src/views/Crashes/Notes.js
+++ b/atd-vze/src/views/Crashes/Notes.js
@@ -94,27 +94,27 @@ const Notes = ({ crashId }) => {
   return (
     <Card>
       <CardHeader>{fieldConfig.title}</CardHeader>
-      <CardBody>
+      <CardBody style={{padding:"5px 20px 20px 20px" }}>
         <Table style={{width: "100%"}}>
           {/* display label for each field in table header*/}
-          <tr>
-            <th style={{width: "10%"}}>
+          <tr style={{"border-top": "0px"}}>
+            <th style={{width: "10%", "border-top": "0px"}}>
             {fieldConfig.fields.date.label}
             </th>
-            <th style={{width: "24%"}}>
+            <th style={{width: "24%", "border-top": "0px"}}>
             {fieldConfig.fields.user_email.label}
             </th>
-            <th style={{width: "54%"}}>
+            <th style={{width: "54%", "border-top": "0px"}}>
             {fieldConfig.fields.text.label}
             </th>
             {/* only create extra columns if user has edit permissions */}
             {!isReadOnly(roles) &&
-              <th style={{width: "6%"}}>
+              <th style={{width: "6%", "border-top": "0px"}}>
               </th>
             }
             {/* only create extra columns if user has edit permissions */}
             {!isReadOnly(roles) &&
-              <th style={{width: "6%"}}>
+              <th style={{width: "6%", "border-top": "0px"}}>
               </th>
             }
           </tr>


### PR DESCRIPTION
## Associated issues

Closes https://github.com/cityofaustin/atd-data-tech/issues/9874

This PR updates the notes section so that users can only edit a row in the notes section if they created it.

## Testing
**URL to test:** <!-- VZ URL or Netlify -->

This can be tested locally or as a Netlify preview (https://deploy-preview-1089--atd-vze-staging.netlify.app/#/dashboard)

**Steps to test:**

1. Click on Crashes tab.
2. Go to crash 1036 (https://deploy-preview-1089--atd-vze-staging.netlify.app/#/crashes/1036).
3. You should not be able to edit or delete any notes unless they were created by you (Updated By column).
4. Try adding a new note and make sure you can edit then save it, edit then cancel, delete, etc.
5. You can check out some other crashes as well, some crashID's with dummy notes data in them include: 17164366, 18851626, 17727381.

---
#### Ship list
- [x] Code reviewed
- [x] Product manager approved
