### PR TITLE
🤠 Dependabot Round Up

### DIFF
--- a/atd-cr3-api/requirements.txt
+++ b/atd-cr3-api/requirements.txt
@@ -10,7 +10,7 @@ durationpy==0.5
 ecdsa==0.15
 Flask==1.1.1
 Flask-Cors==3.0.9
-future==0.18.2
+future==0.18.3
 hjson==3.0.1
 idna==2.9
 importlib-metadata==1.5.0

--- a/atd-vze/package-lock.json
+++ b/atd-vze/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "atd-vz-data",
-  "version": "1.30.0",
+  "version": "1.31.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "atd-vz-data",
-      "version": "1.30.0",
+      "version": "1.31.0",
       "license": "MIT",
       "dependencies": {
         "@apollo/react-hooks": "^3.0.0",
@@ -24763,9 +24763,9 @@
       }
     },
     "node_modules/ua-parser-js": {
-      "version": "0.7.28",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.28.tgz",
-      "integrity": "sha512-6Gurc1n//gjp9eQNXjD9O3M/sMwVtN5S8Lv9bvOYBfKfDNiIIhqiyi01vMBO45u4zkDE420w/e0se7Vs+sIg+g==",
+      "version": "0.7.33",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.33.tgz",
+      "integrity": "sha512-s8ax/CeZdK9R/56Sui0WM6y9OFREJarMRHqLB2EwkovemBxNQ+Bqu8GAsUnVcXKgphb++ghr/B2BZx4mahujPw==",
       "funding": [
         {
           "type": "opencollective",
@@ -46994,9 +46994,9 @@
       "peer": true
     },
     "ua-parser-js": {
-      "version": "0.7.28",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.28.tgz",
-      "integrity": "sha512-6Gurc1n//gjp9eQNXjD9O3M/sMwVtN5S8Lv9bvOYBfKfDNiIIhqiyi01vMBO45u4zkDE420w/e0se7Vs+sIg+g=="
+      "version": "0.7.33",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.33.tgz",
+      "integrity": "sha512-s8ax/CeZdK9R/56Sui0WM6y9OFREJarMRHqLB2EwkovemBxNQ+Bqu8GAsUnVcXKgphb++ghr/B2BZx4mahujPw=="
     },
     "unbox-primitive": {
       "version": "1.0.1",


### PR DESCRIPTION
## Associated issues

_none_

This is an effort to quell the long queue of dependabot PRs which have accumulated in the VZ repo over the last year or so.
It includes the following:

* [Bump future from 0.18.2 to 0.18.3 in /atd-cr3-api](https://github.com/cityofaustin/atd-vz-data/commit/c2f2d981f1d39003f8342c5bf422dd0846894545)
* [Bump ua-parser-js from 0.7.28 to 0.7.33 in /atd-vze](https://github.com/cityofaustin/atd-vz-data/commit/ac1accbc8d835fbeae869edc3a0620ea85ec42f8)

## Testing

* TBD

---
#### Ship list
- [x] ~Code reviewed~
- [ ] Product manager approved
