### PR TITLE
Adds new micromobility and e-scooter types

### DIFF
--- a/atd-vzd/migrations/migration_atd_txdot__veh_unit_desc_lkp_and_atd_txdot__veh_body_styl_lkp_2023-05-11--1464.sql
+++ b/atd-vzd/migrations/migration_atd_txdot__veh_unit_desc_lkp_and_atd_txdot__veh_body_styl_lkp_2023-05-11--1464.sql
@@ -1,0 +1,5 @@
+INSERT INTO atd_txdot__veh_unit_desc_lkp (veh_unit_desc_id, veh_unit_desc_desc, eff_beg_date, eff_end_date) values (9, 'NOT REPORTED', '1999-01-01', '9999-12-31');
+INSERT INTO atd_txdot__veh_unit_desc_lkp (veh_unit_desc_id, veh_unit_desc_desc, eff_beg_date, eff_end_date) values (94, 'REPORTED INVALID', '1999-01-01', '9999-12-31');
+INSERT INTO atd_txdot__veh_unit_desc_lkp (veh_unit_desc_id, veh_unit_desc_desc, eff_beg_date, eff_end_date) values (177, 'MICROMOBILITY DEVICE', '1999-01-01', '9999-12-31');
+
+INSERT INTO atd_txdot__veh_body_styl_lkp (veh_body_styl_id, veh_body_styl_desc, eff_beg_date, eff_end_date) values (177, 'E-SCOOTER', '1999-01-01', '9999-12-31');


### PR DESCRIPTION
## Associated issues
fixes https://github.com/cityofaustin/atd-data-tech/issues/11324

this pr adds the 'micromobility device' type and 'e-scooter' body style to the units table to supersede the micromobility flag on the crash table

## Testing
**URL to test:** <!-- VZ URL or Netlify -->
[staging](https://visionzero-staging.austinmobility.io/editor/#/)

**Steps to test:**
- go to a crash
- in the units table, edit the type to 'micromobility device' and save
- edit the body style to 'e-scooter' and save
- refresh the page, the data should persist

---
#### Ship list
- [ ] Code reviewed
- [ ] Product manager approved
