### PR TITLE
Last column in By Time of Day visualization that should be hidden is hiding inconsistently

### DIFF
--- a/atd-vzv/src/views/summary/CrashesByTimeOfDay.js
+++ b/atd-vzv/src/views/summary/CrashesByTimeOfDay.js
@@ -157,21 +157,21 @@ const CrashesByTimeOfDay = () => {
   }, [maxForLegend, heatmapData, crashType]);
 
   // Hide placeholder cells
-  useEffect(() => {
-    const heatmapChildCellNumbers = [171, 172, 173, 174, 175, 176, 177];
+  // useEffect(() => {
+  //   const heatmapChildCellNumbers = [171, 172, 173, 174, 175, 176, 177];
 
-    let cellsToHide = heatmapChildCellNumbers.map((num) =>
-      document.querySelector(
-        `#demographics-heatmap > div > svg > g > g:nth-child(${num})`
-      )
-    );
+  //   let cellsToHide = heatmapChildCellNumbers.map((num) =>
+  //     document.querySelector(
+  //       `#demographics-heatmap > div > svg > g > g:nth-child(${num})`
+  //     )
+  //   );
 
-    cellsToHide.forEach((cell) => {
-      if (!!cell) {
-        cell.style.visibility = "hidden";
-      }
-    });
-  }, [heatmapDataWithPlaceholder, crashType, maxForLegend]);
+  //   cellsToHide.forEach((cell) => {
+  //     if (!!cell) {
+  //       cell.style.visibility = "hidden";
+  //     }
+  //   });
+  // }, [heatmapDataWithPlaceholder, crashType, maxForLegend]);
 
   const formatValue = (d) => {
     const value = d.data.value ? d.data.value : 0;
@@ -199,7 +199,10 @@ const CrashesByTimeOfDay = () => {
       </Row>
       <Row>
         <Col>
-          <CrashTypeSelector setCrashType={setCrashType} componentName="CrashesByTimeOfDay"/>
+          <CrashTypeSelector
+            setCrashType={setCrashType}
+            componentName="CrashesByTimeOfDay"
+          />
         </Col>
       </Row>
       <Row>

--- a/atd-vzv/src/views/summary/CrashesByTimeOfDay.js
+++ b/atd-vzv/src/views/summary/CrashesByTimeOfDay.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useCallback, useState, useEffect } from "react";
 import axios from "axios";
 import moment from "moment";
 import clonedeep from "lodash.clonedeep";
@@ -141,6 +141,8 @@ const CrashesByTimeOfDay = () => {
     const placeholderArray = heatmapData[0].data.map((data, i) => ({
       key: dayOfWeekArray[i],
       data: maxForLegend[crashType.name],
+      // Add this metadata to find which cells to hide in the callback ref
+      metadata: { isPlaceholder: true },
     }));
 
     const placeholderObjForChartWeighting = {
@@ -172,6 +174,13 @@ const CrashesByTimeOfDay = () => {
   //     }
   //   });
   // }, [heatmapDataWithPlaceholder, crashType, maxForLegend]);
+  const heatmapCellRef = useCallback((node) => {
+    if (node === null) return;
+
+    if (node?.props?.data?.metadata?.isPlaceholder) {
+      console.log(node, "found one");
+    }
+  }, []);
 
   const formatValue = (d) => {
     const value = d.data.value ? d.data.value : 0;
@@ -251,6 +260,7 @@ const CrashesByTimeOfDay = () => {
                 emptyColor={colors.intensity1Of5Lowest}
                 cell={
                   <HeatmapCell
+                    ref={heatmapCellRef}
                     tooltip={
                       <ChartTooltip
                         content={(d) =>

--- a/atd-vzv/src/views/summary/CrashesByTimeOfDay.js
+++ b/atd-vzv/src/views/summary/CrashesByTimeOfDay.js
@@ -33,6 +33,10 @@ const hourBlockArray = [...Array(24).keys()].map((hour) =>
   moment({ hour }).format("hhA")
 );
 
+/**
+ * Build an array of objs for each hour window that holds totals of each day of the week
+ * @returns {Array} Array of objs for each hour window that holds totals of each day of the week
+ */
 const buildDataArray = () => {
   // This array holds weekday totals for each hour window within a day
   // Reaviz Heatmap expects array of weekday total objs to be reversed in order
@@ -40,13 +44,18 @@ const buildDataArray = () => {
     .map((day) => ({ key: day, data: null })) // Initialize totals as null to unweight 0 in viz
     .reverse();
 
-  // Return array of objs for each hour window that holds totals of each day of the week
   return hourBlockArray.map((hour) => ({
     key: hour,
     data: clonedeep(hourWindowTotalsByDay),
   }));
 };
 
+/**
+ * Calculate the figures to populate the heatmap cells
+ * @param {*} records - Array of crash records returned from the Socrata query
+ * @param {Object} crashType - Object containing query and name details (see CrashTypeSelector component)
+ * @returns
+ */
 const calculateHourBlockTotals = (records, crashType) => {
   const dataArray = buildDataArray();
 
@@ -75,7 +84,14 @@ const calculateHourBlockTotals = (records, crashType) => {
   return dataArray;
 };
 
+/**
+ * Generate the query url for the Socrata query based on the active tab and crash type
+ * @param {Number} activeTab - The active tab index that corresponds to year option selected
+ * @param {Object} crashType - Object containing query and name details (see CrashTypeSelector component)
+ * @returns {String} The query url for the Socrata query
+ */
 const getFatalitiesByYearsAgoUrl = (activeTab, crashType) => {
+  console.log("activeTab", activeTab);
   const yearsAgoDate = moment().subtract(activeTab, "year").format("YYYY");
   let queryUrl =
     activeTab === 0
@@ -157,10 +173,11 @@ const CrashesByTimeOfDay = () => {
     setHeatmapDataWithPlaceholder(updatedWeightingData);
   }, [maxForLegend, heatmapData, crashType]);
 
-  // Hide placeholder cells
+  // Hide placeholder cells with a callback ref
   const heatmapCellRef = useCallback((node) => {
+    // Look for the isPlaceholder metadata that we placed there to identify the cells to hide
     if (node?.props?.data?.metadata?.isPlaceholder) {
-      console.log(node, "found one");
+      // Update the cell's style to hide it and its tooltip
       node.rect.current.style.visibility = "hidden";
     }
   }, []);

--- a/atd-vzv/src/views/summary/CrashesByTimeOfDay.js
+++ b/atd-vzv/src/views/summary/CrashesByTimeOfDay.js
@@ -179,6 +179,7 @@ const CrashesByTimeOfDay = () => {
 
     if (node?.props?.data?.metadata?.isPlaceholder) {
       console.log(node, "found one");
+      node.rect.current.style.visibility = "hidden";
     }
   }, []);
 

--- a/atd-vzv/src/views/summary/CrashesByTimeOfDay.js
+++ b/atd-vzv/src/views/summary/CrashesByTimeOfDay.js
@@ -141,7 +141,7 @@ const CrashesByTimeOfDay = () => {
     const placeholderArray = heatmapData[0].data.map((data, i) => ({
       key: dayOfWeekArray[i],
       data: maxForLegend[crashType.name],
-      // Add this metadata to find which cells to hide in the callback ref
+      // Add this metadata to find which cells to hide in the callback ref below
       metadata: { isPlaceholder: true },
     }));
 
@@ -159,24 +159,7 @@ const CrashesByTimeOfDay = () => {
   }, [maxForLegend, heatmapData, crashType]);
 
   // Hide placeholder cells
-  // useEffect(() => {
-  //   const heatmapChildCellNumbers = [171, 172, 173, 174, 175, 176, 177];
-
-  //   let cellsToHide = heatmapChildCellNumbers.map((num) =>
-  //     document.querySelector(
-  //       `#demographics-heatmap > div > svg > g > g:nth-child(${num})`
-  //     )
-  //   );
-
-  //   cellsToHide.forEach((cell) => {
-  //     if (!!cell) {
-  //       cell.style.visibility = "hidden";
-  //     }
-  //   });
-  // }, [heatmapDataWithPlaceholder, crashType, maxForLegend]);
   const heatmapCellRef = useCallback((node) => {
-    if (node === null) return;
-
     if (node?.props?.data?.metadata?.isPlaceholder) {
       console.log(node, "found one");
       node.rect.current.style.visibility = "hidden";
@@ -261,6 +244,7 @@ const CrashesByTimeOfDay = () => {
                 emptyColor={colors.intensity1Of5Lowest}
                 cell={
                   <HeatmapCell
+                    // This callback ref is used to hide placeholder cells
                     ref={heatmapCellRef}
                     tooltip={
                       <ChartTooltip

--- a/atd-vzv/src/views/summary/CrashesByTimeOfDay.js
+++ b/atd-vzv/src/views/summary/CrashesByTimeOfDay.js
@@ -91,7 +91,6 @@ const calculateHourBlockTotals = (records, crashType) => {
  * @returns {String} The query url for the Socrata query
  */
 const getFatalitiesByYearsAgoUrl = (activeTab, crashType) => {
-  console.log("activeTab", activeTab);
   const yearsAgoDate = moment().subtract(activeTab, "year").format("YYYY");
   let queryUrl =
     activeTab === 0
@@ -260,7 +259,7 @@ const CrashesByTimeOfDay = () => {
                 emptyColor={colors.intensity1Of5Lowest}
                 cell={
                   <HeatmapCell
-                    // This callback ref is used to hide placeholder cells
+                    // This ref is needed to hide placeholder cells
                     ref={heatmapCellRef}
                     tooltip={
                       <ChartTooltip


### PR DESCRIPTION
## Associated issues
https://github.com/cityofaustin/atd-data-tech/issues/11214

This patches a bug where a column populated with the maximum single day total of fatailities, serious injuries, or both (depending on the option chosen) would appear as the 25th column in the By Time of Day visualization. 

The fix was to use a callback ref as a way to inspect the refs of rendered cells one by one and hide them if they are placeholder cells. All within the component lifecycle instead of using vanilla JS. Here is the [article about the callback ref pattern](https://tkdodo.eu/blog/avoiding-use-effect-with-callback-refs#usecallback-to-the-rescue).


## Testing
**URL to test:** <!-- VZ URL or Netlify -->
https://deploy-preview-1163--atd-vzv-staging.netlify.app/

**Steps to test:**
1. Go to the preview and look at the By Time of Day visualization
2. Keep refreshing the page and looking to see a 25th column appears with the same color as the max in the legend at the bottom
3. If you see it, let me know that the 👻 has returned

---
#### Ship list
- [x] Code reviewed
- [x] Product manager approved
