### PR TITLE
"Confirm Save" modal is activated when trying to use "X" button to close "Success" modal

### DIFF
--- a/atd-vze/src/views/Tools/ToolsUploadNonCR3.js
+++ b/atd-vze/src/views/Tools/ToolsUploadNonCR3.js
@@ -710,7 +710,7 @@ const ToolsUploadNonCR3 = () => {
         toggle={toggleModalSaveConfirm}
         className={"modal-primary"}
       >
-        <ModalHeader toggle={toggleModalSaveConfirm}>Confirm Save</ModalHeader>
+        <ModalHeader>Confirm Save</ModalHeader>
         <ModalBody>
           <p>
             Only valid records will be processed, if you have any invalid
@@ -736,7 +736,7 @@ const ToolsUploadNonCR3 = () => {
 
       <Modal
         isOpen={modalFeedback}
-        toggle={toggleModalSaveConfirm}
+        toggle={() => setModalFeedback(false)}
         className={"modal-primary"}
       >
         <ModalHeader>{feedback["title"]}</ModalHeader>

--- a/atd-vze/src/views/Tools/ToolsUploadNonCR3.js
+++ b/atd-vze/src/views/Tools/ToolsUploadNonCR3.js
@@ -710,7 +710,7 @@ const ToolsUploadNonCR3 = () => {
         toggle={toggleModalSaveConfirm}
         className={"modal-primary"}
       >
-        <ModalHeader>Confirm Save</ModalHeader>
+        <ModalHeader toggle={toggleModalSaveConfirm}>Confirm Save</ModalHeader>
         <ModalBody>
           <p>
             Only valid records will be processed, if you have any invalid
@@ -739,7 +739,9 @@ const ToolsUploadNonCR3 = () => {
         toggle={() => setModalFeedback(false)}
         className={"modal-primary"}
       >
-        <ModalHeader>{feedback["title"]}</ModalHeader>
+        <ModalHeader toggle={() => setModalFeedback(false)}>
+          {feedback["title"]}
+        </ModalHeader>
         <ModalBody>{feedback["message"]}</ModalBody>
         <ModalFooter>
           <Button color="secondary" onClick={() => setModalFeedback(false)}>

--- a/atd-vze/src/views/Tools/ToolsUploadNonCR3.js
+++ b/atd-vze/src/views/Tools/ToolsUploadNonCR3.js
@@ -739,9 +739,7 @@ const ToolsUploadNonCR3 = () => {
         toggle={toggleModalSaveConfirm}
         className={"modal-primary"}
       >
-        <ModalHeader toggle={toggleModalSaveConfirm}>
-          {feedback["title"]}
-        </ModalHeader>
+        <ModalHeader>{feedback["title"]}</ModalHeader>
         <ModalBody>{feedback["message"]}</ModalBody>
         <ModalFooter>
           <Button color="secondary" onClick={() => setModalFeedback(false)}>


### PR DESCRIPTION
## Associated issues
cityofaustin/atd-data-tech/issues/11210

Linked in the issue above is a video of the bug. ~I thought it made the most sense to just get rid of the "X" buttons at the top of the modals because the other buttons already serve the function of exiting or proceeding to the next modal. Having both just unnecessarily complicates things imo? But if anyone feels strongly about leaving in the "X" buttons I can bring them back!~

My opinion has been changed after reading [this](https://ux.stackexchange.com/questions/90153/are-close-and-x-on-a-popup-redundant) discussion about modal redundancy/user experience so I decided to bring the "X" buttons back in, super curious about what y'all think on this topic!

## Testing
**URL to test:** <!-- VZ URL or Netlify -->
https://deploy-preview-1161--atd-vze-staging.netlify.app/#/tools/upload_non_cr3

1. Go to the upload Non-CR3 page.
2. You can upload [this](https://github.com/cityofaustin/atd-vz-data/files/10449521/non_cr3_template.csv) csv to test
3. Click the "Save to Database" button then click continue on the "Confirm Save" modal
4. Click "Ok" on the "Success" modal
5. Try again but this time click "x" and/or "Cancel" on the "Confirm Save" modal
6. Try again but click away on the screen to exit the modals.

**Steps to test:**


---
#### Ship list
- [ ] Code reviewed
- [ ] Product manager approved
