### PR TITLE
Update VZV map info box to show accurate crash time

### DIFF
--- a/atd-vzv/src/views/map/InfoBox/MapInfoBox.js
+++ b/atd-vzv/src/views/map/InfoBox/MapInfoBox.js
@@ -29,7 +29,7 @@ const MapInfoBox = React.memo(
     const buildSeriousInjuriesOrFatalitiesConfig = (info) => [
       {
         title: "Date/Time",
-        content: moment(info.crash_date).format("MM/DD/YYYY HH:MM A"),
+        content: moment(info.crash_date).format("MM/DD/YYYY HH:mm A"),
       },
       { title: "Fatalities", content: info.death_cnt },
       { title: "Serious Injuries", content: info.sus_serious_injry_cnt },


### PR DESCRIPTION
## Associated issues
https://github.com/cityofaustin/atd-data-tech/issues/11990

## Testing
**URL to test:** <!-- VZ URL or Netlify -->
https://deploy-preview-1212--atd-vzv-staging.netlify.app/viewer/map

**Steps to test:**
1. Go to [VZV production](https://visionzero.austin.gov/viewer/map) and click on a crash marker on the crash map to show the info box
2. You will see that the month and minutes of the crash date and time have the same value
3. Go to the deploy preview link
4. You will see that the month and minutes of the crash time and date do not have the same value
5. You can also compare the screenshots below to the [crash date column of the row that Charlie shared](https://data.austintexas.gov/Transportation-and-Mobility/Vision-Zero-Crash-Report-Data-Crash-Level-Records/y2wy-tgr5/explore/query/SELECT%0A%20%20%60crash_id%60%2C%0A%20%20%60crash_fatal_fl%60%2C%0A%20%20%60crash_date%60%2C%0A%20%20%60crash_time%60%2C%0A%20%20%60case_id%60%2C%0A%20%20%60rpt_latitude%60%2C%0A%20%20%60rpt_longitude%60%2C%0A%20%20%60rpt_block_num%60%2C%0A%20%20%60rpt_street_pfx%60%2C%0A%20%20%60rpt_street_name%60%2C%0A%20%20%60rpt_street_sfx%60%2C%0A%20%20%60crash_speed_limit%60%2C%0A%20%20%60road_constr_zone_fl%60%2C%0A%20%20%60latitude%60%2C%0A%20%20%60longitude%60%2C%0A%20%20%60street_name%60%2C%0A%20%20%60street_nbr%60%2C%0A%20%20%60street_name_2%60%2C%0A%20%20%60street_nbr_2%60%2C%0A%20%20%60crash_sev_id%60%2C%0A%20%20%60sus_serious_injry_cnt%60%2C%0A%20%20%60nonincap_injry_cnt%60%2C%0A%20%20%60poss_injry_cnt%60%2C%0A%20%20%60non_injry_cnt%60%2C%0A%20%20%60unkn_injry_cnt%60%2C%0A%20%20%60tot_injry_cnt%60%2C%0A%20%20%60death_cnt%60%2C%0A%20%20%60contrib_factr_p1_id%60%2C%0A%20%20%60contrib_factr_p2_id%60%2C%0A%20%20%60units_involved%60%2C%0A%20%20%60atd_mode_category_metadata%60%2C%0A%20%20%60pedestrian_fl%60%2C%0A%20%20%60motor_vehicle_fl%60%2C%0A%20%20%60motorcycle_fl%60%2C%0A%20%20%60bicycle_fl%60%2C%0A%20%20%60other_fl%60%2C%0A%20%20%60point%60%2C%0A%20%20%60apd_confirmed_fatality%60%2C%0A%20%20%60apd_confirmed_death_count%60%2C%0A%20%20%60motor_vehicle_death_count%60%2C%0A%20%20%60motor_vehicle_serious_injury_count%60%2C%0A%20%20%60bicycle_death_count%60%2C%0A%20%20%60bicycle_serious_injury_count%60%2C%0A%20%20%60pedestrian_death_count%60%2C%0A%20%20%60pedestrian_serious_injury_count%60%2C%0A%20%20%60motorcycle_death_count%60%2C%0A%20%20%60motorcycle_serious_injury_count%60%2C%0A%20%20%60other_death_count%60%2C%0A%20%20%60other_serious_injury_count%60%2C%0A%20%20%60onsys_fl%60%2C%0A%20%20%60private_dr_fl%60%2C%0A%20%20%60%3A%40computed_region_8spj_utxs%60%2C%0A%20%20%60%3A%40computed_region_jcrc_4uuy%60%2C%0A%20%20%60%3A%40computed_region_q9nd_rr82%60%2C%0A%20%20%60%3A%40computed_region_e9j2_6w3z%60%2C%0A%20%20%60%3A%40computed_region_m2th_e4b7%60%2C%0A%20%20%60%3A%40computed_region_rxpj_nzrk%60%0AWHERE%20%60crash_id%60%20%3D%2019315211/page/filter) when he found the bug

### Before
<img width="480" alt="Screenshot 2023-04-11 at 10 41 07 AM" src="https://user-images.githubusercontent.com/37249039/231216721-48f089d5-5214-405a-a7ff-4fd5b64dd702.png">

### After
<img width="480" alt="Screenshot 2023-04-11 at 10 42 45 AM" src="https://user-images.githubusercontent.com/37249039/231216766-c5fa06cb-d90d-4f12-bf0b-58aa0bd61dba.png">

---
#### Ship list
- [x] Code reviewed
- [x] Product manager approved
