### PR TITLE
Update Victim Name display in FTT Index Page

### DIFF
--- a/atd-vzd/migrations/migration_fatalities_2023_05_22--1726.sql
+++ b/atd-vzd/migrations/migration_fatalities_2023_05_22--1726.sql
@@ -1,0 +1,1 @@
+ALTER TABLE fatalities DROP COLUMN victim_name;

--- a/atd-vzd/views/view_fatalities.sql
+++ b/atd-vzd/views/view_fatalities.sql
@@ -3,9 +3,13 @@ CREATE OR REPLACE VIEW view_fatalities AS (
     SELECT
         f.id,
         f.crash_id,
-        f.victim_name,
         f.person_id,
         f.primaryperson_id,
+        -- if record is primary person then concat primary person names else if person then concat person names.
+        -- also nullify empty string values
+        CASE WHEN f.primaryperson_id IS NOT NULL THEN NULLIF(CONCAT_WS(' ', primaryperson.prsn_first_name, primaryperson.prsn_mid_name, primaryperson.prsn_last_name), '')
+        WHEN f.person_id IS NOT NULL THEN NULLIF(CONCAT_WS(' ', person.prsn_first_name, person.prsn_mid_name, person.prsn_last_name), '')
+        END AS victim_name,
         TO_CHAR(crashes.crash_date,
             'yyyy') AS year,
         CONCAT_WS(' ',
@@ -36,6 +40,8 @@ CREATE OR REPLACE VIEW view_fatalities AS (
     FROM
         fatalities f
     INNER JOIN atd_txdot_crashes crashes ON f.crash_id = crashes.crash_id
+    LEFT JOIN atd_txdot_primaryperson primaryperson ON f.primaryperson_id = primaryperson.primaryperson_id
+    LEFT JOIN atd_txdot_person person ON f.person_id = person.person_id
     WHERE
         crashes.austin_full_purpose = 'Y'
     AND 


### PR DESCRIPTION
## Associated issues
Closes https://github.com/cityofaustin/atd-data-tech/issues/12304

## Testing
**URL to test:** <!-- VZ URL or Netlify -->

**Steps to test:**
1. Check out the Fatalities page and see there are now records with concatenated (first, middle, last) names in the Victim Name column. Records without names should just have a "-".

For merging to prod:
- [ ] Drop view `view_fatalities`
- [ ] Run code to replace `view_fatalities`
- [ ] Drop `victim_name` column from `fatalities`
---
#### Ship list
- [ ] Code reviewed
- [ ] Product manager approved
