### PR TITLE
Show textual delta for year-on-year metrics at the top of the VZV even when the previous year is zero

### DIFF
--- a/atd-vzv/src/Components/Widgets/SummaryWidget.js
+++ b/atd-vzv/src/Components/Widgets/SummaryWidget.js
@@ -82,15 +82,12 @@ const SummaryWidget = ({
       (currentYearTotal > lastYearTotal && "Up from") ||
       (currentYearTotal < lastYearTotal && "Down from") ||
       "Same as";
-
     return (
       <div className="text-left widget-footer-icon d-flex flex-row align-items-center">
         <FontAwesomeIcon size="2x" icon={icon} color={colors.dark} />
-        {!!lastYearTotal && (
           <span className="text-muted text-wrap pl-4">
             {`${text} ${numberWithCommas(lastYearTotal)} this time last year`}
           </span>
-        )}
       </div>
     );
   };


### PR DESCRIPTION
## Related issue

_none_; this is a proposal stemming from [this observation](https://austininnovation.slack.com/archives/CM9MK950S/p1673885832996419?thread_ts=1673803259.981779&cid=CM9MK950S) by @johnclary in slack. 🙏 

## Change

The VZV contains some year-on-year comparisons on a handful of metrics at the very top of the application. In the case that the YTD value for the previous year is zero, the textual description was not emitted. This PR removes that conditional check.

This logic was likely in place in the case that a percentage change was calculated, which would have had this render a div-by-zero bug, but we only show what the previous value was, so zero is valid.

## Testing

To test this locally, I recommend you change line 3 & 4 of `vzv/src/views/summary/queries/socrataQueries.js` to look like this:
```
const crashDatasetID = "y2wy-tgr5";
const personDatasetID = "xecs-rpy9";
```

The use of the "production" datasets is probably what VZV developers want to be doing all the time, unless they are working on the actual form and shape of those datasets.