### PR TITLE
🤠 VZ Suite Dependabot Round Up (Python)

### DIFF
--- a/atd-cr3-api/requirements.txt
+++ b/atd-cr3-api/requirements.txt
@@ -1,6 +1,6 @@
 argcomplete==1.11.1
-boto3>1
-botocore>1
+boto3==1.*
+botocore==1.*
 certifi==2022.12.7
 cfn-flip==1.2.2
 chardet==3.0.4

--- a/atd-cr3-api/requirements.txt
+++ b/atd-cr3-api/requirements.txt
@@ -34,9 +34,9 @@ six==1.14.0
 text-unidecode==1.3
 toml==0.10.0
 tqdm==4.43.0
-troposphere
+troposphere>4
 urllib3==1.26.5
 Werkzeug==0.16.1
 wsgi-request-logger==0.4.6
-zappa
+zappa>0
 zipp==3.1.0

--- a/atd-cr3-api/requirements.txt
+++ b/atd-cr3-api/requirements.txt
@@ -27,14 +27,14 @@ python-dotenv==0.12.0
 python-jose==3.1.0
 python-slugify==4.0.0
 PyYAML==5.4
-requests>2
+requests==2.*
 rsa==4.7
 s3transfer==0.3.3
 six==1.14.0
 text-unidecode==1.3
 toml==0.10.0
 tqdm==4.43.0
-troposphere>4
+troposphere==4.*
 urllib3==1.26.5
 Werkzeug==0.16.1
 wsgi-request-logger==0.4.6

--- a/atd-cr3-api/requirements.txt
+++ b/atd-cr3-api/requirements.txt
@@ -1,6 +1,6 @@
 argcomplete==1.11.1
-boto3==1.17.53
-botocore==1.20.112
+boto3>1
+botocore>1
 certifi==2022.12.7
 cfn-flip==1.2.2
 chardet==3.0.4
@@ -27,7 +27,7 @@ python-dotenv==0.12.0
 python-jose==3.1.0
 python-slugify==4.0.0
 PyYAML==5.4
-requests==2.23.0
+requests>2
 rsa==4.7
 s3transfer==0.3.3
 six==1.14.0

--- a/atd-cr3-api/requirements.txt
+++ b/atd-cr3-api/requirements.txt
@@ -10,7 +10,7 @@ durationpy==0.5
 ecdsa==0.15
 Flask==1.1.1
 Flask-Cors==3.0.9
-future==0.18.2
+future==0.18.3
 hjson==3.0.1
 idna==2.9
 importlib-metadata==1.5.0

--- a/atd-cr3-api/requirements.txt
+++ b/atd-cr3-api/requirements.txt
@@ -1,7 +1,7 @@
 argcomplete==1.11.1
 boto3==1.17.53
 botocore==1.20.112
-certifi==2019.11.28
+certifi==2022.12.7
 cfn-flip==1.2.2
 chardet==3.0.4
 Click==7.0

--- a/atd-cr3-api/requirements.txt
+++ b/atd-cr3-api/requirements.txt
@@ -35,7 +35,7 @@ text-unidecode==1.3
 toml==0.10.0
 tqdm==4.43.0
 troposphere
-urllib3==1.25.8
+urllib3==1.26.5
 Werkzeug==0.16.1
 wsgi-request-logger==0.4.6
 zappa

--- a/atd-cr3-api/requirements.txt
+++ b/atd-cr3-api/requirements.txt
@@ -1,6 +1,6 @@
 argcomplete==1.11.1
-boto3
-botocore
+boto3==1.17.53
+botocore==1.20.112
 certifi==2019.11.28
 cfn-flip==1.2.2
 chardet==3.0.4

--- a/atd-cr3-api/requirements.txt
+++ b/atd-cr3-api/requirements.txt
@@ -38,5 +38,5 @@ troposphere>4
 urllib3==1.26.5
 Werkzeug==0.16.1
 wsgi-request-logger==0.4.6
