### PR TITLE
Change gender to sex in persons table

### DIFF
--- a/atd-vze/src/views/Crashes/personDataMap.js
+++ b/atd-vze/src/views/Crashes/personDataMap.js
@@ -118,7 +118,7 @@ export const personDataMap = [
         mutationVariableKey: "personId",
       },
       gender: {
-        label: "Gender",
+        label: "Sex",
         editable: true,
         lookup_desc: "gndr_desc",
         format: "select",


### PR DESCRIPTION
## Associated issues

I just noticed that I only changed the label from "Gender" to "Sex" in the primary persons table but not the other persons table, this PR fixes that

## Testing
**URL to test:** <!-- VZ URL or Netlify -->
https://deploy-preview-1126--atd-vze-staging.netlify.app/#/crashes/19016360

**Steps to test:**
Check that both the Driver/Primary People and Other People tables have a column for "Sex".

---
#### Ship list
- [ ] Code reviewed
- [ ] Product manager approved
