### PR TITLE
Update Fatality and Serious Injury counts for accuracy

### DIFF
--- a/atd-vzd/migrations/migration_person_primaryperson_2022-09-23--1018.sql
+++ b/atd-vzd/migrations/migration_person_primaryperson_2022-09-23--1018.sql
@@ -1,5 +1,6 @@
 -- Drop existing years_of_life_lost columns which were 0 for all rows
--- Replace with generated field calculated from prsn_age column
+-- Replace with generated field calculated from prsn_age column if
+-- prsn_injry_sev_id = 4 (fatality) otherwise set as 0
 
 -- Name: atd_txdot_person; Type: TABLE; Schema: public; Owner: atd_vz_data
 --

--- a/atd-vzd/migrations/migration_person_primaryperson_2022-09-23--1018.sql
+++ b/atd-vzd/migrations/migration_person_primaryperson_2022-09-23--1018.sql
@@ -8,7 +8,13 @@ ALTER TABLE atd_txdot_person DROP COLUMN years_of_life_lost;
 
 ALTER TABLE atd_txdot_person
 ADD COLUMN years_of_life_lost integer
-GENERATED ALWAYS AS (GREATEST(75 - prsn_age, 0)) STORED;
+GENERATED ALWAYS AS (
+    CASE WHEN prsn_injry_sev_id = 4 
+    THEN (GREATEST(75 - prsn_age, 0)) 
+    ELSE 0 
+    END
+) 
+STORED;
 
 -- Name: atd_txdot_primaryperson; Type: TABLE; Schema: public; Owner: atd_vz_data
 --
@@ -17,4 +23,10 @@ ALTER TABLE atd_txdot_primaryperson DROP COLUMN years_of_life_lost;
 
 ALTER TABLE atd_txdot_primaryperson
 ADD COLUMN years_of_life_lost integer
-GENERATED ALWAYS AS (GREATEST(75 - prsn_age, 0)) STORED;
+GENERATED ALWAYS AS (
+    CASE WHEN prsn_injry_sev_id = 4 
+    THEN (GREATEST(75 - prsn_age, 0)) 
+    ELSE 0 
+    END
+) 
+STORED;

--- a/atd-vzd/migrations/migration_person_primaryperson_2022-09-23--1018.sql
+++ b/atd-vzd/migrations/migration_person_primaryperson_2022-09-23--1018.sql
@@ -1,0 +1,20 @@
+-- Drop existing years_of_life_lost columns which were 0 for all rows
+-- Replace with generated field calculated from prsn_age column
+
+-- Name: atd_txdot_person; Type: TABLE; Schema: public; Owner: atd_vz_data
+--
+
+ALTER TABLE atd_txdot_person DROP COLUMN years_of_life_lost;
+
+ALTER TABLE atd_txdot_person
+ADD COLUMN years_of_life_lost integer
+GENERATED ALWAYS AS (GREATEST(75 - prsn_age, 0)) STORED;
+
+-- Name: atd_txdot_primaryperson; Type: TABLE; Schema: public; Owner: atd_vz_data
+--
+
+ALTER TABLE atd_txdot_primaryperson DROP COLUMN years_of_life_lost;
+
+ALTER TABLE atd_txdot_primaryperson
+ADD COLUMN years_of_life_lost integer
+GENERATED ALWAYS AS (GREATEST(75 - prsn_age, 0)) STORED;

--- a/atd-vze/src/queries/dashboard.js
+++ b/atd-vze/src/queries/dashboard.js
@@ -60,3 +60,17 @@ export const GET_CRASHES_YTD = gql`
     }
   }
 `;
+
+// SELECT
+//   75 - prsn_age as years_of_life_lost
+// FROM
+//   atd_txdot_primaryperson as pp
+// WHERE
+//   1 = 1
+//   AND pp.prsn_injry_sev_id = 4
+//   AND pp.prsn_age < 75
+//   AND pp.prsn_age IS NOT NULL
+
+// ALTER TABLE atd_txdot_person
+// ADD COLUMN years_of_life_lost integer
+// GENERATED ALWAYS AS (GREATEST(75 - prsn_age, 0)) STORED;

--- a/atd-vze/src/queries/dashboard.js
+++ b/atd-vze/src/queries/dashboard.js
@@ -1,5 +1,8 @@
 import { gql } from "apollo-boost";
 
