### PR TITLE
Moved Related Records underneath the Crash Narrative

### DIFF
--- a/atd-vze/src/views/Crashes/Crash.js
+++ b/atd-vze/src/views/Crashes/Crash.js
@@ -289,22 +289,22 @@ function Crash(props) {
         </Row>
       ) : (
         <div></div>
-      )}
-      {shouldShowFatalityRecommendations && (
-        <Row>
-          <Col>
-            <Recommendations crashId={props.match.params.id} />
-          </Col>
-        </Row>
-      )}
-      <Row>
-        <Col>
-          <Notes crashId={props.match.params.id} />
-        </Col>
-      </Row>
+      )}     
       <Row>
         <Col>
           <CrashCollapses data={data} props={props} />
+        </Col>
+      </Row>
+       {shouldShowFatalityRecommendations && (
+        <Row>
+        <Col>
+          <Recommendations crashId={props.match.params.id} />
+        </Col>
+      </Row>
+      )}
+    <Row>
+        <Col>
+          <Notes crashId={props.match.params.id} />
         </Col>
       </Row>
       <Row>
@@ -323,6 +323,7 @@ function Crash(props) {
           <CrashChangeLog data={data} />
         </Col>
       </Row>
+     
     </div>
   );
 }

--- a/atd-vze/src/views/Crashes/Crash.js
+++ b/atd-vze/src/views/Crashes/Crash.js
@@ -296,13 +296,13 @@ function Crash(props) {
         </Col>
       </Row>
        {shouldShowFatalityRecommendations && (
-        <Row>
+      <Row>
         <Col>
           <Recommendations crashId={props.match.params.id} />
         </Col>
       </Row>
       )}
-    <Row>
+      <Row>
         <Col>
           <Notes crashId={props.match.params.id} />
         </Col>


### PR DESCRIPTION
## Associated issues
Moving the Related Records component resolves issue [#10150](https://github.com/cityofaustin/atd-data-tech/issues/10150).

## Testing
**URL to test:** 
https://deploy-preview-1099--atd-vze-staging.netlify.app/#/crashes

In the Netlify link: Crash locations map, crash diagram are not rendering, and the Crash narrative is not showing, which I'm guessing has to do with Netlify not grabbing a CR3 for this record?

Once y'all look at the code, I'll merge to staging and update the link for testing. 

**Steps to test:**

- In the Vision Zero Editor navigate to a crash with a fatality. 
- Verify that the Related Records component is below the Crash Narrative & above the Recommendations and Notes sections

---
#### Ship list
- [ ] Code reviewed
