### PR TITLE
Update the MapGL configuration when in edit mode for a crash location

### DIFF
--- a/atd-vze/src/helpers/map.js
+++ b/atd-vze/src/helpers/map.js
@@ -9,6 +9,8 @@ export const LOCATION_MAP_CONFIG = {
       type: "raster",
       tiles: [
         `https://api.nearmap.com/tiles/v3/Vert/{z}/{x}/{y}.jpg?apikey=${NEARMAP_KEY}`,
+        // testing basic raster tile server for TX, US
+        // "https://tiles.frankhereford.io/tile/{z}/{x}/{y}.png",
       ],
       tileSize: 256,
     },

--- a/atd-vze/src/helpers/map.js
+++ b/atd-vze/src/helpers/map.js
@@ -10,7 +10,7 @@ export const LOCATION_MAP_CONFIG = {
       tiles: [
         `https://api.nearmap.com/tiles/v3/Vert/{z}/{x}/{y}.jpg?apikey=${NEARMAP_KEY}`,
         // testing basic raster tile server for TX, US
-        // "https://tiles.frankhereford.io/tile/{z}/{x}/{y}.png",
+        //`https://tiles.frankhereford.io/tile/{z}/{x}/{y}.png`,
       ],
       tileSize: 256,
     },

--- a/atd-vze/src/views/Crashes/Maps/CrashEditCoordsMap.js
+++ b/atd-vze/src/views/Crashes/Maps/CrashEditCoordsMap.js
@@ -202,7 +202,7 @@ class CrashEditCoordsMap extends Component {
             <Pin size={40} color={pinColor} isDragging={isDragging} animated />
           </Marker>
           <MapStyleSelector>
-              <ButtonGroup className="float-right">
+            <ButtonGroup className="float-right">
               <Button
                 active={mapStyle === "satellite-streets"}
                 id="satellite-streets"

--- a/atd-vze/src/views/Crashes/Maps/CrashEditCoordsMap.js
+++ b/atd-vze/src/views/Crashes/Maps/CrashEditCoordsMap.js
@@ -6,6 +6,8 @@ import MapGL, {
   Marker,
   NavigationControl,
   FullscreenControl,
+  Source,
+  Layer,
 } from "react-map-gl";
 import "mapbox-gl/dist/mapbox-gl.css";
 import Geocoder from "react-map-gl-geocoder";
@@ -20,6 +22,8 @@ import { Button, ButtonGroup } from "reactstrap";
 import Pin from "./Pin";
 import { setPinColor } from "../../../styles/mapPinStyles";
 import { CrashEditLatLonForm } from "./CrashEditLatLonForm";
+
+import { LOCATION_MAP_CONFIG } from "../../../helpers/map";
 
 const TOKEN = process.env.REACT_APP_MAPBOX_TOKEN;
 
@@ -151,6 +155,7 @@ class CrashEditCoordsMap extends Component {
       isDragging,
     } = this.state;
     const geocoderAddress = this.props.mapGeocoderAddress;
+    const isDev = window.location.hostname === "localhost";
 
     return (
       <div>
@@ -159,7 +164,11 @@ class CrashEditCoordsMap extends Component {
           ref={this.mapRef}
           width="100%"
           height="350px"
-          mapStyle={`mapbox://styles/mapbox/${mapStyle}-v9`}
+          mapStyle={
+            isDev
+              ? "mapbox://styles/mapbox/satellite-streets-v11"
+              : LOCATION_MAP_CONFIG.mapStyle
+          }
           onViewportChange={this._updateViewport}
           getCursor={this.getCursor}
           controller={customGeocoderMapController}
@@ -180,31 +189,18 @@ class CrashEditCoordsMap extends Component {
           <div className="nav" style={navStyle}>
             <NavigationControl showCompass={false} />
           </div>
+          {/* add nearmap raster source and style */}
+          {!isDev && (
+            <>
+              <Source {...LOCATION_MAP_CONFIG.sources.aerials} />
+              <Layer {...LOCATION_MAP_CONFIG.layers.aerials} />
+              {/* show street labels on top of other layers */}
+              <Layer {...LOCATION_MAP_CONFIG.layers.streetLabels} />
+            </>
+          )}
           <Marker latitude={markerLatitude} longitude={markerLongitude}>
             <Pin size={40} color={pinColor} isDragging={isDragging} animated />
           </Marker>
-          <MapStyleSelector>
-            <ButtonGroup className="float-right">
-              <Button
-                active={mapStyle === "satellite-streets"}
-                id="satellite-streets"
-                className="map-style-selector"
-                onClick={this.handleMapStyleChange}
-                color="light"
-              >
-                Satellite
-              </Button>
-              <Button
-                active={mapStyle === "streets"}
-                id="streets"
-                className="map-style-selector"
-                onClick={this.handleMapStyleChange}
-                color="light"
-              >
-                Street
-              </Button>
-            </ButtonGroup>
-          </MapStyleSelector>
         </MapGL>
         <CrashEditLatLonForm
           latitude={markerLatitude}

--- a/atd-vze/src/views/Crashes/Maps/CrashEditCoordsMap.js
+++ b/atd-vze/src/views/Crashes/Maps/CrashEditCoordsMap.js
@@ -201,6 +201,28 @@ class CrashEditCoordsMap extends Component {
           <Marker latitude={markerLatitude} longitude={markerLongitude}>
             <Pin size={40} color={pinColor} isDragging={isDragging} animated />
           </Marker>
+          <MapStyleSelector>
+              <ButtonGroup className="float-right">
+              <Button
+                active={mapStyle === "satellite-streets"}
+                id="satellite-streets"
+                className="map-style-selector"
+                onClick={this.handleMapStyleChange}
+                color="light"
+              >
+                Satellite
+              </Button>
+              <Button
+                active={mapStyle === "streets"}
+                id="streets"
+                className="map-style-selector"
+                onClick={this.handleMapStyleChange}
+                color="light"
+              >
+                Street
+              </Button>
+            </ButtonGroup>
+          </MapStyleSelector>
         </MapGL>
         <CrashEditLatLonForm
           latitude={markerLatitude}

--- a/atd-vze/src/views/Crashes/Maps/CrashMap.js
+++ b/atd-vze/src/views/Crashes/Maps/CrashMap.js
@@ -84,7 +84,7 @@ export default class CrashMap extends Component {
         height="100%"
         mapStyle={
           isDev
-            ? "mapbox://styles/mapbox/satellite-streets-v9"
+            ? "mapbox://styles/mapbox/satellite-streets-v11"
             : LOCATION_MAP_CONFIG.mapStyle
         }
         onViewportChange={this._updateViewport}


### PR DESCRIPTION
## Associated issues

This PR intends to close [issue 10174](https://github.com/cityofaustin/atd-data-tech/issues/10174).

## Testing
**URL to test:** 😞 👎 

This one is a trick to test. Nearmap checks the `Referrer` header for a known set of domains, and I don't think our netlify PR builds or `localhost` can be one of them. At least not without first working with CTM, which I don't think we should do for this.

### Testing approaches

* It may be worth comparing this to a recent PR #1100 by @johnclary which actually was where this work and technique were first completed. This PR borrows almost entirely from his work. His previous PR, linked above, has made it to production. You be the judge, but I think a code review can be enough for this minor change.

* Alternatively, you can fire up the app locally and change the raster tile layer definition to use this XYZ tileserver `https://tiles.frankhereford.io/tile/{z}/{x}/{y}.png` which does not check referrers. Then overload the `isDev` boolean to see how things work. You still have to imagine what the imagery would look like as the tile layer just the OSM, but you **can** see that it pulls tiles as expected.

* Go `l33t hax0r` and [overload your referrer header](https://chrome.google.com/webstore/detail/referer-control/hnkcfpcejkafcihlgbojoidoihckciin?hl=en) to convince NearMap that you're coming from the production VZ app. We have a valid, paid key, this isn't a bad thing.

## Additional Considerations
* @johnclary @mddilley I bumped a version in a unrelated style definition, and I wanted to double check with you that that is a good idea.
* ~Everyone, I am removing the toggle between satellite & street layers. It's not working. @patrickm02L, I recommend this become an issue. Do you agree? Let me know, I'd be happy to write it and offer up solutions.~ Nope, it works fine in production.

---

#### Ship list
- [x] Code reviewed
- [x] Product manager approved
