### PR TITLE
Improve secret exchange between VZ Hasura event triggers and CR3 API

### DIFF
--- a/atd-cr3-api/server.py
+++ b/atd-cr3-api/server.py
@@ -45,7 +45,7 @@ AWS_S3_BUCKET = os.getenv("AWS_S3_BUCKET", "")
 # Hasura Config
 HASURA_ADMIN_SECRET = os.getenv("HASURA_ADMIN_SECRET", "")
 HASURA_ENDPOINT = os.getenv("HASURA_ENDPOINT", "")
-HASURA_EVENT_API = os.getenv("HASURA_EVENT_API", "")
+HASURA_TRIGGER_API_KEY = os.getenv("HASURA_TRIGGER_API_KEY", "")
 HASURA_EVENTS_SQS_URL = os.getenv("HASURA_EVENTS_SQS_URL", "")
 
 
@@ -428,10 +428,10 @@ def user_delete_user(id):
 @APP.route("/events/", methods=["PUT", "POST"])
 def associate_location():
     # Require matching token
-    incoming_token = request.headers.get("HASURA_EVENT_API")
+    incoming_token = request.headers.get("HASURA_TRIGGER_API_KEY")
     incoming_event_name = request.headers.get("HASURA_EVENT_NAME", "")
     hashed_events_api = hashlib.md5()
-    hashed_events_api.update(str(HASURA_EVENT_API).encode("utf-8"))
+    hashed_events_api.update(str(HASURA_TRIGGER_API_KEY).encode("utf-8"))
     hashed_incoming_token = hashlib.md5()
     hashed_incoming_token.update(str(incoming_token).encode("utf-8"))
 

--- a/atd-cr3-api/server.py
+++ b/atd-cr3-api/server.py
@@ -62,7 +62,9 @@ def get_api_token():
             "client_secret": API_CLIENT_SECRET,
             "audience": f"https://{AUTH0_DOMAIN}/api/v2/",
         },
-        {"content-type": "application/json", },
+        {
+            "content-type": "application/json",
+        },
     )
     return response.json().get("access_token", None)
 
@@ -87,8 +89,7 @@ def handle_auth_error(ex):
 
 
 def get_token_auth_header():
