### PR TITLE
🤠 VZE Dependabot Round Up (JS Frontend)

### DIFF
--- a/atd-vze/package-lock.json
+++ b/atd-vze/package-lock.json
@@ -435,7 +435,7 @@
       "dev": true,
       "dependencies": {
         "is-core-module": "^2.2.0",
-        "path-parse": "^1.0.6"
+        "path-parse": "^1.0.7"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -5799,7 +5799,7 @@
       "dev": true,
       "dependencies": {
         "is-core-module": "^2.2.0",
-        "path-parse": "^1.0.6"
+        "path-parse": "^1.0.7"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -6042,7 +6042,7 @@
       "dev": true,
       "dependencies": {
         "is-core-module": "^2.2.0",
-        "path-parse": "^1.0.6"
+        "path-parse": "^1.0.7"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -9878,7 +9878,7 @@
       "dev": true,
       "dependencies": {
         "is-core-module": "^2.2.0",
-        "path-parse": "^1.0.6"
+        "path-parse": "^1.0.7"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -10210,7 +10210,7 @@
       "dev": true,
       "dependencies": {
         "is-core-module": "^2.2.0",
-        "path-parse": "^1.0.6"
+        "path-parse": "^1.0.7"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -10508,7 +10508,7 @@
       "dev": true,
       "dependencies": {
         "is-core-module": "^2.2.0",
-        "path-parse": "^1.0.6"
+        "path-parse": "^1.0.7"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -18028,9 +18028,9 @@
       }
     },
     "node_modules/path-parse": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
     },
     "node_modules/path-to-regexp": {
       "version": "1.8.0",
@@ -20740,7 +20740,7 @@
       "integrity": "sha512-+hTmAldEGE80U2wJJDC1lebb5jWqvTYAfm3YZ1ckk1gBr0MnCqUKlwK1e+anaFljIl+F5tR5IoZcm4ZDA1zMQw==",
       "dev": true,
       "dependencies": {
-        "path-parse": "^1.0.6"
+        "path-parse": "^1.0.7"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -21390,7 +21390,7 @@
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.1.tgz",
       "integrity": "sha512-KuIe4mf++td/eFb6wkaPbMDnP6kObCaEtIDuHOUED6MNUo4K670KZUHuuvYPZDxNF0WVLw49n06M2m2dXphEzA==",
       "dependencies": {
-        "path-parse": "^1.0.6"
+        "path-parse": "^1.0.7"
       }
     },
     "node_modules/resolve-cwd": {
@@ -26820,7 +26820,7 @@
           "dev": true,
           "requires": {
             "is-core-module": "^2.2.0",
-            "path-parse": "^1.0.6"
+            "path-parse": "^1.0.7"
           }
         },
         "semver": {
@@ -31120,7 +31120,7 @@
           "dev": true,
           "requires": {
             "is-core-module": "^2.2.0",
-            "path-parse": "^1.0.6"
+            "path-parse": "^1.0.7"
           }
         }
       }
@@ -31310,7 +31310,7 @@
           "dev": true,
           "requires": {
             "is-core-module": "^2.2.0",
-            "path-parse": "^1.0.6"
+            "path-parse": "^1.0.7"
           }
         },
         "resolve-from": {
@@ -34651,7 +34651,7 @@
           "dev": true,
           "requires": {
             "is-core-module": "^2.2.0",
-            "path-parse": "^1.0.6"
+            "path-parse": "^1.0.7"
           }
         }
       }
@@ -34907,7 +34907,7 @@
           "dev": true,
           "requires": {
             "is-core-module": "^2.2.0",
-            "path-parse": "^1.0.6"
+            "path-parse": "^1.0.7"
           }
         },
         "strip-bom": {
@@ -35109,7 +35109,7 @@
           "dev": true,
           "requires": {
             "is-core-module": "^2.2.0",
-            "path-parse": "^1.0.6"
+            "path-parse": "^1.0.7"
           }
         },
         "semver": {
@@ -43350,7 +43350,7 @@
           "integrity": "sha512-+hTmAldEGE80U2wJJDC1lebb5jWqvTYAfm3YZ1ckk1gBr0MnCqUKlwK1e+anaFljIl+F5tR5IoZcm4ZDA1zMQw==",
           "dev": true,
           "requires": {
-            "path-parse": "^1.0.6"
+            "path-parse": "^1.0.7"
           }
         },
         "semver": {
@@ -43842,7 +43842,7 @@
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.1.tgz",
       "integrity": "sha512-KuIe4mf++td/eFb6wkaPbMDnP6kObCaEtIDuHOUED6MNUo4K670KZUHuuvYPZDxNF0WVLw49n06M2m2dXphEzA==",
       "requires": {
-        "path-parse": "^1.0.6"
+        "path-parse": "^1.0.7"
       }
     },
     "resolve-cwd": {

--- a/atd-vze/package-lock.json
+++ b/atd-vze/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "atd-vz-data",
-  "version": "1.30.0",
+  "version": "1.31.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "atd-vz-data",
-      "version": "1.30.0",
+      "version": "1.31.0",
       "license": "MIT",
       "dependencies": {
         "@apollo/react-hooks": "^3.0.0",
@@ -24763,9 +24763,9 @@
       }
     },
     "node_modules/ua-parser-js": {
-      "version": "0.7.28",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.28.tgz",
-      "integrity": "sha512-6Gurc1n//gjp9eQNXjD9O3M/sMwVtN5S8Lv9bvOYBfKfDNiIIhqiyi01vMBO45u4zkDE420w/e0se7Vs+sIg+g==",
+      "version": "0.7.33",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.33.tgz",
+      "integrity": "sha512-s8ax/CeZdK9R/56Sui0WM6y9OFREJarMRHqLB2EwkovemBxNQ+Bqu8GAsUnVcXKgphb++ghr/B2BZx4mahujPw==",
       "funding": [
         {
           "type": "opencollective",
@@ -46994,9 +46994,9 @@
       "peer": true
     },
     "ua-parser-js": {
-      "version": "0.7.28",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.28.tgz",
-      "integrity": "sha512-6Gurc1n//gjp9eQNXjD9O3M/sMwVtN5S8Lv9bvOYBfKfDNiIIhqiyi01vMBO45u4zkDE420w/e0se7Vs+sIg+g=="
+      "version": "0.7.33",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.33.tgz",
+      "integrity": "sha512-s8ax/CeZdK9R/56Sui0WM6y9OFREJarMRHqLB2EwkovemBxNQ+Bqu8GAsUnVcXKgphb++ghr/B2BZx4mahujPw=="
     },
     "unbox-primitive": {
       "version": "1.0.1",


### PR DESCRIPTION
# Dependabot Round Up for the Vision Zero Editor JavaScript Frontend

## Associated issues & Intent

_none_

This PR is intended to address dependabot PRs which are open in this repo for this app. It does not attempt to bring all libraries up to their most recent release, rather it targets the most recent, non-major version used in our application.

Merger of this PR will cause dependabot to close the PRs related included commits below.

## Contents

This PR contains merge commits from dependabot on the VZE application. It includes:

* [Bump path-parse from 1.0.6 to 1.0.7 in /atd-vze](https://github.com/cityofaustin/atd-vz-data/commit/ae9689a89d665441c56a58e02d469e501b222bd1)
* [Bump ajv from 6.10.0 to 6.12.6 in /atd-vze](https://github.com/cityofaustin/atd-vz-data/commit/ec603bf868639f5ad33d45a4a866cfacd3424ff7)
* [Bump url-parse from 1.5.3 to 1.5.10 in /atd-vze](https://github.com/cityofaustin/atd-vz-data/commit/415a438470aa81d2861ae419342cf4b789dfccfb)
* [Bump eventsource from 1.1.0 to 1.1.2 in /atd-vze](https://github.com/cityofaustin/atd-vz-data/commit/c15670b0b5cc683fb5a29404306ca06726fc16f8)
* [Bump node-sass from 4.13.1 to 4.14.1 in /atd-vze](https://github.com/cityofaustin/atd-vz-data/commit/0995876f146ff96abdbd92f272591e127be6c106)
* [Bump follow-redirects from 1.14.5 to 1.15.2 in /atd-vze](https://github.com/cityofaustin/atd-vz-data/commit/131f6f60457b67e6ef3b1546f2b8e2b1fd9df799)
* [Bump decode-uri-component from 0.2.0 to 0.2.2 in /atd-vze](https://github.com/cityofaustin/atd-vz-data/commit/ffbbc71e98c1535060c93674c0dc47d1bb3fbdd4)
* [Bump express from 4.17.1 to 4.18.2 in /atd-vze](https://github.com/cityofaustin/atd-vz-data/commit/2e2d367e456a53dc63b5dcdc693b01a15bb1e17e)
* [Bump qs from 6.5.2 to 6.5.3 in /atd-vze](https://github.com/cityofaustin/atd-vz-data/commit/8a1b5251f507727f43bf786affdec8145d714db3)
* [Bump ua-parser-js from 0.7.28 to 0.7.33 in /atd-vze](https://github.com/cityofaustin/atd-vz-data/commit/ac1accbc8d835fbeae869edc3a0620ea85ec42f8)

It does not include:

* [Bump loader-utils and react-scripts in /atd-vze](https://github.com/cityofaustin/atd-vz-data/pull/1124)
* [Bump shell-quote and react-scripts in /atd-vze](https://github.com/cityofaustin/atd-vz-data/pull/1117)
* [Bump jsdom and react-scripts in /atd-vze](https://github.com/cityofaustin/atd-vz-data/pull/1103)

These exclusions are the result of needing to bring `react-scripts` (a part of `create-react-app`) up from 3.4.4 to 5+, which have taken place over the last 2+ years. This library's jump is over two major releases, which include a host of breaking changes, including the update to webpack 5, which removes a number of polyfills in the browser that the application depends on, an upgrade to eslint 7, among other potentially problematic changes. 

## Long term outlook

Dan Abramov, an original co-author of `create-react-app`, [writes](https://github.com/facebook/create-react-app/issues/11180#issuecomment-874748552) in July, 2021:

> So if you care about delivering the best user experience, I don't think CRA is the right tool in the first place. It has its use cases, but many other tools now exist that do this job better.

With the [decline](https://dev.to/thevinitgupta/create-react-app-is-dead-3igo) [of](https://www.crocoder.dev/blog/create-react-app-is-dead-what-are-the-alternatives/) [create-react-app](https://github.com/facebook/create-react-app/graphs/code-frequency), it appears, in my opinion, that the path of least resistance and hope of improved maintainability is to extract our components and rebuild the application on a more modern framework. I do not mean to imply that this will be a trivial exercise, but only that it may be our brightest future.

## Testing
Netlify preview build: https://deploy-preview-1168--atd-vze-staging.netlify.app/#/dashboard is available backed by our staging database which is problematic for its own reasons, or locally, potentially backed by [PR 1150](https://github.com/cityofaustin/atd-vz-data/pull/1150)'s local development tooling.

As each merge commit was applied and conflicts resolved, the app has been tested (and by 'tested', I mean only that the page appears to compile and functions) on the following pages:
* The dashboard page
* The crash listing page
* The crash details page
* The locations listing page
* The location details page

There is no simple formula to test this PR, but these are things to consider:
* Does this app build for you locally as if you were to develop on it?
* Does the app function as intended, as you use the site?
* Can you find any regressions as you check the various pages and functions of the application?

---
#### Ship list
- [x] ~Code reviewed~
- [ ] Product manager approved
