### PR TITLE
Update README with up-to-date CI details to trigger CI

### DIFF
--- a/atd-events/README.md
+++ b/atd-events/README.md
@@ -91,7 +91,7 @@ $ pip freeze > requirements.txt
 
 #### New PRs
 First, it is recommended that you create a PR. Whenever a PR is created
-CircleCI will begin creating the python bundles for Lambda and SQS and it
+a GitHub Action flow will begin creating the python bundles for Lambda and SQS and it
 will deploy them automatically.
 
 Secondly, it is recommended that you log in to AWS with your credentials


### PR DESCRIPTION
## Associated issues
n/a

This is a small update to the atd-events README to update it to say that GH Actions deploys the SQS + Lambda instead of saying that CircleCI does it. CircleCI only handles the deployment of the CR3 + user management API.

**Question:
**CircleCI uses the Docker Hub username/PW, and I know that we want to move to access tokens. Should this be done now or moved to be a less critical follow-up task?****

## Testing
**URL to test:** <!-- VZ URL or Netlify -->
n/a

**Steps to test:**
Double check these configs to make sure this change will trigger the CircleCI and GH Action runs - it looks right to me but I could use some backup. 🙏 
https://github.com/cityofaustin/atd-vz-data/blob/master/.github/workflows/atd_sqs_build.yml
https://github.com/cityofaustin/atd-vz-data/blob/master/.github/workflows/atd_sqs_cleanup.yml
https://github.com/cityofaustin/atd-vz-data/blob/master/.circleci/config.yml

---
#### Ship list
- [x] Code reviewed
- [x] Product manager approved
