### PR TITLE
11327 council district layer in vzv does not render

### DIFF
--- a/atd-vzv/src/views/map/InfoBox/MapInfoBox.js
+++ b/atd-vzv/src/views/map/InfoBox/MapInfoBox.js
@@ -45,7 +45,7 @@ const MapInfoBox = React.memo(
       seriousInjuries: buildSeriousInjuriesOrFatalitiesConfig,
       cityCouncil: (info) => [
         {
-          title: `City Council District ${info.council_district}`,
+          title: `City Council District ${info.COUNCIL_DISTRICT}`,
           content: "",
         },
       ],

--- a/atd-vzv/src/views/map/Map.js
+++ b/atd-vzv/src/views/map/Map.js
@@ -125,7 +125,7 @@ const Map = () => {
 
   // Fetch City Council Districts geojson
   useEffect(() => {
-    const overlayUrl = `https://data.austintexas.gov/resource/7yq5-3tm4.geojson?$select=simplify_preserve_topology(the_geom,0.00001),council_district`;
+    const overlayUrl = `https://services.arcgis.com/0L95CJ0VTaxqcmED/ArcGIS/rest/services/BOUNDARIES_single_member_districts/FeatureServer/0/query?where=1%3D1&objectIds=&time=&geometry=&geometryType=esriGeometryEnvelope&inSR=&spatialRel=esriSpatialRelIntersects&resultType=none&distance=0.0&units=esriSRUnit_Meter&relationParam=&returnGeodetic=false&outFields=COUNCIL_DISTRICT&returnGeometry=true&returnCentroid=false&featureEncoding=esriDefault&multipatchOption=xyFootprint&maxAllowableOffset=&geometryPrecision=6&outSR=4326&defaultSR=&datumTransformation=&applyVCSProjection=false&returnIdsOnly=false&returnUniqueIdsOnly=false&returnCountOnly=false&returnExtentOnly=false&returnQueryGeometry=false&returnDistinctValues=false&cacheHint=false&orderByFields=&groupByFieldsForStatistics=&outStatistics=&having=&resultOffset=&resultRecordCount=&returnZ=false&returnM=false&returnExceededLimitFeatures=true&quantizationParameters=&sqlFormat=none&f=pgeojson&token=`;
     axios.get(overlayUrl).then((res) => {
       setCityCouncilOverlay(res.data);
     });

--- a/atd-vzv/src/views/map/map-style.js
+++ b/atd-vzv/src/views/map/map-style.js
@@ -204,7 +204,7 @@ export const buildHighInjuryLayer = (overlay) => {
 };
 
 // Style geojson returned from ArcGIS that populates the Source and Layer in Map component
-// https://data.austintexas.gov/Locations-and-Maps/Council-Districts-Fill/hdpc-ysmz
+// https://services.arcgis.com/0L95CJ0VTaxqcmED/ArcGIS/rest/services/BOUNDARIES_single_member_districts/FeatureServer/0/query?where=1%3D1&objectIds=&time=&geometry=&geometryType=esriGeometryEnvelope&inSR=&spatialRel=esriSpatialRelIntersects&resultType=none&distance=0.0&units=esriSRUnit_Meter&relationParam=&returnGeodetic=false&outFields=COUNCIL_DISTRICT&returnGeometry=true&returnCentroid=false&featureEncoding=esriDefault&multipatchOption=xyFootprint&maxAllowableOffset=&geometryPrecision=6&outSR=4326&defaultSR=&datumTransformation=&applyVCSProjection=false&returnIdsOnly=false&returnUniqueIdsOnly=false&returnCountOnly=false&returnExtentOnly=false&returnQueryGeometry=false&returnDistinctValues=false&cacheHint=false&orderByFields=&groupByFieldsForStatistics=&outStatistics=&having=&resultOffset=&resultRecordCount=&returnZ=false&returnM=false&returnExceededLimitFeatures=true&quantizationParameters=&sqlFormat=none&f=pgeojson&token=
 export const cityCouncilDataLayer = {
   id: "cityCouncil",
   type: "fill",
@@ -212,26 +212,26 @@ export const cityCouncilDataLayer = {
     "fill-opacity": 0.25,
     "fill-color": [
       "match",
-      ["get", "council_district"],
-      "1",
+      ["get", "COUNCIL_DISTRICT"],
+      1,
       colors.mapCityCouncil1,
-      "2",
+      2,
       colors.mapCityCouncil2,
-      "3",
+      3,
       colors.mapCityCouncil3,
-      "4",
+      4,
       colors.mapCityCouncil4,
-      "5",
+      5,
       colors.mapCityCouncil5,
-      "6",
+      6,
       colors.mapCityCouncil6,
-      "7",
+      7,
       colors.mapCityCouncil7,
-      "8",
+      8,
       colors.mapCityCouncil8,
-      "9",
+      9,
       colors.mapCityCouncil9,
-      "10",
+      10,
       colors.mapCityCouncil10,
       /* other */ "#ccc",
     ],


### PR DESCRIPTION
## Associated issues
fixes https://github.com/cityofaustin/atd-data-tech/issues/11327

this pr replaces the defunct open data portal endpoint for city council districts with an arcgis online endpoint. thanks @johnclary for providing the agol query!

## Testing
**URL to test:** <!-- VZ URL or Netlify -->
https://deploy-preview-1204--atd-vzv-staging.netlify.app/

**Steps to test:**
- open vision zero viewer and enable the city council district overlay
- click on different council districts to confirm they appear and the correct label is displayed

---
#### Ship list
- [ ] Code reviewed
- [ ] Product manager approved
