### PR TITLE
Check file type in CR3 download script before updating crash record and storing file in S3

### DIFF
--- a/atd-etl/Dockerfile
+++ b/atd-etl/Dockerfile
@@ -13,7 +13,7 @@ RUN apk add bash build-base python3-dev libffi-dev openssl-dev \
 #RUN apk update && apk add build-base python3-dev libffi-dev openssl-dev && pip3 install magic-wormhole
 
 RUN pip install cryptography==3.3.2 splinter selenium requests \
-    awscli web-pdb sodapy boto3 mail-parser
+    awscli web-pdb sodapy boto3 mail-parser filemagic==1.6
 
 WORKDIR /app
 

--- a/atd-etl/Dockerfile
+++ b/atd-etl/Dockerfile
@@ -13,7 +13,7 @@ RUN apk add bash build-base python3-dev libffi-dev openssl-dev \
 #RUN apk update && apk add build-base python3-dev libffi-dev openssl-dev && pip3 install magic-wormhole
 
 RUN pip install cryptography==3.3.2 splinter selenium requests \
-    awscli web-pdb sodapy boto3 mail-parser filemagic==1.6
+    awscli web-pdb sodapy boto3 mail-parser python-magic==0.4.27
 
 WORKDIR /app
 

--- a/atd-etl/Dockerfile
+++ b/atd-etl/Dockerfile
@@ -12,8 +12,8 @@ RUN apk add bash build-base python3-dev libffi-dev openssl-dev \
 # the following is helpful when developing using this image but is not needed for a production build
 #RUN apk update && apk add build-base python3-dev libffi-dev openssl-dev && pip3 install magic-wormhole
 
-RUN pip install cryptography==3.3.2 splinter selenium requests \
-    awscli web-pdb sodapy boto3 mail-parser python-magic==0.4.27
+RUN pip install cryptography==3.3.* splinter==0.* selenium==4.* requests==2.* \
+    awscli==1.* web-pdb==1.* sodapy==2.* boto3==1.* mail-parser==3.* python-magic==0.*
 
 WORKDIR /app
 

--- a/atd-etl/Dockerfile
+++ b/atd-etl/Dockerfile
@@ -12,8 +12,8 @@ RUN apk add bash build-base python3-dev libffi-dev openssl-dev \
 # the following is helpful when developing using this image but is not needed for a production build
 #RUN apk update && apk add build-base python3-dev libffi-dev openssl-dev && pip3 install magic-wormhole
 
-RUN pip install cryptography==3.3.* splinter==0.* selenium==4.* requests==2.* \
-    awscli==1.* web-pdb==1.* sodapy==2.* boto3==1.* mail-parser==3.* python-magic==0.*
+COPY requirements.txt /tmp/
+RUN pip install -r /tmp/requirements.txt
 
 WORKDIR /app
 

--- a/atd-etl/app/process/helpers_cr3.py
+++ b/atd-etl/app/process/helpers_cr3.py
@@ -154,10 +154,9 @@ def process_crash_cr3(crash_record, cookies):
 
         download_path = download_cr3(crash_id, cookies)
         is_file_pdf = check_if_pdf(download_path)
-        print(f"File is pdf: {is_file_pdf}")
 
         if not is_file_pdf:
-            print("File is not a pdf - skipping upload and update")
+            print(f"File {download_path} is not a pdf - skipping upload and update")
             return
         else:
             upload_cr3(crash_id)

--- a/atd-etl/app/process/helpers_cr3.py
+++ b/atd-etl/app/process/helpers_cr3.py
@@ -141,7 +141,7 @@ def check_if_pdf(file_path):
     return file_type == "application/pdf"
 
 
-def process_crash_cr3(crash_record, cookies):
+def process_crash_cr3(crash_record, cookies, skipped_uploads_and_updates):
     """
     Downloads a CR3 pdf, uploads it to s3, updates the database and deletes the pdf.
     :param crash_record: dict - The individual crash record being processed
@@ -153,10 +153,12 @@ def process_crash_cr3(crash_record, cookies):
         print("Processing Crash: " + crash_id)
 
         download_path = download_cr3(crash_id, cookies)
-        is_file_pdf = check_if_pdf(download_path)
+        # is_file_pdf = check_if_pdf(download_path)
+        is_file_pdf = False
 
         if not is_file_pdf:
-            print(f"File {download_path} is not a pdf - skipping upload and update")
+            print(f"\nFile {download_path} is not a pdf - skipping upload and update")
+            skipped_uploads_and_updates.append(crash_id)
             return
         else:
             upload_cr3(crash_id)

--- a/atd-etl/app/process/helpers_cr3.py
+++ b/atd-etl/app/process/helpers_cr3.py
@@ -133,7 +133,7 @@ def update_crash_id(crash_id):
 def check_if_pdf(file_path):
     """
     Checks if a file is a pdf
