### PR TITLE
Resolve AFP toggle naming confusion in crash index advanced filters

### DIFF
--- a/atd-vze/src/views/Crashes/crashGridTableParameters.js
+++ b/atd-vze/src/views/Crashes/crashGridTableParameters.js
@@ -219,7 +219,7 @@ export const crashGridTableAdvancedFilters = {
       },
       {
         id: "geo_geocoded",
-        label: "Has been Geocoded",
+        label: "Has Been Geocoded",
         filter: {
           where: [
             {

--- a/atd-vze/src/views/Crashes/crashGridTableParameters.js
+++ b/atd-vze/src/views/Crashes/crashGridTableParameters.js
@@ -244,7 +244,7 @@ export const crashGridTableAdvancedFilters = {
       },
       {
         id: "geo_afd",
-        label: "Remove Austin Full Purpose",
+        label: "Include Outside Of Austin Full Purpose",
         invert_toggle_state: true,
         filter: {
           where: [


### PR DESCRIPTION
## Associated issues
Closes https://github.com/cityofaustin/atd-data-tech/issues/11819

## Testing
**URL to test:** <!-- VZ URL or Netlify -->
[Netlify](https://deploy-preview-1200--atd-vze-staging.netlify.app/#/)

**Steps to test:**
1. Go to the crashes page advance filters section, see the new toggle label that says "Include Outside Of Austin Full Purpose".


---
#### Ship list
- [x] Code reviewed
- [x] Product manager approved
