### PR TITLE
Add CR3 code sheet link to support menu

### DIFF
--- a/atd-vze/src/containers/DefaultLayout/DefaultHeader.js
+++ b/atd-vze/src/containers/DefaultLayout/DefaultHeader.js
@@ -84,7 +84,7 @@ const DefaultHeader = props => {
             </DropdownToggle>
             <DropdownMenu right>
               <DropdownItem header tag="div" className="text-center">
-                <strong>Help</strong>
+                <strong>Support</strong>
               </DropdownItem>
               <DropdownItem
                 href="https://atd.knack.com/dts#new-service-request/?view_249_vars=%7B%22field_398%22%3A%22Bug%20Report%20%E2%80%94%20Something%20is%20not%20working%22%2C%22field_399%22%3A%22Vision%20Zero%20(Editor)%22%7D"
@@ -97,6 +97,12 @@ const DefaultHeader = props => {
                 target="_blank"
               >
                 <i class="fa fa-wrench" /> Request an enhancement&nbsp;&nbsp; <i className="fa fa-external-link" />
+              </DropdownItem>
+              <DropdownItem
+                href="https://ftp.dot.state.tx.us/pub/txdot-info/trf/crash_notifications/cr3_code_sheet.pdf"
+                target="_blank"
+              >
+                <i class="fa fa-briefcase" /> CR3 code sheet&nbsp;&nbsp; <i className="fa fa-external-link" />
               </DropdownItem>
             </DropdownMenu>
         </UncontrolledDropdown>

--- a/atd-vze/src/containers/DefaultLayout/DefaultHeader.js
+++ b/atd-vze/src/containers/DefaultLayout/DefaultHeader.js
@@ -89,18 +89,21 @@ const DefaultHeader = props => {
               <DropdownItem
                 href="https://atd.knack.com/dts#new-service-request/?view_249_vars=%7B%22field_398%22%3A%22Bug%20Report%20%E2%80%94%20Something%20is%20not%20working%22%2C%22field_399%22%3A%22Vision%20Zero%20(Editor)%22%7D"
                 target="_blank"
+                rel="noreferrer"
               >
                 <i class="fa fa-bug" /> Report a bug&nbsp;&nbsp; <i className="fa fa-external-link" />
               </DropdownItem>
               <DropdownItem
                 href="https://atd.knack.com/dts#new-service-request/?view_249_vars=%7B%22field_398%22%3A%22Feature%20or%20Enhancement%20%E2%80%94%20An%20application%20I%20use%20could%20be%20improved%22%2C%22field_399%22%3A%22Vision%20Zero%20(Editor)%22%7D"
                 target="_blank"
+                rel="noreferrer"
               >
                 <i class="fa fa-wrench" /> Request an enhancement&nbsp;&nbsp; <i className="fa fa-external-link" />
               </DropdownItem>
               <DropdownItem
                 href="https://ftp.dot.state.tx.us/pub/txdot-info/trf/crash_notifications/2023/code-sheet.pdf"
                 target="_blank"
+                rel="noreferrer"
               >
                 <i class="fa fa-briefcase" /> CR3 code sheet&nbsp;&nbsp; <i className="fa fa-external-link" />
               </DropdownItem>

--- a/atd-vze/src/containers/DefaultLayout/DefaultHeader.js
+++ b/atd-vze/src/containers/DefaultLayout/DefaultHeader.js
@@ -99,7 +99,7 @@ const DefaultHeader = props => {
                 <i class="fa fa-wrench" /> Request an enhancement&nbsp;&nbsp; <i className="fa fa-external-link" />
               </DropdownItem>
               <DropdownItem
-                href="https://ftp.dot.state.tx.us/pub/txdot-info/trf/crash_notifications/cr3_code_sheet.pdf"
+                href="https://ftp.dot.state.tx.us/pub/txdot-info/trf/crash_notifications/2023/code-sheet.pdf"
                 target="_blank"
               >
                 <i class="fa fa-briefcase" /> CR3 code sheet&nbsp;&nbsp; <i className="fa fa-external-link" />


### PR DESCRIPTION
## Associated issues

This issue closes [#11799](https://github.com/cityofaustin/atd-data-tech/issues/11799)

VZ Staff wanted to add a link to the support menu that linked to the CR3 codes. 

## Testing
**URL to test:** <!-- VZ URL or Netlify -->
https://deploy-preview-1216--atd-vze-staging.netlify.app/#/dashboard

**Steps to test:**
- Click on Support Menu (?) to see new link to CR3 code sheet
- Click on link to make sure it goes to [external link](https://ftp.dot.state.tx.us/pub/txdot-info/trf/crash_notifications/cr3_code_sheet.pdf)

---
#### Ship list
- [ ] Code reviewed
- [ ] Product manager approved
