### PR TITLE
Databases trigger on crashes table to update/delete/insert fatalities records

### DIFF
--- a/atd-vzd/schema/atd_txdot_crashes.sql
+++ b/atd-vzd/schema/atd_txdot_crashes.sql
@@ -2,10 +2,8 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 10.6
--- Dumped by pg_dump version 10.10
-
--- Started on 2019-10-15 13:48:23 CDT
+-- Dumped from database version 14.6 (Debian 14.6-1.pgdg110+1)
+-- Dumped by pg_dump version 14.7 (Ubuntu 14.7-0ubuntu0.22.04.1)
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
@@ -20,15 +18,14 @@ SET row_security = off;
 
 SET default_tablespace = '';
 
-SET default_with_oids = false;
+SET default_table_access_method = heap;
 
 --
--- TOC entry 219 (class 1259 OID 2345633)
--- Name: atd_txdot_crashes; Type: TABLE; Schema: public; Owner: atd_vz_data
+-- Name: atd_txdot_crashes; Type: TABLE; Schema: public; Owner: visionzero
 --
 
 CREATE TABLE public.atd_txdot_crashes (
-    crash_id integer,
+    crash_id integer NOT NULL,
     crash_fatal_fl character varying(1),
     cmv_involv_fl character varying(1),
     schl_bus_fl character varying(1),
@@ -219,84 +216,215 @@ CREATE TABLE public.atd_txdot_crashes (
     address_confirmed_secondary text,
     est_comp_cost numeric(10,2) DEFAULT 0.00,
     est_econ_cost numeric(10,2) DEFAULT 0.00,
-    "position" public.geometry,
+    "position" public.geometry(Geometry,4326),
     apd_confirmed_fatality character varying(1) DEFAULT 'N'::character varying NOT NULL,
     apd_confirmed_death_count integer,
-    micromobility_device_flag character varying(1) DEFAULT 'N'::character varying NOT NULL
+    micromobility_device_flag character varying(1) DEFAULT 'N'::character varying NOT NULL,
+    cr3_stored_flag character varying(1) DEFAULT 'N'::character varying NOT NULL,
+    apd_human_update character varying DEFAULT 'N'::character varying NOT NULL,
+    speed_mgmt_points numeric(10,2) DEFAULT 0.00,
+    geocode_match_quality numeric,
+    geocode_match_metadata json,
+    atd_mode_category_metadata json,
+    location_id character varying,
+    changes_approved_date timestamp without time zone,
+    austin_full_purpose character varying(1) DEFAULT 'N'::character varying NOT NULL,
+    original_city_id integer,
+    atd_fatality_count integer,
+    temp_record boolean DEFAULT false,
+    cr3_file_metadata jsonb,
+    cr3_ocr_extraction_date timestamp with time zone,
+    investigator_narrative_ocr text,
+    est_comp_cost_crash_based numeric(10,2) DEFAULT 0,
+    imported_at timestamp without time zone DEFAULT now()
 );
 
 
-ALTER TABLE public.atd_txdot_crashes OWNER TO atd_vz_data;
+ALTER TABLE public.atd_txdot_crashes OWNER TO visionzero;
 
 --
--- TOC entry 5627 (class 1259 OID 2348640)
--- Name: atd_txdot_crashes_apd_confirmed_fatality_index; Type: INDEX; Schema: public; Owner: atd_vz_data
+-- Name: atd_txdot_crashes atd_txdot_crashes_pkey; Type: CONSTRAINT; Schema: public; Owner: visionzero
+--
+
+ALTER TABLE ONLY public.atd_txdot_crashes
+    ADD CONSTRAINT atd_txdot_crashes_pkey PRIMARY KEY (crash_id);
+
+
+--
+-- Name: atd_txdot_crashes_apd_confirmed_fatality_index; Type: INDEX; Schema: public; Owner: visionzero
 --
 
 CREATE INDEX atd_txdot_crashes_apd_confirmed_fatality_index ON public.atd_txdot_crashes USING btree (apd_confirmed_fatality);
 
 
 --
--- TOC entry 5628 (class 1259 OID 2346767)
--- Name: atd_txdot_crashes_geocode_provider_index; Type: INDEX; Schema: public; Owner: atd_vz_data
+-- Name: atd_txdot_crashes_austin_full_purpose_index; Type: INDEX; Schema: public; Owner: visionzero
+--
+
+CREATE INDEX atd_txdot_crashes_austin_full_purpose_index ON public.atd_txdot_crashes USING btree (austin_full_purpose);
+
+
+--
+-- Name: atd_txdot_crashes_case_id_index; Type: INDEX; Schema: public; Owner: visionzero
+--
+
+CREATE INDEX atd_txdot_crashes_case_id_index ON public.atd_txdot_crashes USING btree (case_id);
+
+
+--
+-- Name: atd_txdot_crashes_city_id_index; Type: INDEX; Schema: public; Owner: visionzero
+--
+
+CREATE INDEX atd_txdot_crashes_city_id_index ON public.atd_txdot_crashes USING btree (city_id);
+
+
+--
+-- Name: atd_txdot_crashes_cr3_file_metadata_index; Type: INDEX; Schema: public; Owner: visionzero
+--
+
+CREATE INDEX atd_txdot_crashes_cr3_file_metadata_index ON public.atd_txdot_crashes USING gin (cr3_file_metadata);
+
+
+--
+-- Name: atd_txdot_crashes_cr3_stored_flag_index; Type: INDEX; Schema: public; Owner: visionzero
+--
+
+CREATE INDEX atd_txdot_crashes_cr3_stored_flag_index ON public.atd_txdot_crashes USING btree (cr3_stored_flag);
+
+
+--
+-- Name: atd_txdot_crashes_crash_date_index; Type: INDEX; Schema: public; Owner: visionzero
+--
+
+CREATE INDEX atd_txdot_crashes_crash_date_index ON public.atd_txdot_crashes USING btree (crash_date);
+
+
+--
+-- Name: atd_txdot_crashes_crash_fatal_fl_index; Type: INDEX; Schema: public; Owner: visionzero
+--
+
+CREATE INDEX atd_txdot_crashes_crash_fatal_fl_index ON public.atd_txdot_crashes USING btree (crash_fatal_fl);
+
+
+--
+-- Name: atd_txdot_crashes_death_cnt_index; Type: INDEX; Schema: public; Owner: visionzero
+--
+
+CREATE INDEX atd_txdot_crashes_death_cnt_index ON public.atd_txdot_crashes USING btree (death_cnt);
+
+
+--
+-- Name: atd_txdot_crashes_geocode_provider_index; Type: INDEX; Schema: public; Owner: visionzero
 --
 
 CREATE INDEX atd_txdot_crashes_geocode_provider_index ON public.atd_txdot_crashes USING btree (geocode_provider);
 
 
 --
--- TOC entry 5629 (class 1259 OID 2346768)
--- Name: atd_txdot_crashes_geocode_status_index; Type: INDEX; Schema: public; Owner: atd_vz_data
+-- Name: atd_txdot_crashes_geocode_status_index; Type: INDEX; Schema: public; Owner: visionzero
 --
 
 CREATE INDEX atd_txdot_crashes_geocode_status_index ON public.atd_txdot_crashes USING btree (geocode_status);
 
 
 --
--- TOC entry 5630 (class 1259 OID 2346769)
--- Name: atd_txdot_crashes_geocoded_index; Type: INDEX; Schema: public; Owner: atd_vz_data
+-- Name: atd_txdot_crashes_geocoded_index; Type: INDEX; Schema: public; Owner: visionzero
 --
 
 CREATE INDEX atd_txdot_crashes_geocoded_index ON public.atd_txdot_crashes USING btree (geocoded);
 
 
 --
--- TOC entry 5631 (class 1259 OID 2346770)
--- Name: atd_txdot_crashes_is_retired_index; Type: INDEX; Schema: public; Owner: atd_vz_data
+-- Name: atd_txdot_crashes_investigat_agency_id_index; Type: INDEX; Schema: public; Owner: visionzero
+--
+
+CREATE INDEX atd_txdot_crashes_investigat_agency_id_index ON public.atd_txdot_crashes USING btree (investigat_agency_id);
+
+
+--
+-- Name: atd_txdot_crashes_is_retired_index; Type: INDEX; Schema: public; Owner: visionzero
 --
 
 CREATE INDEX atd_txdot_crashes_is_retired_index ON public.atd_txdot_crashes USING btree (is_retired);
 
 
 --
--- TOC entry 5632 (class 1259 OID 2346771)
--- Name: atd_txdot_crashes_qa_status_index; Type: INDEX; Schema: public; Owner: atd_vz_data
+-- Name: atd_txdot_crashes_original_city_id_index; Type: INDEX; Schema: public; Owner: visionzero
+--
+
+CREATE INDEX atd_txdot_crashes_original_city_id_index ON public.atd_txdot_crashes USING btree (original_city_id);
+
+
+--
+-- Name: atd_txdot_crashes_position_index; Type: INDEX; Schema: public; Owner: visionzero
+--
+
+CREATE INDEX atd_txdot_crashes_position_index ON public.atd_txdot_crashes USING gist ("position");
+
+
+--
+-- Name: atd_txdot_crashes_qa_status_index; Type: INDEX; Schema: public; Owner: visionzero
 --
 
 CREATE INDEX atd_txdot_crashes_qa_status_index ON public.atd_txdot_crashes USING btree (qa_status);
 
 
 --
--- TOC entry 5633 (class 1259 OID 2346795)
--- Name: idx_atd_txdot_crashes_crash_id; Type: INDEX; Schema: public; Owner: atd_vz_data
+-- Name: atd_txdot_crashes_sus_serious_injry_cnt_index; Type: INDEX; Schema: public; Owner: visionzero
 --
 
-CREATE UNIQUE INDEX idx_atd_txdot_crashes_crash_id ON public.atd_txdot_crashes USING btree (crash_id);
+CREATE INDEX atd_txdot_crashes_sus_serious_injry_cnt_index ON public.atd_txdot_crashes USING btree (sus_serious_injry_cnt);
 
 
 --
--- TOC entry 5634 (class 2620 OID 2346813)
--- Name: atd_txdot_crashes atd_txdot_crashes_audit_log; Type: TRIGGER; Schema: public; Owner: atd_vz_data
+-- Name: atd_txdot_crashes_temp_record_index; Type: INDEX; Schema: public; Owner: visionzero
 --
 
-CREATE TRIGGER atd_txdot_crashes_audit_log BEFORE INSERT OR UPDATE ON public.atd_txdot_crashes FOR EACH ROW EXECUTE PROCEDURE public.atd_txdot_crashes_updates_audit_log();
-
-ALTER TABLE public.atd_txdot_crashes DISABLE TRIGGER atd_txdot_crashes_audit_log;
+CREATE INDEX atd_txdot_crashes_temp_record_index ON public.atd_txdot_crashes USING btree (temp_record);
 
 
--- Completed on 2019-10-15 13:48:26 CDT
+--
+-- Name: atd_txdot_crashes atd_txdot_crashes_audit_log; Type: TRIGGER; Schema: public; Owner: visionzero
+--
+
+CREATE TRIGGER atd_txdot_crashes_audit_log BEFORE INSERT OR UPDATE ON public.atd_txdot_crashes FOR EACH ROW EXECUTE FUNCTION public.atd_txdot_crashes_updates_audit_log();
+
+
+--
+-- Name: atd_txdot_crashes atd_txdot_crashes_update_fatalities; Type: TRIGGER; Schema: public; Owner: visionzero
+--
+
+CREATE TRIGGER atd_txdot_crashes_update_fatalities AFTER UPDATE ON public.atd_txdot_crashes FOR EACH ROW EXECUTE FUNCTION public.update_fatalities_on_crash_update();
+
+
+--
+-- Name: atd_txdot_crashes notify_hasura_jurisdiction_from_latlon_INSERT; Type: TRIGGER; Schema: public; Owner: visionzero
+--
+
+CREATE TRIGGER "notify_hasura_jurisdiction_from_latlon_INSERT" AFTER INSERT ON public.atd_txdot_crashes FOR EACH ROW EXECUTE FUNCTION hdb_catalog."notify_hasura_jurisdiction_from_latlon_INSERT"();
+
+
+--
+-- Name: atd_txdot_crashes notify_hasura_jurisdiction_from_latlon_UPDATE; Type: TRIGGER; Schema: public; Owner: visionzero
+--
+
+CREATE TRIGGER "notify_hasura_jurisdiction_from_latlon_UPDATE" AFTER UPDATE ON public.atd_txdot_crashes FOR EACH ROW EXECUTE FUNCTION hdb_catalog."notify_hasura_jurisdiction_from_latlon_UPDATE"();
+
+
+--
+-- Name: atd_txdot_crashes notify_hasura_location_from_latlon_INSERT; Type: TRIGGER; Schema: public; Owner: visionzero
+--
+
+CREATE TRIGGER "notify_hasura_location_from_latlon_INSERT" AFTER INSERT ON public.atd_txdot_crashes FOR EACH ROW EXECUTE FUNCTION hdb_catalog."notify_hasura_location_from_latlon_INSERT"();
+
+
+--
+-- Name: atd_txdot_crashes notify_hasura_location_from_latlon_UPDATE; Type: TRIGGER; Schema: public; Owner: visionzero
+--
+
+CREATE TRIGGER "notify_hasura_location_from_latlon_UPDATE" AFTER UPDATE ON public.atd_txdot_crashes FOR EACH ROW EXECUTE FUNCTION hdb_catalog."notify_hasura_location_from_latlon_UPDATE"();
+
 
 --
 -- PostgreSQL database dump complete
 --
-

--- a/atd-vzd/triggers/update_fatalities_on_crash_update.sql
+++ b/atd-vzd/triggers/update_fatalities_on_crash_update.sql
@@ -18,7 +18,7 @@ AS $function$
                 -- if person is not in fatalities table but is in austin then add them
                 IF (NOT EXISTS (SELECT person_id FROM fatalities WHERE person_id = person.person_id) AND ST_CONTAINS((SELECT geometry FROM atd_jurisdictions WHERE atd_jurisdictions.id = 5), NEW.position)) THEN
                     INSERT INTO fatalities (crash_id, person_id, year, location)
-                    VALUES (NEW.crash_id, NEW.person_id, TO_CHAR(NEW.crash_date,'yyyy'), CONCAT_WS(' ', NEW.rpt_block_num, NEW.rpt_street_pfx, NEW.rpt_street_name, '(', NEW.rpt_sec_block_num, NEW.rpt_sec_street_pfx, NEW.rpt_sec_street_name, ')'));
+                    VALUES (NEW.crash_id, person.person_id, TO_CHAR(NEW.crash_date,'yyyy'), CONCAT_WS(' ', NEW.rpt_block_num, NEW.rpt_street_pfx, NEW.rpt_street_name, '(', NEW.rpt_sec_block_num, NEW.rpt_sec_street_pfx, NEW.rpt_sec_street_name, ')'));
                 END IF;
                 -- if person is in fatalities table but not in austin then remove them
                 IF (EXISTS (SELECT person_id FROM fatalities WHERE person_id = person.person_id) AND NOT ST_CONTAINS((SELECT geometry FROM atd_jurisdictions WHERE atd_jurisdictions.id = 5), NEW.position)) THEN

--- a/atd-vzd/triggers/update_fatalities_on_crash_update.sql
+++ b/atd-vzd/triggers/update_fatalities_on_crash_update.sql
@@ -1,0 +1,61 @@
+
+-- This function is triggered by updates to a crash. If the crash position changes to be outside of Austin Full Purpose,
+-- any associated fatalities will be removed from the fatalities table.
+-- If the crash position changes to inside AFP and has fatalities associated with it, records will be added to the fatalities table.
+-- Changes to the date and location columns will also be reflected in any associated fatality records.
+CREATE OR REPLACE FUNCTION update_fatalities_on_crash_update() 
+    RETURNS trigger
+    LANGUAGE plpgsql
+AS $function$
+    DECLARE
+        primary_person record;
+        person record;
+    BEGIN
+        -- check if the position was updated
+        IF (OLD.position IS DISTINCT FROM NEW.position) THEN
+            -- loop through fatalities in person table if there are any
+            FOR person IN (SELECT person_id FROM atd_txdot_person WHERE crash_id = NEW.crash_id AND prsn_injry_sev_id = 4) loop
+                -- if person is not in fatalities table but is in austin then add them
+                IF (NOT EXISTS (SELECT person_id FROM fatalities WHERE person_id = person.person_id) AND ST_CONTAINS((SELECT geometry FROM atd_jurisdictions WHERE atd_jurisdictions.id = 5), NEW.position)) THEN
+                    INSERT INTO fatalities (crash_id, person_id, year, location)
+                    VALUES (NEW.crash_id, NEW.person_id, TO_CHAR(NEW.crash_date,'yyyy'), CONCAT_WS(' ', NEW.rpt_block_num, NEW.rpt_street_pfx, NEW.rpt_street_name, '(', NEW.rpt_sec_block_num, NEW.rpt_sec_street_pfx, NEW.rpt_sec_street_name, ')'));
+                END IF;
+                -- if person is in fatalities table but not in austin then remove them
+                IF (EXISTS (SELECT person_id FROM fatalities WHERE person_id = person.person_id) AND NOT ST_CONTAINS((SELECT geometry FROM atd_jurisdictions WHERE atd_jurisdictions.id = 5), NEW.position)) THEN
+                    DELETE FROM fatalities WHERE person_id = person.person_id;
+                END IF;
+            end loop;
+            -- loop through fatalities in primary person table if there are any
+            FOR primary_person IN (SELECT primaryperson_id FROM atd_txdot_primaryperson WHERE crash_id = NEW.crash_id AND prsn_injry_sev_id = 4) loop
+                -- if person is not in fatalities table but is in austin then add them
+                IF (NOT EXISTS (SELECT primaryperson_id FROM fatalities WHERE primaryperson_id = primary_person.primaryperson_id) AND ST_CONTAINS((SELECT geometry FROM atd_jurisdictions WHERE atd_jurisdictions.id = 5), NEW.position)) THEN
+                    INSERT INTO fatalities (crash_id, primaryperson_id, year, location)
+                    VALUES (NEW.crash_id, primary_person.primaryperson_id, TO_CHAR(NEW.crash_date,'yyyy'), CONCAT_WS(' ', NEW.rpt_block_num, NEW.rpt_street_pfx, NEW.rpt_street_name, '(', NEW.rpt_sec_block_num, NEW.rpt_sec_street_pfx, NEW.rpt_sec_street_name, ')'));
+                END IF;
+                -- if person is in fatalities table but not in austin then remove them
+                IF (EXISTS (SELECT primaryperson_id FROM fatalities WHERE primaryperson_id = primary_person.primaryperson_id) AND NOT ST_CONTAINS((SELECT geometry FROM atd_jurisdictions WHERE atd_jurisdictions.id = 5), NEW.position)) THEN
+                    DELETE FROM fatalities WHERE primaryperson_id = primary_person.primaryperson_id;
+                END IF;
+            end loop;
+        END IF;
+        -- if the crash date was updated then update the year column in the fatalities table
+        IF (OLD.crash_date IS DISTINCT FROM NEW.crash_date) THEN
+            UPDATE fatalities
+                SET year = TO_CHAR(NEW.crash_date,'yyyy')
+                WHERE crash_id = NEW.crash_id;
+        END IF;
+        -- if any of the location columns were updated then update the location column in the fatalities table
+        IF (NEW.rpt_block_num IS DISTINCT FROM OLD.rpt_block_num
+        OR NEW.rpt_street_pfx IS DISTINCT FROM OLD.rpt_street_pfx
+        OR NEW.rpt_street_name IS DISTINCT FROM OLD.rpt_street_name
+        OR NEW.rpt_sec_block_num IS DISTINCT FROM OLD.rpt_sec_block_num
+        OR NEW.rpt_sec_street_pfx IS DISTINCT FROM OLD.rpt_sec_street_pfx
+        OR NEW.rpt_sec_street_name IS DISTINCT FROM OLD.rpt_sec_street_name) THEN
+            UPDATE fatalities
+                SET location = CONCAT_WS(' ', NEW.rpt_block_num, NEW.rpt_street_pfx, NEW.rpt_street_name, '(', NEW.rpt_sec_block_num, NEW.rpt_sec_street_pfx, NEW.rpt_sec_street_name, ')')
+                WHERE crash_id = NEW.crash_id;
+        END IF;
+    RETURN NEW;
+    END
+$function$
+;


### PR DESCRIPTION
## Associated issues
Closes cityofaustin/atd-data-tech/issues/11649

## Testing
**URL to test:** <!-- VZ URL or Netlify -->
Use a local VZ DB environment

Test this after testing cityofaustin/atd-vz-data/pull/1179 and cityofaustin/atd-vz-data/pull/1181

**Steps to test:**
1. Checkout this branch locally
2. In the root of the branch follow instructions in the README to start up a local instance of the VZ stack and `./vision-zero vze-up`
3. Make sure you un-comment [this](https://github.com/cityofaustin/atd-vz-data/blob/e09b9ad73c9c5e5880ad9757975b930ec01fbec9/atd-vze/.env#L2) line and comment out the other one, I also had to change the "https" to "http" or else I get an Network connection error when trying to load data in the VZE.
4. Open up your localhost:8080 instance of the hasura console and click on the Data tab and then the SQL button on the bottom of the left bar (or you can do this in DBeaver). Copy and paste the contents of [this](https://github.com/cityofaustin/atd-vz-data/files/10914267/update_fatalities.txt) file into the SQL editor and click "Run". This will add the trigger to the crashes table.
5. Start up the VZE using localhost:8080 as your hasura endpoint (Step 3).
6. Go to the fatalities page and click on a crash. Edit the coordinates of that crash to be outside of Austin Full Purpose.
7. Any fatalities associated with that crash should be removed from the fatalities table.
8. Now edit the coordinates and move them back into Austin, fatalities associated with that table should be back in the fatality table.
9. In your local graphql engine test editing the `crash_date` year for a crash that is in the fatality table (go to the `atd_txdot_crashes` table and edit the `crash_date` there). The `year` for that fatality should update to whatever year you changed it to. You can double check this both in the DB and the UI.
10. Now test changing any of the rpt_block_num, rpt_street_pfx, rpt_street_name, rpt_sec_block_num, rpt_sec_street_pfx, rpt_sec_street_name columns for a crash that is in the fatality table. The `location` for all fatalities associated with that crash should have updated. 


---
#### Ship list
- [ ] Code reviewed
- [ ] Product manager approved