### PR TITLE
Update VZ Github Actions so that we can manually trigger them

### DIFF
--- a/.github/workflows/atd_sqs_build.yml
+++ b/.github/workflows/atd_sqs_build.yml
@@ -15,6 +15,10 @@ on:
       - master
     paths:
       - "atd-events/**"
+  workflow_dispatch:
+    inputs:
+      description:
+        default: ""
 
 jobs:
   build:

--- a/.github/workflows/atd_sqs_cleanup.yml
+++ b/.github/workflows/atd_sqs_cleanup.yml
@@ -1,6 +1,6 @@
 #
-# This GitHub action removes PR resources created by CircleCI
-# and it is only triggered whenever a PR is closed or merged.
+# This GitHub action removes PR resources created by the Build & Publish SQS
+# Github action, and it is only triggered whenever a PR is closed or merged.
 #
 name: "Remove Unused SQS PRs"
 


### PR DESCRIPTION
## Associated issues
https://github.com/cityofaustin/atd-data-tech/issues/11752

This will help us manually trigger these in the future when rotating secrets. 🔐 I don't think it is important to be able to manually trigger the SQS clean up workflow so I left it as is, but let me know if any of y'all disagree! 

See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch and https://github.com/cityofaustin/atd-moped/blob/main/.github/workflows/atd_moped_api.yml#L20

## Testing
**URL to test:** <!-- VZ URL or Netlify -->
n/a

**Steps to test:**
n/a

---
#### Ship list
- [ ] Code reviewed
- [ ] Product manager approved
