### PR TITLE
manually adjust 2022 pedestrian fatalities

### DIFF
--- a/atd-vzv/src/views/summary/CrashesByMode.js
+++ b/atd-vzv/src/views/summary/CrashesByMode.js
@@ -134,6 +134,15 @@ const CrashesByMode = () => {
       }, 0);
     });
 
+  const adjustModeData = (modeData) => {
+    // TEMPORARY MEASURE!!
+    // Manually adjust mode data displayed for 2022 pedestrian fatalities to match VZ Team's analysis
+    if (crashType.name === "fatalitiesAndSeriousInjuries" || crashType.name === "fatalities") {
+      modeData[1].data[3] = modeData[1].data[3] + 1
+    }
+    return modeData;
+  }
+
   // Sort mode order in stack and apply colors by averaging total mode fatalities across all years in chart
   const sortAndColorModeData = (modeData) => {
     modeData.forEach((category, i) => {
@@ -143,7 +152,7 @@ const CrashesByMode = () => {
       category.hoverBackgroundColor = color;
       category.hoverBorderColor = color;
     });
-    return modeData;
+    return adjustModeData(modeData);
   };
 
   // Create dataset for each mode type, data property is an array of fatality sums sorted chronologically


### PR DESCRIPTION
## Associated issues
fixes https://github.com/cityofaustin/atd-data-tech/issues/11391

this simple helper function is a temporary measure to reconcile the data displayed in VZV with the data the VZ Team is using based on their analyses. ultimately the data responsible for the discrepancy will be reconfigurable via the Layer Data Model, at which point this function will need to be removed. by its nature, this code goes against established patterns by hardcoding (in this case incrementing) changes to specific fields in the data display, but i did not see an alternative and did not want to spend too much time on this since it is a temporary measure. however, I welcome any comments to improve this code!

## Testing
**URL to test:** <!-- VZ URL or Netlify -->
https://deploy-preview-1175--atd-vzv-staging.netlify.app/

**Steps to test:**
- compare prod and deploy preview
- 2022 pedestrian fatalities in deploy preview should be 136 (all) and 48 (fatalities), incremented by one over prod
- all other numbers should be unchanged

before
<img width="627" alt="Screen Shot 2023-02-09 at 12 52 25 PM" src="https://user-images.githubusercontent.com/35410637/217911443-48ece998-f799-4231-ae3b-2afdb5e760eb.png">

after
<img width="627" alt="Screen Shot 2023-02-09 at 12 52 38 PM" src="https://user-images.githubusercontent.com/35410637/217911493-5b4486a3-3faf-4beb-8fea-65c5725cae11.png">

before
<img width="626" alt="Screen Shot 2023-02-09 at 12 52 47 PM" src="https://user-images.githubusercontent.com/35410637/217911533-bdc4dce5-b1d1-4abe-9da7-ac85ed658225.png">

after
<img width="628" alt="Screen Shot 2023-02-09 at 12 53 18 PM" src="https://user-images.githubusercontent.com/35410637/217911578-20c1ad72-f6a5-4094-becd-93e4cc1a6d6a.png">

before
<img width="629" alt="Screen Shot 2023-02-09 at 12 53 30 PM" src="https://user-images.githubusercontent.com/35410637/217911631-9ecba235-c0d5-4fda-be84-d1848b3f8c5d.png">

after (no change)
<img width="634" alt="Screen Shot 2023-02-09 at 12 53 38 PM" src="https://user-images.githubusercontent.com/35410637/217911712-51388da3-b1a6-43f7-85b4-b942a955a209.png">

---
#### Ship list
- [x] Code reviewed
- [ ] Product manager approved
