### PR TITLE
Fix bug location page export not working

### DIFF
--- a/atd-vze/src/queries/Locations.js
+++ b/atd-vze/src/queries/Locations.js
@@ -63,8 +63,8 @@ export const UPDATE_LOCATION_POLYGON = gql`
 export const locationQueryExportFields = `
 location_id
 description
-crashes_count_cost_summary { total_crashes }
-crashes_count_cost_summary { total_deaths }
-crashes_count_cost_summary { total_serious_injuries }
-crashes_count_cost_summary { est_comp_cost }
+crash_count
+fatalities_count
+serious_injury_count
+total_est_comp_cost
 `;

--- a/atd-vze/src/views/Locations/Locations.js
+++ b/atd-vze/src/views/Locations/Locations.js
@@ -61,9 +61,9 @@ let queryConf = {
     },
   },
   order_by: {
-    total_est_comp_cost: 'desc_nulls_last',
+    total_est_comp_cost: "desc_nulls_last",
   },
-  where: { },
+  where: {},
   limit: 25,
   offset: 0,
 };


### PR DESCRIPTION
## Associated issues
Closes https://github.com/cityofaustin/atd-data-tech/issues/12251

The csv export wasn't working because the [code](https://github.com/cityofaustin/atd-vz-data/blob/2034805b74f2f960833655523f9c9627199aaaf0/atd-vze/src/queries/Locations.js#LL66C14-L66C14) was trying to pull columns from a relationship between the `locations_with_crash_injury_counts` view and `view_location_injry_count_cost_summary` called `crashes_count_cost_summary`, but this relationship didn't exist. I'm not sure why this relationship was even necessary because the required fields are already in the view that the Locations page is based on, `locations_with_crash_injury_counts`, so I just added those columns to the export list instead. Does anyone have any context as to why the code was originally trying to pull from a relationship with `view_location_injry_count_cost_summary` or why we have these two views in the first place when they seemingly carry the same information?

## Testing
**URL to test:** <!-- VZ URL or Netlify -->
https://deploy-preview-1228--atd-vze-staging.netlify.app/#/locations

**Steps to test:**
1. Go to the Locations page, click the export/save button to export a csv, confirm that all the fields are there (location_id
description, crash_count, fatalities_count, serious_injury_count, total_est_comp_cost)


---
#### Ship list
- [x] Code reviewed
- [x] Product manager approved