-zappa>0
+zappa==0.*
 zipp==3.1.0

--- a/atd-events/crash_update_jurisdiction/requirements.txt
+++ b/atd-events/crash_update_jurisdiction/requirements.txt
@@ -1,4 +1,4 @@
-certifi==2020.4.5.1
+certifi==2022.12.7
 chardet==3.0.4
 idna==2.9
 requests==2.23.0

--- a/atd-events/crash_update_jurisdiction/requirements.txt
+++ b/atd-events/crash_update_jurisdiction/requirements.txt
@@ -2,4 +2,4 @@ certifi==2022.12.7
 chardet==3.0.4
 idna==2.9
 requests==2.23.0
-urllib3==1.25.9
+urllib3==1.26.5

--- a/atd-events/crash_update_jurisdiction/requirements.txt
+++ b/atd-events/crash_update_jurisdiction/requirements.txt
@@ -1,5 +1,5 @@
 certifi==2022.12.7
 chardet==3.0.4
 idna==2.9
-requests==2.23.0
+requests>2
 urllib3==1.26.5

--- a/atd-events/crash_update_jurisdiction/requirements.txt
+++ b/atd-events/crash_update_jurisdiction/requirements.txt
@@ -1,5 +1,5 @@
 certifi==2022.12.7
 chardet==3.0.4
 idna==2.9
-requests>2
+requests==2.*
 urllib3==1.26.5

--- a/atd-events/crash_update_location/requirements.txt
+++ b/atd-events/crash_update_location/requirements.txt
@@ -1,4 +1,4 @@
-certifi==2020.4.5.1
+certifi==2022.12.7
 chardet==3.0.4
 idna==2.9
 requests==2.26.0

--- a/atd-events/crash_update_noncr3_location/requirements.txt
+++ b/atd-events/crash_update_noncr3_location/requirements.txt
@@ -1,4 +1,4 @@
-certifi==2020.4.5.1
+certifi==2022.12.7
 chardet==3.0.4
 idna==2.9
 requests==2.23.0

--- a/atd-events/crash_update_noncr3_location/requirements.txt
+++ b/atd-events/crash_update_noncr3_location/requirements.txt
@@ -2,4 +2,4 @@ certifi==2022.12.7
 chardet==3.0.4
 idna==2.9
 requests==2.23.0
-urllib3==1.25.9
+urllib3==1.26.5

--- a/atd-events/crash_update_noncr3_location/requirements.txt
+++ b/atd-events/crash_update_noncr3_location/requirements.txt
@@ -1,5 +1,5 @@
 certifi==2022.12.7
 chardet==3.0.4
 idna==2.9
-requests==2.23.0
+requests>2
 urllib3==1.26.5

--- a/atd-events/crash_update_noncr3_location/requirements.txt
+++ b/atd-events/crash_update_noncr3_location/requirements.txt
@@ -1,5 +1,5 @@
 certifi==2022.12.7
 chardet==3.0.4
 idna==2.9
-requests>2
+requests==2.*
 urllib3==1.26.5

--- a/atd-toolbox/reposition_crashes_to_centroid_of_svrd_locations/requirements.txt
+++ b/atd-toolbox/reposition_crashes_to_centroid_of_svrd_locations/requirements.txt
@@ -1,4 +1,4 @@
-certifi==2021.5.30
+certifi==2022.12.7
 charset-normalizer==2.0.4
 idna==3.2
 requests==2.26.0

--- a/atd-toolbox/s3_restore_cr3_pdfs/requirements.txt
+++ b/atd-toolbox/s3_restore_cr3_pdfs/requirements.txt
@@ -1,6 +1,6 @@
 boto3==1.18.17
 botocore==1.21.17
-certifi==2021.5.30
+certifi==2022.12.7
 charset-normalizer==2.0.4
 filemagic==1.6
 idna==3.2


### PR DESCRIPTION
# Dependabot Round Up for the Vision Zero Suite's Python λ functions and toolbox utilities

## Associated issues

_none_

