### PR TITLE
Add new widget in the VZE dashboard

### DIFF
--- a/atd-vze/src/views/VZDashboard/VZDashboard.js
+++ b/atd-vze/src/views/VZDashboard/VZDashboard.js
@@ -140,6 +140,14 @@ function VZDashboard() {
             link="https://visionzero.austin.gov/viewer/"
             target="_vzv"
           />
+          <VZLinksWidget
+            header={`Access Management Crashes`}
+            mainText={`Summary of crashes for individual locations`}
+            icon="fa fa-map"
+            color="primary"
+            link="https://austin.maps.arcgis.com/apps/instant/interactivelegend/index.html?appid=ea84226e6e5a4ecf998082b73b8c6cca"
+            target="_arcgis"
+          />
         </Col>
       </Row>
     </div>


### PR DESCRIPTION
## Associated issues
This PR closes [#11880](https://github.com/cityofaustin/atd-data-tech/issues/11800). 

Staff wanted a link on the dashboard for quick access.

## Testing
**URL to test:** [Netlify](https://deploy-preview-1201--atd-vze-staging.netlify.app/#/dashboard)

**Steps to test:**

Click on the new "Access Management Crashes" widget title. Verify the link goes [here](https://austin.maps.arcgis.com/apps/instant/interactivelegend/index.html?appid=ea84226e6e5a4ecf998082b73b8c6cca).


![Screen Shot 2023-03-27 at 11 49 43 AM](https://user-images.githubusercontent.com/5566727/228018537-24babd9d-01e5-4a0b-bc84-dfc5400ceb7f.png)



---
#### Ship list
- [x] Code reviewed
- [x] Product manager approved
