### PR TITLE
10462 migrate recommendation partners

### DIFF
--- a/atd-toolbox/coordination_partners_migration/coordination_partners_migration.py
+++ b/atd-toolbox/coordination_partners_migration/coordination_partners_migration.py
@@ -1,0 +1,95 @@
+import argparse
+import requests
+
+from secrets import HASURA_AUTH
+
+def make_hasura_request(*, query, variables, env):
+  """Fetch data from hasura
+  Args:
+    query (str): the hasura query
+    env (str): the environment name, which will be used to acces secrets
+  Raises:
+    ValueError: If no data is returned
+  Returns:
+    dict: Hasura JSON response data
+  """
+  admin_secret = HASURA_AUTH["hasura_graphql_admin_secret"][env]
+  endpoint = HASURA_AUTH["hasura_graphql_endpoint"][env]
+  headers = {
+    "X-Hasura-Admin-Secret": admin_secret,
+    "content-type": "application/json",
+  }
+  payload = {"query": query, "variables": variables}
+  res = requests.post(endpoint, json=payload, headers=headers)
+  res.raise_for_status()
+  data = res.json()
+  try:
+    return data["data"]
+  except KeyError:
+    raise ValueError(data)
+
+RECOMMENDATIONS_QUERY = """
+  query GetRecommendations {
+    recommendations(where: {coordination_partner_id: {_is_null: false}}) {
+      id
+      coordination_partner_id
+    }
+  }
+"""
+
+RECOMMENDATIONS_PARTNER_INSERT = """
+  mutation InsertRecommendationPartner(
+    $recommendation_id: Int!,
+    $partner_id: Int!
+  ) {
+    insert_recommendations_partners(objects: {
+      recommendation_id: $recommendation_id
+      partner_id: $partner_id
+    }) {
+      affected_rows
+    }
+  }
+"""
+
+def main(env):
+  counts = 0
+  # fetch all records that do not have a null value in the coordination_partner_id field
+  data = make_hasura_request(query=RECOMMENDATIONS_QUERY, env=env, variables=None)
+  recommendations = data["recommendations"]
+
+  for rec in recommendations:
+
+    recommendation_id = rec["id"]
+    partner_id = rec["coordination_partner_id"]
+
+    """ this mutation will:
+    1. insert a record in the recommendations_partners table for every rec that has a coordination partner
+    """
+    make_hasura_request(
+      query=RECOMMENDATIONS_PARTNER_INSERT,
+      variables={
+        "recommendation_id": recommendation_id,
+        "partner_id": partner_id
+      },
+      env=env,
+    )
+    counts += 1
+    print(counts)
+
+  print(counts)
+
+if __name__ == "__main__":
+  parser = argparse.ArgumentParser()
+
+  parser.add_argument(
+    "-e",
+    "--env",
+    type=str,
+    choices=["local", "staging", "prod"],
+    default="staging",
+    help=f"Environment",
+  )
+
+  args = parser.parse_args()
+
+  main(args.env)

--- a/atd-toolbox/coordination_partners_migration/secrets.py
+++ b/atd-toolbox/coordination_partners_migration/secrets.py
@@ -1,0 +1,10 @@
+HASURA_AUTH = {
+  "hasura_graphql_endpoint": {
+    "staging": "<redacted>",
+    "prod": "<redacted>",
+  },
+  "hasura_graphql_admin_secret": {
+    "staging": "<redacted>",
+    "prod": "<redacted>",
+  },
+}


### PR DESCRIPTION
## Associated issues

Closes cityofaustin/atd-data-tech/issues/10462

This PR includes a script that migrates `recommendation_id`'s and their corresponding `partner_id`'s from the `recommendations` table to the new `recommendations_partners` table. The pattern for this code was copied from @johnclary 's [work](https://github.com/cityofaustin/atd-moped/blob/10474-jc-team-table-edits/moped-toolbox/migrate_personnel/run.py) in a moped migration, so thank you to John for that 🙏 This will be the final step in changing the database relationship to many to many between recommendations and partners.

I have run it with the staging database and it worked just as expected, so whenever it comes time to update prod, this script is ready to go!

- [ ] A clean-up todo after this is done is to delete the coordination_partner_id column in the recommendations table.

#### Ship list
- [x] Code reviewed
- [x] PM reviewed