This PR intends to address dependabot PRs which are open for this repo that relate to python libraries. It does not bring all libraries up to their latest version, rather, it targets the minimal update that resolves the requested changes in the dependabot PRs.

Because this PR ventures into the `atd-toolbox` utilities, the branch name may have been better chosen as `dependabot-round-up-python`, but the primary focus is on our λ functions.

## Contents

This PR contains merge commits from dependabot including:

* [Bump urllib3 from 1.25.8 to 1.26.5 in /atd-cr3-api](https://github.com/cityofaustin/atd-vz-data/commit/88a8b1974bda7bc234a20998379f95616d43ba7a)
* [Bump urllib3 in /atd-events/crash_update_noncr3_location](https://github.com/cityofaustin/atd-vz-data/commit/3888f5bb23065c17930cac91cb53b9d3fb9efd2e)
* [Bump urllib3 in /atd-events/crash_update_jurisdiction](https://github.com/cityofaustin/atd-vz-data/commit/aa56ad82657464e7da7328acc3e174d469d37c96)
* [Bump certifi from 2019.11.28 to 2022.12.7 in /atd-cr3-api](https://github.com/cityofaustin/atd-vz-data/commit/fb0230eec021d9968f9754e07aa04929fddd2a6f)
* [Bump certifi from 2019.11.28 to 2022.12.7 in /atd-cr3-api](https://github.com/cityofaustin/atd-vz-data/commit/fb0230eec021d9968f9754e07aa04929fddd2a6f)
* [Bump certifi in /atd-events/crash_update_location](https://github.com/cityofaustin/atd-vz-data/commit/e4f0722075468279d68dc1f24299b73bb9af24a4)
* [Bump certifi in /atd-toolbox/s3_restore_cr3_pdfs](https://github.com/cityofaustin/atd-vz-data/commit/002bad50d0f21db77f833498afef737fd0bf7ddb)
* [Bump certifi](https://github.com/cityofaustin/atd-vz-data/commit/29374c733e393376cba52fa6ac6eb7df17da5c77)
* [Bump certifi in /atd-events/crash_update_jurisdiction](https://github.com/cityofaustin/atd-vz-data/commit/068bfcee3e95ce7604f532640710252f3726aafa)
* [Bump certifi in /atd-events/crash_update_noncr3_location](https://github.com/cityofaustin/atd-vz-data/commit/7deb3667ea5a69d9761339698b112d9be6f6a5fa)
* [Bump future from 0.18.2 to 0.18.3 in /atd-cr3-api](https://github.com/cityofaustin/atd-vz-data/commit/c2f2d981f1d39003f8342c5bf422dd0846894545)

Due to the nature of `pip freeze` outputting libraries pinned to a specific release and that output being used as `requirements.txt` files, there were various times in this process that I had to loosen other library version to accommodate dependabot's requested upgrades. @johnclary, I believe, has observed that there better ways to specify library version requirements, and I'd be eager for his input on how we may better do this in the future.

## Process

Each application has been tested to see that `pip install -r requirements.txt` completes successfully in a fresh virtual environment. Further, λ functions have been executed to check to see if they compile and run in those same virtual environments. Toolbox applications have not been run in their environments, due to fear of unexpected side effects. That said, they are generally one-off scripts, and if needed, it will be a reasonable ask of the developer to use them with consideration of their contents. 

Presently, our CI for building staging λ functions is non-functional. Please see https://github.com/cityofaustin/atd-data-tech/issues/11371. 

## Testing

Testing may consist of creating a virtual environment and checking if libraries can be installed based on the specification in the various affected `requirements.txt` files. Additionally, when the staging λ deployment is restored, we should check the functionality of these scripts as they interact with the VZE.

However, these functions do deploy in the context of this PR deploy preview, so that is promising. I do not yet have enough experience with this CI to want to venture to say that this constitutes the testing we need, but I am optimistic.

---
#### Ship list
- [x] ~Code reviewed~
- [ ] Product manager approved