-    :param file: string - The file path
+    :param file_path: string - The file path
     :return: boolean - True if the file is a pdf
     """
     mime = magic.Magic(mime=True)
@@ -159,7 +159,6 @@ def process_crash_cr3(crash_record, cookies, skipped_uploads_and_updates):
         if not is_file_pdf:
             print(f"\nFile {download_path} is not a pdf - skipping upload and update")
             skipped_uploads_and_updates.append(crash_id)
-            return
         else:
             upload_cr3(crash_id)
             update_crash_id(crash_id)

--- a/atd-etl/app/process/helpers_cr3.py
+++ b/atd-etl/app/process/helpers_cr3.py
@@ -16,6 +16,7 @@ import subprocess
 import time
 from http.cookies import SimpleCookie
 
+import magic
 
 # We need to import our configuration, and the run_query method
 from .config import ATD_ETL_CONFIG

--- a/atd-etl/app/process/helpers_cr3.py
+++ b/atd-etl/app/process/helpers_cr3.py
@@ -64,6 +64,7 @@ def download_cr3(crash_id, cookies):
     resp = requests.get(url, allow_redirects=True, cookies=baked_cookies)
     open(download_path, 'wb').write(resp.content)
 
+    return download_path
 
 def upload_cr3(crash_id):
     """
@@ -129,6 +130,16 @@ def update_crash_id(crash_id):
     print(update_record_cr3)
     return run_query(update_record_cr3)
 
+def check_if_pdf(file):
+    """
+    Checks if a file is a pdf
+    :param file: string - The file path
+    :return: boolean - True if the file is a pdf
+    """
+    mime = magic.Magic(mime=True)
+    file_type = mime.from_file(file)
+    return file_type == "application/pdf"
+
 
 def process_crash_cr3(crash_record, cookies):
     """
@@ -141,9 +152,16 @@ def process_crash_cr3(crash_record, cookies):
 
         print("Processing Crash: " + crash_id)
 
-        download_cr3(crash_id, cookies)
-        upload_cr3(crash_id)
-        update_crash_id(crash_id)
+        download_path = download_cr3(crash_id, cookies)
+        is_file_pdf = check_if_pdf(download_path)
+
+        if not is_file_pdf:
+            print("File is not a pdf - skipping upload and update")
+            return
+        else:
+            upload_cr3(crash_id)
+            update_crash_id(crash_id)
+            
         delete_cr3s(crash_id)
 
     except Exception as e:

--- a/atd-etl/app/process/helpers_cr3.py
+++ b/atd-etl/app/process/helpers_cr3.py
@@ -130,14 +130,14 @@ def update_crash_id(crash_id):
     print(update_record_cr3)
     return run_query(update_record_cr3)
 
-def check_if_pdf(file):
+def check_if_pdf(file_path):
     """
     Checks if a file is a pdf
     :param file: string - The file path
     :return: boolean - True if the file is a pdf
     """
     mime = magic.Magic(mime=True)
-    file_type = mime.from_file(file)
+    file_type = mime.from_file(file_path)
     return file_type == "application/pdf"
 
 
@@ -154,6 +154,7 @@ def process_crash_cr3(crash_record, cookies):
 
         download_path = download_cr3(crash_id, cookies)
         is_file_pdf = check_if_pdf(download_path)
+        print(f"File is pdf: {is_file_pdf}")
 
         if not is_file_pdf:
             print("File is not a pdf - skipping upload and update")

--- a/atd-etl/app/process/helpers_cr3.py
+++ b/atd-etl/app/process/helpers_cr3.py
@@ -146,6 +146,7 @@ def process_crash_cr3(crash_record, cookies, skipped_uploads_and_updates):
     Downloads a CR3 pdf, uploads it to s3, updates the database and deletes the pdf.
     :param crash_record: dict - The individual crash record being processed
     :param cookies: dict - The cookies taken from the browser object
+    :param skipped_uploads_and_updates: list - Crash IDs of unsuccessful pdf downloads
     """
     try:
         crash_id = str(crash_record["crash_id"])
