### PR TITLE
Bump local stack's graphql-engine version to 2.20.1

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,13 @@
 version: '3.7'
 services:
   graphql-engine:
-    image: hasura/graphql-engine:v2.16.1 # can jump cleanly to this with shorter event names
+    image: hasura/graphql-engine:v2.20.1  # added to patch critical security vulnerability
+
+    # I'm keeping these next two notes around until we're fully up to date with 2.20.1+ in 
+    # production, because I feel it will be prudent to re-test when we upgrade to 2.20.1+.
+    # since we're going to be coming all the way from the 1.* versions.
+
+    # image: hasura/graphql-engine:v2.16.1 # can jump cleanly to this with shorter event names
     # image: hasura/graphql-engine:v1.3.3 # use this to rename the events
     volumes:
       - ./atd-vzd/graphql-engine-metadata:/metadata


### PR DESCRIPTION
## Associated issues

Tangentially related to https://github.com/cityofaustin/atd-data-tech/issues/11750. 

## Testing
* Spin up the local VZ stack and see if the VZE is working as expected.

## Known issue
* In my testing locally, I'm finding that the locations listing page is unresponsive due to a slow query. I have not delved into it enough to know exactly why this is happening on my machine and not in production, but I have created an issue to get to the bottom of it. You can find that [here](https://github.com/cityofaustin/atd-data-tech/issues/11755). 

---
#### Ship list
- [ ] Code reviewed
- [ ] Product manager approved
