### PR TITLE
Add list of skippable crash IDs to CR3 download script

### DIFF
--- a/atd-etl/app/process_cris_cr3.py
+++ b/atd-etl/app/process_cris_cr3.py
@@ -35,9 +35,15 @@ CRIS_BROWSER_COOKIES = input('Please login to CRIS and extract the contents of t
 print("Preparing download loop.")
 
 print("Gathering list of crashes.")
-crashes_list = []
 # Track crash IDs that we don't successfully retrieve a pdf file for
 skipped_uploads_and_updates = []
+
+# Some crash IDs were manually added at the request of the VZ team so
+# CR3s for these crash IDs are not available in the CRIS database.
+# We can skip requesting them.
+known_skips = ["180290542"]
+
+crashes_list_without_skips = []
 
 try:
     print("Hasura endpoint: '%s' " % ATD_ETL_CONFIG["HASURA_ENDPOINT"])
@@ -50,14 +56,18 @@ try:
 
     crashes_list = response['data']['atd_txdot_crashes']
     print("\nList of crashes: %s" % json.dumps(crashes_list))
+
+    crashes_list_without_skips = [
+        x for x in crashes_list if x["crash_id"] not in known_skips
+    ]
  
     print("\nStarting CR3 downloads:")
 except Exception as e:
-    crashes_list = []
+    crashes_list_without_skips = []
     print("Error, could not run CR3 processing: " + str(e))
 
 
-for crash_record in crashes_list:
+for crash_record in crashes_list_without_skips:
     process_crash_cr3(crash_record, CRIS_BROWSER_COOKIES, skipped_uploads_and_updates)
 
 print("\nProcess done.")

--- a/atd-etl/app/process_cris_cr3.py
+++ b/atd-etl/app/process_cris_cr3.py
@@ -42,7 +42,7 @@ skipped_uploads_and_updates = []
 # CR3s for these crash IDs are not available in the CRIS database.
 # We can skip requesting them.
 # See https://github.com/cityofaustin/atd-data-tech/issues/9786
-known_skips = ["180290542"]
+known_skips = [180290542]
 
 crashes_list_without_skips = []
 
@@ -56,11 +56,11 @@ try:
     print("\nResponse from Hasura: %s" % json.dumps(response))
 
     crashes_list = response['data']['atd_txdot_crashes']
-    print("\nList of crashes: %s" % json.dumps(crashes_list))
 
     crashes_list_without_skips = [
         x for x in crashes_list if x["crash_id"] not in known_skips
     ]
+    print("\nList of crashes needing CR3 download: %s" % json.dumps(crashes_list_without_skips))
  
     print("\nStarting CR3 downloads:")
 except Exception as e:

--- a/atd-etl/app/process_cris_cr3.py
+++ b/atd-etl/app/process_cris_cr3.py
@@ -41,6 +41,7 @@ skipped_uploads_and_updates = []
 # Some crash IDs were manually added at the request of the VZ team so
 # CR3s for these crash IDs are not available in the CRIS database.
 # We can skip requesting them.
+# See https://github.com/cityofaustin/atd-data-tech/issues/9786
 known_skips = ["180290542"]
 
 crashes_list_without_skips = []


### PR DESCRIPTION
## Associated issues
https://github.com/cityofaustin/atd-data-tech/issues/9786

This PR adds a list of crash IDs that are skipped when requesting CR3 pdfs. I'd appreciate any feedback on the naming. 🙏

## Testing
**URL to test:** <!-- VZ URL or Netlify -->
Local only

**Steps to test:**
1. Checkout this branch locally
2. Follow the steps in the [CR3 download docs](https://app.gitbook.com/o/-LzDQOVGhTudbKRDGpUA/s/-M4Ul-hSBiM-3KkOynqS/vision-zero-crash-database/cr3-download-script)
3. You should see that the script no longer logs `Unable to download pdfs for crash IDs: 16529633, 180290542, 14683802, 12582284` every time it runs (3 of those records were deleted from VZDB and the fourth is skipped by the code in this diff)

### Example script output if there are no new CR3s to retrieve
```bash
Response from Hasura: {"data": {"atd_txdot_crashes": [{"crash_id": 180290542}]}}

List of crashes needing CR3 download: []

Starting CR3 downloads:

Process done.

Finished in: 00:06:29.54
```

---
#### Ship list
- [x] Code reviewed
- [x] Product manager approved