@@ -153,8 +154,7 @@ def process_crash_cr3(crash_record, cookies, skipped_uploads_and_updates):
         print("Processing Crash: " + crash_id)
 
         download_path = download_cr3(crash_id, cookies)
-        # is_file_pdf = check_if_pdf(download_path)
-        is_file_pdf = False
+        is_file_pdf = check_if_pdf(download_path)
 
         if not is_file_pdf:
             print(f"\nFile {download_path} is not a pdf - skipping upload and update")

--- a/atd-etl/app/process_cris_cr3.py
+++ b/atd-etl/app/process_cris_cr3.py
@@ -7,14 +7,10 @@ Description: This script allows the user to log in to the CRIS website
 and download CR3 pdf files as needed. The list of CR3 files to be downloaded
 is obtained from Hasura, and it is contingent to records that do not have
 any CR3 files associated.
-
-The application requires the splinter library, and the requests library:
-    https://splinter.readthedocs.io/en/latest/
 """
 
 import time
 import json
-import concurrent.futures
 
 from process.config import ATD_ETL_CONFIG
 from process.helpers_cr3 import *
@@ -55,18 +51,18 @@ try:
     crashes_list = response['data']['atd_txdot_crashes']
     print("\nList of crashes: %s" % json.dumps(crashes_list))
  
-    print("\nInitializing Execution Thread Pool:")
+    print("\nStarting CR3 downloads :")
 except Exception as e:
     crashes_list = []
     print("Error, could not run CR3 processing: " + str(e))
 
-with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
-    for crash_record in crashes_list:
-        executor.submit(process_crash_cr3, crash_record, CRIS_BROWSER_COOKIES, skipped_uploads_and_updates)
+
+for crash_record in crashes_list:
+    process_crash_cr3(crash_record, CRIS_BROWSER_COOKIES, skipped_uploads_and_updates)
 
 print("\nProcess done.")
 
-if len(skipped_uploads_and_updates) > 0:
+if skipped_uploads_and_updates:
     skipped_downloads = ", ".join(skipped_uploads_and_updates)
     print(f"\nUnable to download pdfs for crash IDs: {skipped_downloads}")
 

--- a/atd-etl/app/process_cris_cr3.py
+++ b/atd-etl/app/process_cris_cr3.py
@@ -40,6 +40,9 @@ print("Preparing download loop.")
 
 print("Gathering list of crashes.")
 crashes_list = []
+# Track crash IDs that we don't successfully retrieve a pdf file for
+skipped_uploads_and_updates = []
+
 try:
     print("Hasura endpoint: '%s' " % ATD_ETL_CONFIG["HASURA_ENDPOINT"])
     downloads_per_run = ATD_ETL_CONFIG["ATD_CRIS_CR3_DOWNLOADS_PER_RUN"]
@@ -59,9 +62,10 @@ except Exception as e:
 
 with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
     for crash_record in crashes_list:
-        executor.submit(process_crash_cr3, crash_record, CRIS_BROWSER_COOKIES)
+        executor.submit(process_crash_cr3, crash_record, CRIS_BROWSER_COOKIES, skipped_uploads_and_updates)
 
-print("\nProcess done.")
+skipped_downloads = ", ".join(skipped_uploads_and_updates)
+print(f"\nProcess done. \nUnable to download pdfs for crash IDs: {skipped_downloads}\n")
 
 end = time.time()
 hours, rem = divmod(end-start, 3600)

--- a/atd-etl/app/process_cris_cr3.py
+++ b/atd-etl/app/process_cris_cr3.py
@@ -51,7 +51,7 @@ try:
     crashes_list = response['data']['atd_txdot_crashes']
     print("\nList of crashes: %s" % json.dumps(crashes_list))
  
-    print("\nStarting CR3 downloads :")
+    print("\nStarting CR3 downloads:")
 except Exception as e:
     crashes_list = []
     print("Error, could not run CR3 processing: " + str(e))

--- a/atd-etl/app/process_cris_cr3.py
+++ b/atd-etl/app/process_cris_cr3.py
@@ -64,10 +64,13 @@ with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
     for crash_record in crashes_list:
         executor.submit(process_crash_cr3, crash_record, CRIS_BROWSER_COOKIES, skipped_uploads_and_updates)
 
-skipped_downloads = ", ".join(skipped_uploads_and_updates)
-print(f"\nProcess done. \nUnable to download pdfs for crash IDs: {skipped_downloads}\n")
+print("\nProcess done.")
+
+if len(skipped_uploads_and_updates) > 0:
+    skipped_downloads = ", ".join(skipped_uploads_and_updates)
+    print(f"\nUnable to download pdfs for crash IDs: {skipped_downloads}")
 
 end = time.time()
 hours, rem = divmod(end-start, 3600)
 minutes, seconds = divmod(rem, 60)
-print("Finished in: {:0>2}:{:0>2}:{:05.2f}".format(int(hours),int(minutes),seconds))
+print("\nFinished in: {:0>2}:{:0>2}:{:05.2f}".format(int(hours),int(minutes),seconds))

--- a/atd-etl/requirements.txt
+++ b/atd-etl/requirements.txt
@@ -1,0 +1,10 @@
+cryptography==3.3.*
+splinter==0.*
+selenium==4.*
+requests==2.*
+awscli==1.*
+web-pdb==1.*
+sodapy==2.*
+boto3==1.*
+mail-parser==3.*
+python-magic==0.*


### PR DESCRIPTION
## Associated issues
https://github.com/cityofaustin/atd-data-tech/issues/8711

This PR updates the CR3 download script to check the mime type of the file downloaded for each crash before storing them and updating the DB to show that it has been processed. This will help us avoid seeing errors in VZE where a valid CR3 pdf cannot be shown for a record that appears to have one. Open to any and all feedback about the logging. 🙏 

## Testing
**URL to test:** <!-- VZ URL or Netlify -->
Local

**Steps to test:**
It isn't easy to make a real non-pdf CR3 download happen so we can simulate it by running the script locally and making the script think a non-pdf has been downloaded. To do this, follow the steps below. You can also see the screenshots below to see the output for invalid and valid CR3 files below without running this locally.

1. Using the production read replica, find a crash record ID that has a non-pdf file stored in S3 by running this statement:
```sql
SELECT
	*
FROM
	atd_txdot_crashes
WHERE
	cr3_file_metadata->>'mime_type' = 'text/html'
```
2. ⚠️ **Very carefully** ⚠️  (or ping me if you would like me to handle this part - happy to take this on and give you a crash record to look for when running the script), connect to the production VZ database and update one of the records that you found to make the script see it as non-processed using this statement:
```sql
UPDATE
	atd_txdot_crashes
SET
	cr3_stored_flag = 'N',
	cr3_file_metadata = NULL,
	cr3_ocr_extraction_date = NULL
WHERE
	crash_id = <the crash record that you found>
```
4. Now that the script will recognize this crash ID as not processed yet, modify [this line](https://github.com/cityofaustin/atd-vz-data/blob/494c482940e721ed4d3db83c02e904f1b5393c4b/atd-etl/app/process/helpers_cr3.py#L157) to read as follows:
```python
is_file_pdf = False
```
5. This will make the file type appear to be non-pdf so we can test that path of the code. You can run the script by following [these steps](https://app.gitbook.com/o/-LzDQOVGhTudbKRDGpUA/s/-M4Ul-hSBiM-3KkOynqS/vision-zero-crash-database/cr3-download-script).
6. You should see the script log that the file upload and crash record update was skipped for this record and also see a list containing this crash ID print at the end of the script.
7. Now that you have tested an invalid CR3 pdf, update [this line](https://github.com/cityofaustin/atd-vz-data/blob/494c482940e721ed4d3db83c02e904f1b5393c4b/atd-etl/app/process/helpers_cr3.py#L157) back from the change made above.
8. Run the script again and the valid CR3 will upload and the crash record will be updated to show that it is processed.
 
## Screenshots

### Script handling a non-pdf CR3 download ❌
<img width="865" alt="Screenshot 2023-02-06 at 11 31 23 AM" src="https://user-images.githubusercontent.com/37249039/217043210-f5213635-6536-4db3-affd-8df67184d7b1.png">

### Script handling a pdf CR3 download ✅ 
<img width="871" alt="Screenshot 2023-02-06 at 11 12 24 AM" src="https://user-images.githubusercontent.com/37249039/217041474-7811b045-c2f3-4025-b33d-f38cc666fcc7.png">

---
#### Ship list
- [x] Code reviewed
- [ ] Product manager approved
