### PR TITLE
Changes to support CRIS import ETL redux

### DIFF
--- a/atd-etl/app/process/helpers_import.py
+++ b/atd-etl/app/process/helpers_import.py
@@ -551,11 +551,8 @@ def insert_crash_change_template(new_record_dict, differences, crash_id):
     :param str crash_id
     :return: string
     """
-    # Turn the dictionary into a character-escaped json string
-    print(new_record_dict)
 
     new_record_crash_date = None
-
     try: 
         new_record_crash_date = new_record_dict["crash_date"].strftime("%Y-%m-%d")  #convert_date(new_record_dict["crash_date"])
     except:
@@ -567,6 +564,7 @@ def insert_crash_change_template(new_record_dict, differences, crash_id):
         if isinstance(new_record_dict[key], datetime.time):
             new_record_dict[key] = new_record_dict[key].strftime("%H:%M:%S")
 
+    # Turn the dictionary into a character-escaped json string
     new_record_escaped = json.dumps(json.dumps(new_record_dict), default=str)
     # Build the template and inject required values
     output = (

--- a/atd-etl/app/process/helpers_import.py
+++ b/atd-etl/app/process/helpers_import.py
@@ -554,8 +554,13 @@ def insert_crash_change_template(new_record_dict, differences, crash_id):
     # Turn the dictionary into a character-escaped json string
     print(new_record_dict)
 
-    # need to iterate over fields and stringify dates and times, but not datetimes 😜
-    new_record_crash_date = new_record_dict["crash_date"].strftime("%Y-%m-%d")  #convert_date(new_record_dict["crash_date"])
+    new_record_crash_date = None
+
+    try: 
+        new_record_crash_date = new_record_dict["crash_date"].strftime("%Y-%m-%d")  #convert_date(new_record_dict["crash_date"])
+    except:
+        print("Failed to convert crash_date")
+
     for key in new_record_dict:
         if isinstance(new_record_dict[key], datetime.date):
             new_record_dict[key] = new_record_dict[key].strftime("%Y-%m-%d")

--- a/atd-etl/app/process/helpers_import.py
+++ b/atd-etl/app/process/helpers_import.py
@@ -590,7 +590,7 @@ def insert_crash_change_template(new_record_dict, differences, crash_id):
         )
         .replace("%NEW_RECORD_ID%", crash_id)
         .replace("%NEW_UNIQUE_ID%", crash_id)
-        .replace("%AFFECTED_COLUMNS%", json.dumps(json.dumps(differences)))
+        .replace("%AFFECTED_COLUMNS%", json.dumps(json.dumps(differences), default=str))
         .replace(
             "%NEW_RECORD_CRASH_DATE%",
             "null" if new_record_crash_date is None else f'"{new_record_crash_date}"',

--- a/atd-etl/app/process/helpers_import.py
+++ b/atd-etl/app/process/helpers_import.py
@@ -555,10 +555,10 @@ def insert_crash_change_template(new_record_dict, differences, crash_id):
     print(new_record_dict)
 
     # need to iterate over fields and stringify dates and times, but not datetimes 😜
-    new_record_crash_date = new_record_dict["crash_date"].strftime("%m/%d/%Y")  #convert_date(new_record_dict["crash_date"])
+    new_record_crash_date = new_record_dict["crash_date"].strftime("%Y-%m-%d")  #convert_date(new_record_dict["crash_date"])
     for key in new_record_dict:
         if isinstance(new_record_dict[key], datetime.date):
-            new_record_dict[key] = new_record_dict[key].strftime("%Y/%d/%m")
+            new_record_dict[key] = new_record_dict[key].strftime("%Y-%m-%d")
         if isinstance(new_record_dict[key], datetime.time):
             new_record_dict[key] = new_record_dict[key].strftime("%H:%M:%S")
 

--- a/atd-etl/app/process/helpers_import.py
+++ b/atd-etl/app/process/helpers_import.py
@@ -552,8 +552,17 @@ def insert_crash_change_template(new_record_dict, differences, crash_id):
     :return: string
     """
     # Turn the dictionary into a character-escaped json string
