### PR TITLE
 Add New FTT fields to the crash export

### DIFF
--- a/atd-vzd/migrations/migration_recommendations_2023_05_03--0926.sql
+++ b/atd-vzd/migrations/migration_recommendations_2023_05_03--0926.sql
@@ -1,0 +1,11 @@
+ALTER TABLE recommendations
+RENAME COLUMN text TO rec_text;
+
+ALTER TABLE recommendations
+RENAME COLUMN update TO rec_update;
+
+ALTER TABLE atd__recommendation_status_lkp
+RENAME COLUMN description TO rec_status_desc;
+
+ALTER TABLE atd__coordination_partners_lkp
+RENAME COLUMN description TO coord_partner_desc;

--- a/atd-vze/src/Components/GridExportData.js
+++ b/atd-vze/src/Components/GridExportData.js
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import { withApollo } from "react-apollo";
+import { useAuth0, isAdmin, isItSupervisor } from "../auth/authContext";
 import { useLazyQuery } from "@apollo/react-hooks";
 import { formatISO } from "date-fns";
 import { CSVLink } from "react-csv";
@@ -33,6 +34,25 @@ const StyledSaveLink = styled.i`
 
 const GridExportData = ({ query, columnsToExport, totalRecords }) => {
   const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const { getRoles } = useAuth0();
+  const roles = getRoles();
+
+  // Columns that can only be exported by admins & it supervisors
+  const adminColumns = [
+    "recommendation { rec_text }",
+    "recommendation { rec_update }",
+    "recommendation { atd__recommendation_status_lkp { rec_status_desc } }",
+    "recommendation { recommendations_partners { atd__coordination_partners_lkp { coord_partner_desc }} }",
+  ];
+
+  // Remove admin-only columns from columnsToExport for users without admin/it supervisor permissions
+  if (!(isAdmin(roles) || isItSupervisor(roles))) {
+    console.log("not admin");
+    adminColumns.forEach(col => {
+      columnsToExport = columnsToExport.replace(col, "");
+    });
+  }
 
   // Use .queryCSV to insert columnsToExport prop into query
   let [getExport, { loading, data }] = useLazyQuery(

--- a/atd-vze/src/Components/GridTable.js
+++ b/atd-vze/src/Components/GridTable.js
@@ -5,7 +5,6 @@ import { useQuery, useLazyQuery } from "@apollo/react-hooks";
 import { withApollo } from "react-apollo";
 import { format, subYears } from "date-fns";
 
-
 import {
   Card,
   CardBody,
@@ -32,7 +31,7 @@ import GridTableDoughnut from "./GridTableDoughnut";
 import GridTableHorizontalBar from "./GridTableHorizontalBar";
 import GridTableFilterBadges from "./GridTableFilterBadges";
 
-const codeName = 'jester';
+const codeName = "jester";
 
 const GridTable = ({
   title,

--- a/atd-vze/src/queries/crashes.js
+++ b/atd-vze/src/queries/crashes.js
@@ -282,10 +282,10 @@ latitude_primary
 longitude_primary
 crash_speed_limit
 death_cnt
-recommendation { text }
-recommendation { update }
-recommendation { atd__recommendation_status_lkp { description } }
-recommendation { recommendations_partners { atd__coordination_partners_lkp { description }} }
+recommendation { rec_text }
+recommendation { rec_update }
+recommendation { atd__recommendation_status_lkp { rec_status_desc } }
+recommendation { recommendations_partners { atd__coordination_partners_lkp { coord_partner_desc }} }
 `;
 
 export const locationCrashesQueryExportFieldsNonCR3 = `

--- a/atd-vze/src/queries/crashes.js
+++ b/atd-vze/src/queries/crashes.js
@@ -282,6 +282,10 @@ latitude_primary
 longitude_primary
 crash_speed_limit
 death_cnt
+recommendation { text }
+recommendation { update }
+recommendation { atd__recommendation_status_lkp { description } }
+recommendation { recommendations_partners { atd__coordination_partners_lkp { description }} }
 `;
 
 export const locationCrashesQueryExportFieldsNonCR3 = `

--- a/atd-vze/src/queries/recommendations.js
+++ b/atd-vze/src/queries/recommendations.js
@@ -5,12 +5,12 @@ export const GET_RECOMMENDATIONS = gql`
     recommendations(where: { crash_id: { _eq: $crashId } }) {
       id
       created_at
-      text
+      rec_text
       created_by
       crash_id
-      update
+      rec_update
       atd__recommendation_status_lkp {
-        description
+        rec_status_desc
       }
       recommendations_partners {
         id
@@ -18,17 +18,17 @@ export const GET_RECOMMENDATIONS = gql`
         recommendation_id
         atd__coordination_partners_lkp {
           id
-          description
+          coord_partner_desc
         }
       }
     }
-    atd__coordination_partners_lkp(order_by: { description: asc }) {
+    atd__coordination_partners_lkp(order_by: { coord_partner_desc: asc }) {
       id
-      description
+      coord_partner_desc
     }
     atd__recommendation_status_lkp {
       id
-      description
+      rec_status_desc
     }
   }
 `;
@@ -44,8 +44,8 @@ export const INSERT_RECOMMENDATION = gql`
   ) {
     insert_recommendations(
       objects: {
-        text: $text
-        update: $update
+        rec_text: $text
+        rec_update: $update
         crash_id: $crashId
         created_by: $userEmail
         recommendation_status_id: $recommendation_status_id
@@ -54,8 +54,8 @@ export const INSERT_RECOMMENDATION = gql`
     ) {
       returning {
         crash_id
-        update
-        text
+        rec_update
+        rec_text
         created_at
         created_by
       }
@@ -70,8 +70,8 @@ export const UPDATE_RECOMMENDATION = gql`
   ) {
     update_recommendations_by_pk(pk_columns: { id: $id }, _set: $changes) {
       crash_id
-      text
-      update
+      rec_text
+      rec_update
     }
   }
 `;

--- a/atd-vze/src/views/Crashes/Recommendations/RecommendationMultipleSelectDropdown.js
+++ b/atd-vze/src/views/Crashes/Recommendations/RecommendationMultipleSelectDropdown.js
@@ -34,7 +34,9 @@ const RecommendationMultipleSelectDropdown = ({
       displayValue={"description"}
       showCheckbox
       selectedValues={
-        partners ? getSelectedValues(fieldConfig.fields.partner_id) : null
+        partners
+          ? getSelectedValues(fieldConfig.fields.coordination_partner_id)
+          : null
       }
       showArrow
       hidePlaceholder

--- a/atd-vze/src/views/Crashes/Recommendations/RecommendationMultipleSelectDropdown.js
+++ b/atd-vze/src/views/Crashes/Recommendations/RecommendationMultipleSelectDropdown.js
@@ -31,7 +31,7 @@ const RecommendationMultipleSelectDropdown = ({
   return (
     <Multiselect
       options={options}
-      displayValue={"description"}
+      displayValue={"coord_partner_desc"}
       showCheckbox
       selectedValues={
         partners

--- a/atd-vze/src/views/Crashes/Recommendations/RecommendationSelectValueDropdown.js
+++ b/atd-vze/src/views/Crashes/Recommendations/RecommendationSelectValueDropdown.js
@@ -16,7 +16,6 @@ const RecommendationSelectValueDropdown = ({
 
   const handleOptionClick = e => {
     const { id } = e.target;
-
     // Mutation expect lookup IDs as integers
     const valuesObject = { [field]: parseInt(id) };
     onOptionClick(valuesObject);
@@ -24,7 +23,7 @@ const RecommendationSelectValueDropdown = ({
 
   // Add a null option to enable users to clear out the value
   const makeOptionsWithNullOption = options => [
-    { id: null, description: "None" },
+    { id: null, rec_status_desc: "None" },
     ...options,
   ];
 
@@ -54,7 +53,7 @@ const RecommendationSelectValueDropdown = ({
               onClick={handleOptionClick}
               className="pl-2"
             >
-              {option.description}
+              {option.rec_status_desc}
             </DropdownItem>
           );
         })}

--- a/atd-vze/src/views/Crashes/Recommendations/Recommendations.js
+++ b/atd-vze/src/views/Crashes/Recommendations/Recommendations.js
@@ -157,10 +157,10 @@ const Recommendations = ({ crashId }) => {
             <div className="col-12 pr-0">
               <RecommendationTextInput
                 label={"Recommendation"}
-                data={recommendation?.text}
+                data={recommendation?.rec_text}
                 placeholder={"Enter recommendation here..."}
-                existingValue={getFieldValue(fieldConfig.fields.text.key)}
-                field={fieldConfig.fields.text.key}
+                existingValue={getFieldValue(fieldConfig.fields.rec_text.key)}
+                field={fieldConfig.fields.rec_text.key}
                 doesRecommendationRecordExist={doesRecommendationRecordExist}
                 onAdd={onAdd}
                 onEdit={onEdit}
@@ -171,10 +171,10 @@ const Recommendations = ({ crashId }) => {
             <div className="col-12 pr-0">
               <RecommendationTextInput
                 label={"Updates"}
-                data={recommendation?.update}
+                data={recommendation?.rec_update}
                 placeholder={"Enter updates here..."}
-                existingValue={getFieldValue(fieldConfig.fields.update.key)}
-                field={fieldConfig.fields.update.key}
+                existingValue={getFieldValue(fieldConfig.fields.rec_update.key)}
+                field={fieldConfig.fields.rec_update.key}
                 doesRecommendationRecordExist={doesRecommendationRecordExist}
                 onAdd={onAdd}
                 onEdit={onEdit}

--- a/atd-vze/src/views/Crashes/Recommendations/recommendationsDataMap.js
+++ b/atd-vze/src/views/Crashes/Recommendations/recommendationsDataMap.js
@@ -5,25 +5,25 @@ export const recommendationsDataMap = {
     coordination_partner_id: {
       label: "Coordination Partner:",
       lookupOptions: "atd__coordination_partners_lkp",
-      key: "description",
+      key: "coord_partner_desc",
     },
     recommendation_status_id: {
       label: "Status:",
       lookupOptions: "atd__recommendation_status_lkp",
-      key: "description",
+      key: "rec_status_desc",
     },
-    text: {
+    rec_text: {
       label: "Recommendation",
-      key: "text",
+      key: "rec_text",
     },
-    update: {
+    rec_update: {
       label: "Updates",
-      key: "update",
+      key: "rec_update",
     },
     partner_id: {
       label: "Coordination Partner:",
       lookupOptions: "atd__coordination_partners_lkp",
-      key: "description",
+      key: "coord_partner_desc",
     },
   },
 };

--- a/atd-vze/src/views/Crashes/RelatedRecordsTable.js
+++ b/atd-vze/src/views/Crashes/RelatedRecordsTable.js
@@ -195,9 +195,7 @@ const RelatedRecordsTable = ({
                         {!isEditing &&
                           (fieldConfig.fields[field].badge ? (
                             <Badge
-                              color={fieldConfig.fields[field].badgeColor(
-                                row
-                              )}
+                              color={fieldConfig.fields[field].badgeColor(row)}
                             >
                               {formatValue(row, field)}
                             </Badge>

--- a/atd-vze/src/views/Fatalities/fatalityGridTableParameters.js
+++ b/atd-vze/src/views/Fatalities/fatalityGridTableParameters.js
@@ -55,13 +55,13 @@ export const fatalityGridTableColumns = {
     label_table: "Victim Name",
     type: "String",
   },
-  "recommendation { atd__recommendation_status_lkp { description } }": {
+  "recommendation { atd__recommendation_status_lkp { rec_status_desc } }": {
     searchable: false,
     sortable: true,
     label_table: "Current FRB Status",
     type: "String",
   },
-  "recommendation { text }": {
+  "recommendation { rec_text }": {
     searchable: false,
     sortable: false,
     label_table: "FRB Recommendation",


### PR DESCRIPTION
## Associated issues
Closes https://github.com/cityofaustin/atd-data-tech/issues/12126

## Testing
**URL to test:** <!-- VZ URL or Netlify -->
Local, check out this branch and you have to run the commands in the migrations file to update the recommendations column names

**Steps to test:**
1. Test as admin, IT supervisor, editor, and read only users if you really want to go above and beyond.
2. Go to the crashes table and click the export (save icon) button.
3. If you are admin or IT supervisor you will see 4 new fields at the end of the csv file for recommendation text, update, status, and partners. Note that if you export crashes that dont have data for these fields then the columns wont show up in the export, so make sure you are targeting crashes with fatalities that have recommendations.


---
#### Ship list
- [ ] Code reviewed
- [ ] Product manager approved