-    """Obtains the access token from the Authorization Header
-    """
+    """Obtains the access token from the Authorization Header"""
     auth = request.headers.get("Authorization", None)
     if not auth:
         raise AuthError(
@@ -142,8 +143,7 @@ def requires_scope(required_scope):
 
 
 def requires_auth(f):
-    """Determines if the access token is valid
-    """
+    """Determines if the access token is valid"""
 
     @wraps(f)
     def decorated(*args, **kwargs):
@@ -233,8 +233,7 @@ def requires_auth(f):
     return decorated
 
 
-current_user = LocalProxy(lambda: getattr(
-    _request_ctx_stack.top, "current_user", None))
+current_user = LocalProxy(lambda: getattr(_request_ctx_stack.top, "current_user", None))
 
 # Controllers API
 
@@ -242,8 +241,7 @@ current_user = LocalProxy(lambda: getattr(
 @APP.route("/")
 @cross_origin(headers=["Content-Type", "Authorization"])
 def healthcheck():
-    """No access token required to access this route
-    """
+    """No access token required to access this route"""
     now = datetime.datetime.now()
     response = "CR3 Download API - Health Check - Available @ %s" % now.strftime(
         "%Y-%m-%d %H:%M:%S"
@@ -256,8 +254,7 @@ def healthcheck():
 @cross_origin(headers=["Access-Control-Allow-Origin", CORS_URL])
 @requires_auth
 def download_crash_id(crash_id):
-    """A valid access token is required to access this route
-    """
+    """A valid access token is required to access this route"""
     # We only care for an integer string, anything else is not safe:
     safe_crash_id = re.sub("[^0-9]", "", crash_id)
 
@@ -371,8 +368,7 @@ def user_create_user():
         json_data = request.json
         endpoint = f"https://{AUTH0_DOMAIN}/api/v2/users"
         headers = {"Authorization": f"Bearer {get_api_token()}"}
-        response = requests.post(
-            endpoint, headers=headers, json=json_data).json()
+        response = requests.post(endpoint, headers=headers, json=json_data).json()
         return jsonify(response)
     else:
         abort(403)
@@ -388,8 +384,7 @@ def user_update_user(id):
         json_data = request.json
         endpoint = f"https://{AUTH0_DOMAIN}/api/v2/users/" + id
         headers = {"Authorization": f"Bearer {get_api_token()}"}
-        response = requests.patch(
-            endpoint, headers=headers, json=json_data).json()
+        response = requests.patch(endpoint, headers=headers, json=json_data).json()
         return jsonify(response)
     else:
         abort(403)
@@ -446,9 +441,12 @@ def associate_location():
         "crash_update_jurisdiction_",
         "crash_update_location_",
     ]
-    
+
     if incoming_event_name not in valid_event_names:
-        return {"statusCode": 403, "body": json.dumps({"message": "Forbidden Request: Invalid Event Name"})}
+        return {
+            "statusCode": 403,
+            "body": json.dumps({"message": "Forbidden Request: Invalid Event Name"}),
+        }
 
     # We continue the execution
     try:
@@ -456,10 +454,12 @@ def associate_location():
         queue_url = (
             # The SQS url is a constant that follows this pattern:
             # https://sqs.us-east-1.amazonaws.com/{AWS_ACCOUNT_NUMBER}/{THE_QUEUE_NAME}
-            HASURA_EVENTS_SQS_URL[0:48]  # This is the length of the url with the account number
-            + "/atd-vz-data-events-"     # We're going to add a prefix pattern for our ATD VisionZero queues
-            + incoming_event_name        # And append the name of the incoming event
-            + environment_for_queue_name # Append the environment name to target the correct queue
+            HASURA_EVENTS_SQS_URL[
+                0:48
+            ]  # This is the length of the url with the account number
+            + "/atd-vz-data-events-"  # We're going to add a prefix pattern for our ATD VisionZero queues
+            + incoming_event_name  # And append the name of the incoming event
+            + environment_for_queue_name  # Append the environment name to target the correct queue
         )
 
         # Send message to SQS queue

--- a/atd-cr3-api/server.py
+++ b/atd-cr3-api/server.py
@@ -430,6 +430,7 @@ def associate_location():
     # Require matching token
     incoming_token = request.headers.get("HASURA_TRIGGER_API_KEY")
     incoming_event_name = request.headers.get("HASURA_EVENT_NAME", "")
+    environment_for_queue_name = API_ENVIRONMENT.lower()
     hashed_events_api = hashlib.md5()
     hashed_events_api.update(str(HASURA_TRIGGER_API_KEY).encode("utf-8"))
     hashed_incoming_token = hashlib.md5()
@@ -452,6 +453,7 @@ def associate_location():
             HASURA_EVENTS_SQS_URL[0:48]  # This is the length of the url with the account number
             + "/atd-vz-data-events-"     # We're going to add a prefix pattern for our ATD VisionZero queues
             + incoming_event_name        # And append the name of the incoming event
+            + environment_for_queue_name # Append the environment name to target the correct queue
         )
 
         # Send message to SQS queue

--- a/atd-cr3-api/server.py
+++ b/atd-cr3-api/server.py
@@ -440,9 +440,15 @@ def associate_location():
     if hashed_events_api.hexdigest() != hashed_incoming_token.hexdigest():
         return {"statusCode": 403, "body": json.dumps({"message": "Forbidden Request"})}
 
-    # Check if there is an event name provided, if not provide feedback.
-    if incoming_event_name == "":
-        return {"statusCode": 403, "body": json.dumps({"message": "Forbidden Request: Missing Event Name"})}
+    # Check if there is a valid event name provided, if not reject the request.
+    valid_event_names = [
+        "crash_update_noncr3_location_",
+        "crash_update_jurisdiction_",
+        "crash_update_location_",
+    ]
+    
+    if incoming_event_name not in valid_event_names:
+        return {"statusCode": 403, "body": json.dumps({"message": "Forbidden Request: Invalid Event Name"})}
 
     # We continue the execution
     try:

--- a/atd-events/crash_update_jurisdiction/app.py
+++ b/atd-events/crash_update_jurisdiction/app.py
@@ -10,7 +10,6 @@ import os
 
 HASURA_ADMIN_SECRET = os.getenv("HASURA_ADMIN_SECRET", "")
 HASURA_ENDPOINT = os.getenv("HASURA_ENDPOINT", "")
-HASURA_EVENT_API = os.getenv("HASURA_EVENT_API", "")
 
 # Prep Hasura query
 HEADERS = {

--- a/atd-events/crash_update_location/app.py
+++ b/atd-events/crash_update_location/app.py
@@ -10,7 +10,6 @@ from typing import Optional
 
 HASURA_ADMIN_SECRET = os.getenv("HASURA_ADMIN_SECRET", "")
 HASURA_ENDPOINT = os.getenv("HASURA_ENDPOINT", "")
-HASURA_EVENT_API = os.getenv("HASURA_EVENT_API", "")
 # The following environment variable should only be set to False for local development.
 # In production, this variable should be omitted or set explicitly to true.
 HASURA_SSL_VERIFY = os.getenv("HASURA_SSL_VERIFY", True)

--- a/atd-events/crash_update_noncr3_location/app.py
+++ b/atd-events/crash_update_noncr3_location/app.py
@@ -10,7 +10,6 @@ from typing import Optional
 
 HASURA_ADMIN_SECRET = os.getenv("HASURA_ADMIN_SECRET", "")
 HASURA_ENDPOINT = os.getenv("HASURA_ENDPOINT", "")
-HASURA_EVENT_API = os.getenv("HASURA_EVENT_API", "")
 
 # Prep Hasura query
 HEADERS = {

--- a/atd-events/tests/README.md
+++ b/atd-events/tests/README.md
@@ -23,7 +23,7 @@ variables for the staging environment only:
    ```
    export HASURA_ADMIN_SECRET="..."
    export HASURA_ENDPOINT="..."
-   export HASURA_EVENT_API="..."
+   export HASURA_TRIGGER_API_KEY="..."
    ```
 4. Run your tests:
    ```

--- a/atd-events/tests/env.sh
+++ b/atd-events/tests/env.sh
@@ -6,4 +6,4 @@
 
 export HASURA_ADMIN_SECRET="...";
 export HASURA_ENDPOINT="...";
-export HASURA_EVENT_API="...";
+export HASURA_TRIGGER_API_KEY="...";


### PR DESCRIPTION
## Associated issues
https://github.com/cityofaustin/atd-data-tech/issues/11803

This PR:
- Updates the `HASURA_EVENT_API` secret name to `HASURA_TRIGGER_API_KEY`. This secret's role is to be passed in the headers of a Hasura event trigger request that is received by the CR3 API. In the API code, it is checked for a matching value that comes from `ZAPPA_SETTINGS`.  This secret will be moved to the Hasura environment variables that are set in the AWS ECS task definition so we don't leak it in the Hasura metadata accidentally.
- Updates the CR3 API code to get the environment name from env vars that come from `ZAPPA_SECRETS`
- Removes this env var from the SQS Lambdas code since it is not used in any of them

## Testing
**URL to test:** <!-- VZ URL or Netlify -->
n/a

**Steps to test:**
1. Is the name of this secret any better? If anyone comes up with a stronger name, I'm 100% down to change it. 🙏
2. Do you agree with [this plan](https://github.com/cityofaustin/atd-data-tech/issues/11803#issuecomment-1489437919) to deploy these changes?
3. The rest of this will have to be tested after merge to `master`. From PRs, we deploy preview SQS + Lambda that handle the event triggers but not the CR3 API that processes and routes them there.

---
#### Ship list
- [x] Code reviewed
- [x] Product manager approved