-    new_record_escaped = json.dumps(json.dumps(new_record_dict))
-    new_record_crash_date = convert_date(new_record_dict["crash_date"])
+    print(new_record_dict)
+
+    # need to iterate over fields and stringify dates and times, but not datetimes 😜
+    new_record_crash_date = new_record_dict["crash_date"].strftime("%m/%d/%Y")  #convert_date(new_record_dict["crash_date"])
+    for key in new_record_dict:
+        if isinstance(new_record_dict[key], datetime.date):
+            new_record_dict[key] = new_record_dict[key].strftime("%Y/%d/%m")
+        if isinstance(new_record_dict[key], datetime.time):
+            new_record_dict[key] = new_record_dict[key].strftime("%H:%M:%S")
+
+    new_record_escaped = json.dumps(json.dumps(new_record_dict), default=str)
     # Build the template and inject required values
     output = (
         """

--- a/atd-vze/.env
+++ b/atd-vze/.env
@@ -1,7 +1,7 @@
 REACT_APP_HASURA_ENDPOINT="https://vzd-staging.austinmobility.io/v1/graphql"
+#REACT_APP_HASURA_ENDPOINT="https://localhost:8080/v1/graphql"
 REACT_APP_AUTH0_DOMAIN=atd-datatech.auth0.com
 REACT_APP_AUTH0_CLIENT_ID=2qbqz2sf8L9idBOwn0d5YA9efNgQbL7c
 REACT_APP_MAPBOX_TOKEN="pk.eyJ1Ijoiam9obmNsYXJ5IiwiYSI6ImNqemU4OGQzaTBlZjczYm1rZWg1c2lidTcifQ.2eooq4Q7dv_1Le5la9D96Q"
 REACT_APP_NEARMAP_KEY="YzI5YTM1ZWMtMWRkNy00NGU4LTkxMWQtNDI3ZDcxNjVjMzg3"
 REACT_APP_CR3_API_DOMAIN="https://atd-vz-api-staging.austinmobility.io"
-

--- a/atd-vze/.env
+++ b/atd-vze/.env
@@ -1,4 +1,3 @@
-# IMPORTANT: YOU NEED TO INSERT *YOUR* DOMAIN AND CLIENT_ID BELOW
 REACT_APP_HASURA_ENDPOINT="https://vzd-staging.austinmobility.io/v1/graphql"
 REACT_APP_AUTH0_DOMAIN=atd-datatech.auth0.com
 REACT_APP_AUTH0_CLIENT_ID=2qbqz2sf8L9idBOwn0d5YA9efNgQbL7c

--- a/atd-vze/src/views/Crashes/CrashChange.js
+++ b/atd-vze/src/views/Crashes/CrashChange.js
@@ -61,7 +61,7 @@ function CrashChange(props) {
   const [errorDialog, setErrorDialog] = useState(false);
   const [saveStatus, setSaveStatus] = useState("");
   const [errorMessage, setErrorMessage] = useState("");
-  // CR3 Availbable
+  // CR3 Available
   const [cr3available, setCR3Available] = useState(false);
   const [upsertRecordQuery, setUpsertRecordQuery] = useState(
     UPSERT_MUTATION_DUMMY

--- a/atd-vze/src/views/Crashes/CrashChange.js
+++ b/atd-vze/src/views/Crashes/CrashChange.js
@@ -170,7 +170,7 @@ function CrashChange(props) {
   };
 
   /**
-   * Returns an deconstructable array with two objects containing the old record and the new record.
+   * Returns a deconstructable array with two objects containing the old record and the new record.
    * @returns {object[]}
    */
   const getOriginalNewRecords = () => {


### PR DESCRIPTION
## Associated Content

This PR has a sibling PR in the prefect repo: [#28](https://github.com/cityofaustin/atd-prefect/pull/28).

## Background

The new ETL uses a single particular function from the previous ETL, `insert_crash_change_template()`. This function is sort of the "key" to the VZE conflict resolution system's "keyhole." 🗝

This PR contains the most minimal set of changes I could do to this function, in an attempt to not have change anything in the VZE app. ✅✨

---
#### Ship list
- [x] Code reviewed
- [x] Product manager approved
