### PR TITLE
Fix Person Badge Colors

### DIFF
--- a/atd-vze/src/views/Crashes/RelatedRecordsTable.js
+++ b/atd-vze/src/views/Crashes/RelatedRecordsTable.js
@@ -196,7 +196,7 @@ const RelatedRecordsTable = ({
                           (fieldConfig.fields[field].badge ? (
                             <Badge
                               color={fieldConfig.fields[field].badgeColor(
-                                formatValue(row, field)
+                                row
                               )}
                             >
                               {formatValue(row, field)}

--- a/atd-vze/src/views/Crashes/personDataMap.js
+++ b/atd-vze/src/views/Crashes/personDataMap.js
@@ -1,18 +1,16 @@
-const getInjurySeverityColor = desc => {
-  switch (desc) {
-    case "UNKNOWN":
+const getInjurySeverityColor = personRecord => {
+  switch (personRecord["prsn_injry_sev_id"]) {
+    case 0: // UNKNOWN
       return "muted";
-    case "NOT INJURED":
+    case 5: // NOT INJURED
       return "primary";
-    case "SUSPECTED SERIOUS INJURY" || "INCAPACITATING INJURY":
-      // INCAPACITATING INJURY is deprecated terminology but including
-      // a fallback here just in case.
+    case 1: // SUSPECTED INCAPACITATING INJURY
       return "warning";
-    case "NON-INCAPACITATING INJURY":
+    case 2: // SUSPECTED MINOR INJURY
       return "warning";
-    case "POSSIBLE INJURY":
+    case 3: // POSSIBLE INJURY
       return "warning";
-    case "KILLED":
+    case 4: // FATAL INJURY
       return "danger";
     default:
       break;

--- a/vision-zero
+++ b/vision-zero
@@ -120,6 +120,7 @@ def replicateDb(args):
         "--no-owner",
         "--no-privileges",
         "--if-exists",
+        "--exclude-schema=import*"
         #"--table", "atd_txdot__airbag_lkp",
         #"-t", "atd_txdot_crashes",
     ]


### PR DESCRIPTION
## Associated issues

This PR intends to close https://github.com/cityofaustin/atd-data-tech/issues/12135. 

This came out of [an observation in slack](https://austininnovation.slack.com/archives/CM9MK950S/p1682696549485749) by @roseeichelmann  that the updates today to many of our lookup tables had broken the color picking scheme for our person badges.

I'm also sneaking in a fix to the repo orchestration helper that updates it for our new multi-import-schema ETL mechanism.

Based on direction from @patrickm02L, should this patch be accepted, it will be deployed into production today.

## Testing
**URL to test:** <!-- VZ URL or Netlify -->

https://deploy-preview-1220--atd-vze-staging.netlify.app/#/

**Steps to test:**

Check out various people on crashes pages and observe if their badges' colors match the injury they received. 

---
#### Ship list
- [ ] Code reviewed
- [ ] Product manager approved
