### PR TITLE
Add special handling of a float from CRIS in the new speed limit column

### DIFF
--- a/atd-etl/app/process/helpers_import.py
+++ b/atd-etl/app/process/helpers_import.py
@@ -558,12 +558,6 @@ def insert_crash_change_template(new_record_dict, differences, crash_id):
     except:
         print("Failed to convert crash_date")
 
-    if "rpt_sec_speed_limit" in new_record_dict:
-        print("🔥")
-        print(new_record_dict["rpt_sec_speed_limit"])
-        print(type(new_record_dict["rpt_sec_speed_limit"]))
-        #print(isinstance(new_record_dict[key], Decimal))
-
     for key in new_record_dict:
         if isinstance(new_record_dict[key], datetime.date):
             new_record_dict[key] = new_record_dict[key].strftime("%Y-%m-%d")

--- a/atd-etl/app/process/helpers_import.py
+++ b/atd-etl/app/process/helpers_import.py
@@ -558,11 +558,21 @@ def insert_crash_change_template(new_record_dict, differences, crash_id):
     except:
         print("Failed to convert crash_date")
 
+    if "rpt_sec_speed_limit" in new_record_dict:
+        print("🔥")
+        print(new_record_dict["rpt_sec_speed_limit"])
+        print(type(new_record_dict["rpt_sec_speed_limit"]))
+        #print(isinstance(new_record_dict[key], Decimal))
+
     for key in new_record_dict:
         if isinstance(new_record_dict[key], datetime.date):
             new_record_dict[key] = new_record_dict[key].strftime("%Y-%m-%d")
         if isinstance(new_record_dict[key], datetime.time):
             new_record_dict[key] = new_record_dict[key].strftime("%H:%M:%S")
+
+        # CRIS or the upstream ETL is representing this datum as a float, so cast it back
+        if key == "rpt_sec_speed_limit": 
+            new_record_dict[key] = int(new_record_dict[key])
 
     # Turn the dictionary into a character-escaped json string
     new_record_escaped = json.dumps(json.dumps(new_record_dict), default=str)


### PR DESCRIPTION
## Intent

This is a tag-along fix for the problem which alerted us to the larger issues in the VZ ETL.

This PR intends to close https://github.com/cityofaustin/atd-data-tech/issues/12053.

## Related PR

this is a child/sibling of https://github.com/cityofaustin/atd-prefect/pull/71. 

## Description

CRIS or the upstream ETL is representing the value for the new `rpt_sec_speed_limit` field in new CRIS crash CSVs in a manner that gets down to here as a `decimal.Decimal` class object. We want an int out of it, so this `int()`s the value back into something the database is ready for.

---
#### Ship list
- [ ] Code reviewed
- [ ] Product manager approved
