### PR TITLE
augment local storage key name

### DIFF
--- a/atd-vze/package.json
+++ b/atd-vze/package.json
@@ -1,6 +1,6 @@
 {
   "name": "atd-vz-data",
-  "version": "1.31.0",
+  "version": "1.31.1",
   "homepage": "./",
   "description": "ATD Vision Zero Editor",
   "author": "ATD Data & Technology Services",

--- a/atd-vze/src/Components/GridTable.js
+++ b/atd-vze/src/Components/GridTable.js
@@ -5,6 +5,7 @@ import { useQuery, useLazyQuery } from "@apollo/react-hooks";
 import { withApollo } from "react-apollo";
 import { format, subYears } from "date-fns";
 
+
 import {
   Card,
   CardBody,
@@ -31,6 +32,8 @@ import GridTableDoughnut from "./GridTableDoughnut";
 import GridTableHorizontalBar from "./GridTableHorizontalBar";
 import GridTableFilterBadges from "./GridTableFilterBadges";
 
+const codeName = 'jester';
+
 const GridTable = ({
   title,
   query,
@@ -44,7 +47,7 @@ const GridTable = ({
 }) => {
   // Load table filters from localStorage by title
   const savedFilterState = JSON.parse(
-    localStorage.getItem(`saved${title}Config`)
+    localStorage.getItem(`${codeName}saved${title}Config`)
   );
 
   // Return saved filters if they exist
@@ -104,7 +107,7 @@ const GridTable = ({
       dateRangeFilter,
     };
     localStorage.setItem(
-      `saved${title}Config`,
+      `${codeName}saved${title}Config`,
       JSON.stringify(stateForFilters)
     );
   });


### PR DESCRIPTION
This appends the code name, currently hardcoded into the app, to the local storage key name, so we can change that anytime we want to wipe out the currently used local storage.

As a follow on issue, I'd like to get this value pulled from the package.json file in some form or another. Perhaps a substring of a md5 sum of the version number.

#### Ship list
- [ ] Code reviewed
- [ ] Product manager approved