+// These queries are derived from the ETL that populates our Socrata data sets
+// so that the VZV and VZE widget totals match up
+// See https://github.com/cityofaustin/atd-vz-data/blob/master/atd-etl/app/process/socrata_queries.py
 export const GET_CRASHES_YTD = gql`
   query GetCrashesYTD($yearStart: date, $yearEnd: date) {
     fatalities: atd_txdot_crashes_aggregate(
@@ -92,19 +95,3 @@ export const GET_CRASHES_YTD = gql`
     }
   }
 `;
-
-// TODO: Try old query!!!!!!!
-
-// SELECT
-//   75 - prsn_age as years_of_life_lost
-// FROM
-//   atd_txdot_primaryperson as pp
-// WHERE
-//   1 = 1
-//   AND pp.prsn_injry_sev_id = 4
-//   AND pp.prsn_age < 75
-//   AND pp.prsn_age IS NOT NULL
-
-// ALTER TABLE atd_txdot_person
-// ADD COLUMN years_of_life_lost integer
-// GENERATED ALWAYS AS (GREATEST(75 - prsn_age, 0)) STORED;

--- a/atd-vze/src/queries/dashboard.js
+++ b/atd-vze/src/queries/dashboard.js
@@ -24,13 +24,19 @@ export const GET_CRASHES_YTD = gql`
     }
     seriousInjuriesAndTotal: atd_txdot_crashes_aggregate(
       where: {
-        city_id: { _eq: 22 }
-        crash_date: { _gte: $yearStart, _lte: $yearEnd }
-        private_dr_fl: { _neq: "Y" }
+        crash_date: { _lt: $yearEnd, _gte: $yearStart }
+        private_dr_fl: { _eq: "N" }
+        _and: [
+          { crash_date: { _is_null: false } }
+          { crash_time: { _is_null: false } }
+        ]
+        _or: [
+          { austin_full_purpose: { _eq: "Y" } }
+          { _and: [{ city_id: { _eq: 22 } }, { position: { _is_null: true } }] }
+        ]
       }
     ) {
       aggregate {
-        count
         sum {
           sus_serious_injry_cnt
         }

--- a/atd-vze/src/queries/dashboard.js
+++ b/atd-vze/src/queries/dashboard.js
@@ -42,24 +42,58 @@ export const GET_CRASHES_YTD = gql`
         }
       }
     }
-    primaryPersonFatalities: atd_txdot_primaryperson(
+    primaryPersonFatalities: atd_txdot_primaryperson_aggregate(
       where: {
-        crash: { crash_date: { _lt: $yearEnd, _gte: $yearStart } }
-        _and: { prsn_injry_sev_id: { _eq: 4 } }
+        crash: { private_dr_fl: { _eq: "N" } }
+        _and: {
+          prsn_injry_sev_id: { _eq: 4 }
+          crash: { crash_date: { _lt: $yearEnd, _gte: $yearStart } }
+          _or: [
+            { crash: { austin_full_purpose: { _eq: "Y" } } }
+            {
+              _and: [
+                { crash: { city_id: { _eq: 22 } } }
+                { crash: { position: { _is_null: true } } }
+              ]
+            }
+          ]
+        }
       }
     ) {
-      prsn_age
+      aggregate {
+        sum {
+          years_of_life_lost
+        }
+      }
     }
-    personFatalities: atd_txdot_person(
+    personFatalities: atd_txdot_person_aggregate(
       where: {
-        crash: { crash_date: { _lt: $yearEnd, _gte: $yearStart } }
-        _and: { prsn_injry_sev_id: { _eq: 4 } }
+        crash: { private_dr_fl: { _eq: "N" } }
+        _and: {
+          prsn_injry_sev_id: { _eq: 4 }
+          crash: { crash_date: { _lt: $yearEnd, _gte: $yearStart } }
+          _or: [
+            { crash: { austin_full_purpose: { _eq: "Y" } } }
+            {
+              _and: [
+                { crash: { city_id: { _eq: 22 } } }
+                { crash: { position: { _is_null: true } } }
+              ]
+            }
+          ]
+        }
       }
     ) {
-      prsn_age
+      aggregate {
+        sum {
+          years_of_life_lost
+        }
+      }
     }
   }
 `;
+
+// TODO: Try old query!!!!!!!
 
 // SELECT
 //   75 - prsn_age as years_of_life_lost

--- a/atd-vze/src/queries/dashboard.js
+++ b/atd-vze/src/queries/dashboard.js
@@ -4,15 +4,21 @@ export const GET_CRASHES_YTD = gql`
   query GetCrashesYTD($yearStart: date, $yearEnd: date) {
     fatalities: atd_txdot_crashes_aggregate(
       where: {
-        city_id: { _eq: 22 }
-        crash_date: { _gte: $yearStart, _lte: $yearEnd }
-        private_dr_fl: { _neq: "Y" }
-        apd_confirmed_fatality: { _neq: "N" }
+        crash_date: { _lt: $yearEnd, _gte: $yearStart }
+        private_dr_fl: { _eq: "N" }
+        _and: [
+          { crash_date: { _is_null: false } }
+          { crash_time: { _is_null: false } }
+        ]
+        _or: [
+          { austin_full_purpose: { _eq: "Y" } }
+          { _and: [{ city_id: { _eq: 22 } }, { position: { _is_null: true } }] }
+        ]
       }
     ) {
       aggregate {
         sum {
-          apd_confirmed_death_count
+          atd_fatality_count
         }
       }
     }
@@ -32,11 +38,22 @@ export const GET_CRASHES_YTD = gql`
     }
     atd_txdot_person_aggregate(
       where: {
-        injury_severity: { injry_sev_desc: { _eq: "KILLED" } }
-        crash: {
-          city_id: { _eq: 22 }
-          crash_date: { _gte: $yearStart, _lte: $yearEnd }
-          apd_confirmed_fatality: { _neq: "N" }
+        crash: { private_dr_fl: { _eq: "N" } }
+        _or: [
+          { prsn_injry_sev_id: { _eq: 1 } }
+          { prsn_injry_sev_id: { _eq: 4 } }
+        ]
+        _and: {
+          crash: { crash_date: { _lt: $yearEnd, _gte: $yearStart } }
+          _or: [
+            { crash: { austin_full_purpose: { _eq: "Y" } } }
+            {
+              _and: [
+                { crash: { city_id: { _eq: 22 } } }
+                { crash: { position: { _is_null: true } } }
+              ]
+            }
+          ]
         }
       }
     ) {
@@ -64,3 +81,32 @@ export const GET_CRASHES_YTD = gql`
     }
   }
 `;
+
+// Notes
+// atd_txdot_person_aggregate(
+//   where: {
+//       crash: { private_dr_fl: { _eq: "N" }},
+//       _or: [
+//           {prsn_injry_sev_id: {_eq: 1}},
+//           {prsn_injry_sev_id: {_eq: 4}}
+//       ],
+//       _and: {
+//           crash: {crash_date: {_lt: $yearEnd, _gte: $yearStart }}
+//           _or: [
+//               {crash: {austin_full_purpose: {_eq: "Y"}}},
+//               {
+//                   _and: [
+//                       {crash: {city_id: {_eq: 22}}},
+//                       {crash: {position: {_is_null: true}}}
+//                   ]
+//               }
+//           ]
+//       }
+//   }
+// ) {
+// aggregate {
+// sum {
+// prsn_age
+// }
+// }
+// }

--- a/atd-vze/src/queries/dashboard.js
+++ b/atd-vze/src/queries/dashboard.js
@@ -42,77 +42,21 @@ export const GET_CRASHES_YTD = gql`
         }
       }
     }
-    atd_txdot_person_aggregate(
+    primaryPersonFatalities: atd_txdot_primaryperson(
       where: {
-        crash: { private_dr_fl: { _eq: "N" } }
-        _or: [
-          { prsn_injry_sev_id: { _eq: 1 } }
-          { prsn_injry_sev_id: { _eq: 4 } }
-        ]
-        _and: {
-          crash: { crash_date: { _lt: $yearEnd, _gte: $yearStart } }
-          _or: [
-            { crash: { austin_full_purpose: { _eq: "Y" } } }
-            {
-              _and: [
-                { crash: { city_id: { _eq: 22 } } }
-                { crash: { position: { _is_null: true } } }
-              ]
-            }
-          ]
-        }
+        crash: { crash_date: { _lt: $yearEnd, _gte: $yearStart } }
+        _and: { prsn_injry_sev_id: { _eq: 4 } }
       }
     ) {
-      aggregate {
-        sum {
-          years_of_life_lost
-        }
-      }
+      prsn_age
     }
-    atd_txdot_primaryperson_aggregate(
+    personFatalities: atd_txdot_person(
       where: {
-        injury_severity: { injry_sev_desc: { _eq: "KILLED" } }
-        crash: {
-          city_id: { _eq: 22 }
-          crash_date: { _gte: $yearStart, _lte: $yearEnd }
-          apd_confirmed_fatality: { _neq: "N" }
-        }
+        crash: { crash_date: { _lt: $yearEnd, _gte: $yearStart } }
+        _and: { prsn_injry_sev_id: { _eq: 4 } }
       }
     ) {
-      aggregate {
-        sum {
-          years_of_life_lost
-        }
-      }
+      prsn_age
     }
   }
 `;
-
-// Notes
-// atd_txdot_person_aggregate(
-//   where: {
-//       crash: { private_dr_fl: { _eq: "N" }},
-//       _or: [
-//           {prsn_injry_sev_id: {_eq: 1}},
-//           {prsn_injry_sev_id: {_eq: 4}}
-//       ],
-//       _and: {
-//           crash: {crash_date: {_lt: $yearEnd, _gte: $yearStart }}
-//           _or: [
-//               {crash: {austin_full_purpose: {_eq: "Y"}}},
-//               {
-//                   _and: [
-//                       {crash: {city_id: {_eq: 22}}},
-//                       {crash: {position: {_is_null: true}}}
-//                   ]
-//               }
-//           ]
-//       }
-//   }
-// ) {
-// aggregate {
-// sum {
-// prsn_age
-// }
-// }
-// }

--- a/atd-vze/src/views/VZDashboard/VZDashboard.js
+++ b/atd-vze/src/views/VZDashboard/VZDashboard.js
@@ -5,6 +5,7 @@ import { useQuery } from "@apollo/react-hooks";
 import Widget02 from "../Widgets/Widget02";
 import VZLinksWidget from "../Widgets/VZLinksWidget";
 import VZNoticeWidget from "../Widgets/VZNoticeWidget";
+import moment from "moment";
 
 import { GET_CRASHES_YTD } from "../../queries/dashboard";
 
@@ -12,10 +13,11 @@ import bi_logo from "../../assets/img/brand/power_bi_icon_white_on_transparent.p
 
 function VZDashboard() {
   const year = new Date().getFullYear();
-  // TODO: Use same date range as VZV
   const yearStart = `${year}-01-01`;
-  const yearEnd = `${year}-12-31`;
-  console.log(yearStart, yearEnd);
+  // We use the same end date as VZV so VZE widget totals match VZV widgets
+  const yearEnd = moment()
+    .subtract(14, "day")
+    .format("YYYY-MM-DD");
   const { loading, error, data } = useQuery(GET_CRASHES_YTD, {
     variables: { yearStart, yearEnd },
   });
@@ -40,8 +42,6 @@ function VZDashboard() {
     yearsOfLifeLostPrimaryPerson + yearsOfLifeLostPerson;
   const fatalitiesYTD = deathCount;
   const seriousInjuriesYTD = seriousInjuryCount;
-
-  console.log(data, yearsOfLifeLostYTD, fatalitiesYTD, seriousInjuriesYTD);
 
   // Widget02 expects a string value, DB returns number or null
   const commaSeparator = number =>

--- a/atd-vze/src/views/VZDashboard/VZDashboard.js
+++ b/atd-vze/src/views/VZDashboard/VZDashboard.js
@@ -12,7 +12,7 @@ import bi_logo from "../../assets/img/brand/power_bi_icon_white_on_transparent.p
 
 function VZDashboard() {
   const year = new Date().getFullYear();
-  // TODO: Use same data range as VZV
+  // TODO: Use same date range as VZV
   const yearStart = `${year}-01-01`;
   const yearEnd = `${year}-12-31`;
   console.log(yearStart, yearEnd);

--- a/atd-vze/src/views/VZDashboard/VZDashboard.js
+++ b/atd-vze/src/views/VZDashboard/VZDashboard.js
@@ -12,18 +12,22 @@ import bi_logo from "../../assets/img/brand/power_bi_icon_white_on_transparent.p
 
 function VZDashboard() {
   const year = new Date().getFullYear();
+  // TODO: Use same data range as VZV
   const yearStart = `${year}-01-01`;
   const yearEnd = `${year}-12-31`;
+  console.log(yearStart, yearEnd);
   const { loading, error, data } = useQuery(GET_CRASHES_YTD, {
     variables: { yearStart, yearEnd },
   });
 
   if (loading) return "Loading...";
   if (error) return `Error! ${error.message}`;
-
+  console.log(data);
   const {
     years_of_life_lost: yearsOfLifeLostPrimaryPerson,
   } = data.atd_txdot_primaryperson_aggregate.aggregate.sum;
+
+  // years_of_life_lost is equal to 0 for every person record
   const {
     years_of_life_lost: yearsOfLifeLostPerson,
   } = data.atd_txdot_person_aggregate.aggregate.sum;
@@ -88,7 +92,7 @@ function VZDashboard() {
           }
         </Col>
       </Row>
-      <Row className='mt-3'>
+      <Row className="mt-3">
         <Col xs="12" sm="6" md="6">
           <VZLinksWidget
             header={`Arterial Management Division Overview`}
@@ -98,7 +102,7 @@ function VZDashboard() {
             raster_icon_alt="Power BI"
             color="dark"
             link="https://app.powerbigov.us/links/GACOsce5fi?ctid=5c5e19f6-a6ab-4b45-b1d0-be4608a9a67f&pbi_source=linkShare"
-            target='_bi_amd'
+            target="_bi_amd"
           />
           <VZLinksWidget
             header={`High Injury Roadways`}
@@ -108,7 +112,7 @@ function VZDashboard() {
             raster_icon_alt="Power BI"
             color="dark"
             link="https://app.powerbigov.us/links/pdguGuhSGE?ctid=5c5e19f6-a6ab-4b45-b1d0-be4608a9a67f&pbi_source=linkShare"
-            target='_bi_hir'
+            target="_bi_hir"
           />
           <VZLinksWidget
             header={`Emerging Hotspots and Bond Locations`}
@@ -118,7 +122,7 @@ function VZDashboard() {
             raster_icon_alt="Power BI"
             color="dark"
             link="https://app.powerbigov.us/links/RmMrnaSMLp?ctid=5c5e19f6-a6ab-4b45-b1d0-be4608a9a67f&pbi_source=linkShare"
-            target='_bi_hotspots'
+            target="_bi_hotspots"
           />
         </Col>
         <Col xs="12" sm="6" md="6">
@@ -128,7 +132,7 @@ function VZDashboard() {
             icon="fa fa-map"
             color="primary"
             link="https://austin.maps.arcgis.com/apps/instant/interactivelegend/index.html?appid=32b276f4e6cd406aa1c2040d2eb26b37"
-            target='_compcostmap'
+            target="_compcostmap"
           />
           <VZLinksWidget
             header={`Vision Zero Viewer`}
@@ -136,7 +140,7 @@ function VZDashboard() {
             icon="fa fa-map"
             color="primary"
             link="https://visionzero.austin.gov/viewer/"
-            target='_vzv'
+            target="_vzv"
           />
         </Col>
       </Row>

--- a/atd-vze/src/views/VZDashboard/VZDashboard.js
+++ b/atd-vze/src/views/VZDashboard/VZDashboard.js
@@ -22,26 +22,26 @@ function VZDashboard() {
 
   if (loading) return "Loading...";
   if (error) return `Error! ${error.message}`;
-  console.log(data);
+
   const {
     years_of_life_lost: yearsOfLifeLostPrimaryPerson,
-  } = data.atd_txdot_primaryperson_aggregate.aggregate.sum;
+  } = data.primaryPersonFatalities.aggregate.sum;
 
-  // years_of_life_lost is equal to 0 for every person record
   const {
     years_of_life_lost: yearsOfLifeLostPerson,
-  } = data.atd_txdot_person_aggregate.aggregate.sum;
+  } = data.personFatalities.aggregate.sum;
+
   const {
     sus_serious_injry_cnt: seriousInjuryCount,
   } = data.seriousInjuriesAndTotal.aggregate.sum;
-  const {
-    apd_confirmed_death_count: deathCount,
-  } = data.fatalities.aggregate.sum;
+  const { atd_fatality_count: deathCount } = data.fatalities.aggregate.sum;
 
   const yearsOfLifeLostYTD =
     yearsOfLifeLostPrimaryPerson + yearsOfLifeLostPerson;
   const fatalitiesYTD = deathCount;
   const seriousInjuriesYTD = seriousInjuryCount;
+
+  console.log(data, yearsOfLifeLostYTD, fatalitiesYTD, seriousInjuriesYTD);
 
   // Widget02 expects a string value, DB returns number or null
   const commaSeparator = number =>

--- a/atd-vze/src/views/VZDashboard/VZDashboard.js
+++ b/atd-vze/src/views/VZDashboard/VZDashboard.js
@@ -62,14 +62,6 @@ function VZDashboard() {
       <Row>
         <Col xs="12" sm="6" md="4">
           <Widget02
-            header={commaSeparator(yearsOfLifeLostYTD)}
-            mainText={`Years of life lost in ${year}`}
-            icon="fa fa-hourglass-end"
-            color="info"
-          />
-        </Col>
-        <Col xs="12" sm="6" md="4">
-          <Widget02
             header={commaSeparator(fatalitiesYTD)}
             mainText={`Fatalities in ${year}`}
             icon="fa fa-heartbeat"
@@ -78,10 +70,18 @@ function VZDashboard() {
         </Col>
         <Col xs="12" sm="6" md="4">
           <Widget02
+            header={commaSeparator(yearsOfLifeLostYTD)}
+            mainText={`Years of life lost in ${year}`}
+            icon="fa fa-hourglass-end"
+            color="info"
+          />
+        </Col>
+        <Col xs="12" sm="6" md="4">
+          <Widget02
             header={commaSeparator(seriousInjuriesYTD)}
             mainText={`Suspected Serious Injuries in ${year}`}
             icon="fa fa-medkit"
-            color="info"
+            color="warning"
           />
         </Col>
       </Row>


### PR DESCRIPTION
## Associated issues
https://github.com/cityofaustin/atd-data-tech/issues/7080

This PR updates the queries that power the dashboard to mirror the queries that populate the Socrata dataset that powers VZV. The years of life lost column for person and primary person records are now [generated columns](https://www.postgresql.org/docs/current/ddl-generated-columns.html) that are calculated from the `prsn_age` column in the same table.

The column follows these rules: 
a. if the injury severity is fatal, use 75 - person age to calculate years of life lost
b. if the injury severity is not fatal, use 0 for years of life lost
c. if 75 - person age is negative, use 0 for years of life lost

Thanks to @frankhereford for populating staging with production data - it made verifying the totals for this issue a breeze 🍃 

## Testing
**URL to test:** <!-- VZ URL or Netlify -->
https://deploy-preview-1111--atd-vze-staging.netlify.app/

**Steps to test:**

**Widget counts**
1. Go to https://visionzero.austin.gov/viewer/
2. In a separate tab, go to https://deploy-preview-1111--atd-vze-staging.netlify.app/#/dashboard
3. Compare the counts in the widgets

**Locations years of life lost widget**
1. Go to https://deploy-preview-1111--atd-vze-staging.netlify.app/#/locations/05186FFEDB
2. In the **CR3 Crashes** card, enter a date range start of 09/29/2019 and end of 09/29/2022
3. You should see see one fatal crash (ID# 17662317) and the **Years of Life Lost widget** should show a total of 25
4. Go to https://deploy-preview-1111--atd-vze-staging.netlify.app/#/crashes/17662317 and see in the **Related Records People accordion**, and you will see that one person with the age of 50 passed away in this crash making the total years of life lost for this location 25 years for the entered date range

VZV totals as of September 15th, 2022
<img width="1103" alt="Screen Shot 2022-09-29 at 11 36 24 PM" src="https://user-images.githubusercontent.com/37249039/193191187-2e5db9eb-0b9f-46e7-9da4-27ac331182b8.png">

VZE totals with this PR's code as of September 15th, 2022
<img width="977" alt="Screen Shot 2022-09-29 at 11 37 33 PM" src="https://user-images.githubusercontent.com/37249039/193191277-01196d61-448b-481d-8865-af1daecfeadc.png">

---
#### Ship list
- [x] Code reviewed
- [x] Product manager approved
