### PR TITLE
Refinements to Fatalities Advanced Search

### DIFF
--- a/atd-vze/src/views/Crashes/VictimNameField.js
+++ b/atd-vze/src/views/Crashes/VictimNameField.js
@@ -39,7 +39,7 @@ const VictimNameField = ({
   // Format name by concatenating first, middle, last or returning NO DATA
   const formatName = () => {
     var concatenatedName = "";
-    Object.keys(nameFieldConfig.subfields).map(field => {
+    Object.keys(nameFieldConfig.subfields).forEach(field => {
       if (personData?.[field] != null) {
         concatenatedName = concatenatedName.concat(" ", personData?.[field]);
       }

--- a/atd-vze/src/views/Fatalities/fatalityGridTableParameters.js
+++ b/atd-vze/src/views/Fatalities/fatalityGridTableParameters.js
@@ -83,7 +83,32 @@ export const fatalityGridTableAdvancedFilters = {
         filter: {
           where: [
             {
-              "_or: [ { _and: [ { person: { unit: { unit_desc_id: { _eq: 1 } } } }, { _and: [ { person: { unit: { veh_body_styl_id: { _neq: 71 } } } }, { person: { unit: { veh_body_styl_id: { _neq: 90 } } } } ] } ] }, { _and: [ { primaryperson: { unit: { unit_desc_id: { _eq: 1 } } } }, { _and: [ { primaryperson: { unit: { veh_body_styl_id: { _neq: 71 } } } }, { primaryperson: { unit: { veh_body_styl_id: { _neq: 90 } } } } ] } ] } ]": null,
+              "_or: \
+              [ \
+                { _and: \
+                  [ \
+                    { person: { unit: { unit_desc_id: { _eq: 1 } } } }, \
+                    { _and: \
+                      [ \
+                        { person: { unit: { veh_body_styl_id: { _neq: 71 } } } }, \
+                        { person: { unit: { veh_body_styl_id: { _neq: 90 } } } } \
+                      ] \
+                    } \
+                  ] \
+                }, \
+                { _and: \
+                  [ \
+                    { primaryperson: { unit: { unit_desc_id: { _eq: 1 } } } }, \
+                    { _and: \
+                      [ \
+                        { primaryperson: { unit: { veh_body_styl_id: { _neq: 71 } } } }, \
+                        { primaryperson: { unit: { veh_body_styl_id: { _neq: 90 } } } } \
+                      ] \
+                    } \
+                  ] \
+                } \
+              ] \
+              ": null,
             },
           ],
         },
@@ -94,7 +119,32 @@ export const fatalityGridTableAdvancedFilters = {
         filter: {
           where: [
             {
-              "_or: [ { _and: [ { person: { unit: { unit_desc_id: { _eq: 1 } } } }, { _or: [ { person: { unit: { veh_body_styl_id: { _eq: 71 } } } } , { person: { unit: { veh_body_styl_id: { _eq: 90 } } } } ] } ] }, { _and: [ { primaryperson: { unit: { unit_desc_id: { _eq: 1 } } } }, { _or: [ { primaryperson: { unit: { veh_body_styl_id: { _eq: 71 } } } } , { primaryperson: { unit: { veh_body_styl_id: { _eq: 90 } } } } ] } ] } ]": null,
+              "_or: \
+              [ \
+                { _and: \
+                  [ \
+                    { person: { unit: { unit_desc_id: { _eq: 1 } } } }, \
+                    { _or: \
+                      [ \
+                        { person: { unit: { veh_body_styl_id: { _eq: 71 } } } } , \
+                        { person: { unit: { veh_body_styl_id: { _eq: 90 } } } } \
+                      ] \
+                    } \
+                  ] \
+                }, \
+                { _and: \
+                  [ \
+                    { primaryperson: { unit: { unit_desc_id: { _eq: 1 } } } }, \
+                    { _or: \
+                      [ \
+                        { primaryperson: { unit: { veh_body_styl_id: { _eq: 71 } } } } , \
+                        { primaryperson: { unit: { veh_body_styl_id: { _eq: 90 } } } } \
+                      ] \
+                    } \
+                  ] \
+                } \
+              ] \
+              ": null,
             },
           ],
         },
@@ -127,7 +177,22 @@ export const fatalityGridTableAdvancedFilters = {
         filter: {
           where: [
             {
-              "_or: [ { _and: [ { person: { unit: { unit_desc_id: { _eq: 177 } } } }, { person: { unit: { veh_body_styl_id: { _eq: 177 } } } } ] }, { _and: [ { primaryperson: { unit: { unit_desc_id: { _eq: 177 } } } }, { primaryperson: { unit: { veh_body_styl_id: { _eq: 177 } } } } ] } ]": null,
+              "_or: \
+              [ \
+                { _and: \
+                  [ \
+                    { person: { unit: { unit_desc_id: { _eq: 177 } } } }, \
+                    { person: { unit: { veh_body_styl_id: { _eq: 177 } } } } \
+                  ] \
+                }, \
+                { _and: \
+                  [ \
+                    { primaryperson: { unit: { unit_desc_id: { _eq: 177 } } } }, \
+                    { primaryperson: { unit: { veh_body_styl_id: { _eq: 177 } } } } \
+                  ] \
+                } \
+              ] \
+              ": null,
             },
           ],
         },

--- a/atd-vze/src/views/Fatalities/fatalityGridTableParameters.js
+++ b/atd-vze/src/views/Fatalities/fatalityGridTableParameters.js
@@ -83,32 +83,33 @@ export const fatalityGridTableAdvancedFilters = {
         filter: {
           where: [
             {
-              "_or: \
-              [ \
-                { _and: \
-                  [ \
-                    { person: { unit: { unit_desc_id: { _eq: 1 } } } }, \
-                    { _and: \
-                      [ \
-                        { person: { unit: { veh_body_styl_id: { _neq: 71 } } } }, \
-                        { person: { unit: { veh_body_styl_id: { _neq: 90 } } } } \
-                      ] \
-                    } \
-                  ] \
-                }, \
-                { _and: \
-                  [ \
-                    { primaryperson: { unit: { unit_desc_id: { _eq: 1 } } } }, \
-                    { _and: \
-                      [ \
-                        { primaryperson: { unit: { veh_body_styl_id: { _neq: 71 } } } }, \
-                        { primaryperson: { unit: { veh_body_styl_id: { _neq: 90 } } } } \
-                      ] \
-                    } \
-                  ] \
-                } \
-              ] \
-              ": null,
+              // Wrapped in array brackets so that the template literal can function as an object key
+              [`_or:
+                [
+                  { _and:
+                    [
+                      { person: { unit: { unit_desc_id: { _eq: 1 } } } },
+                      { _and:
+                        [
+                          { person: { unit: { veh_body_styl_id: { _neq: 71 } } } },
+                          { person: { unit: { veh_body_styl_id: { _neq: 90 } } } }
+                        ]
+                      }
+                    ]
+                  },
+                  { _and:
+                    [
+                      { primaryperson: { unit: { unit_desc_id: { _eq: 1 } } } },
+                      { _and:
+                        [
+                          { primaryperson: { unit: { veh_body_styl_id: { _neq: 71 } } } },
+                          { primaryperson: { unit: { veh_body_styl_id: { _neq: 90 } } } }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              `]: null,
             },
           ],
         },
@@ -119,32 +120,32 @@ export const fatalityGridTableAdvancedFilters = {
         filter: {
           where: [
             {
-              "_or: \
-              [ \
-                { _and: \
-                  [ \
-                    { person: { unit: { unit_desc_id: { _eq: 1 } } } }, \
-                    { _or: \
-                      [ \
-                        { person: { unit: { veh_body_styl_id: { _eq: 71 } } } } , \
-                        { person: { unit: { veh_body_styl_id: { _eq: 90 } } } } \
-                      ] \
-                    } \
-                  ] \
-                }, \
-                { _and: \
-                  [ \
-                    { primaryperson: { unit: { unit_desc_id: { _eq: 1 } } } }, \
-                    { _or: \
-                      [ \
-                        { primaryperson: { unit: { veh_body_styl_id: { _eq: 71 } } } } , \
-                        { primaryperson: { unit: { veh_body_styl_id: { _eq: 90 } } } } \
-                      ] \
-                    } \
-                  ] \
-                } \
-              ] \
-              ": null,
+              [`_or:
+                [
+                  { _and:
+                    [
+                      { person: { unit: { unit_desc_id: { _eq: 1 } } } },
+                      { _or:
+                        [
+                          { person: { unit: { veh_body_styl_id: { _eq: 71 } } } } ,
+                          { person: { unit: { veh_body_styl_id: { _eq: 90 } } } } 
+                        ]
+                      }
+                    ]
+                  },
+                  { _and:
+                    [
+                      { primaryperson: { unit: { unit_desc_id: { _eq: 1 } } } },
+                      { _or:
+                        [
+                          { primaryperson: { unit: { veh_body_styl_id: { _eq: 71 } } } } ,
+                          { primaryperson: { unit: { veh_body_styl_id: { _eq: 90 } } } }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              `]: null,
             },
           ],
         },
@@ -177,22 +178,22 @@ export const fatalityGridTableAdvancedFilters = {
         filter: {
           where: [
             {
-              "_or: \
-              [ \
-                { _and: \
-                  [ \
-                    { person: { unit: { unit_desc_id: { _eq: 177 } } } }, \
-                    { person: { unit: { veh_body_styl_id: { _eq: 177 } } } } \
-                  ] \
-                }, \
-                { _and: \
-                  [ \
-                    { primaryperson: { unit: { unit_desc_id: { _eq: 177 } } } }, \
-                    { primaryperson: { unit: { veh_body_styl_id: { _eq: 177 } } } } \
-                  ] \
-                } \
-              ] \
-              ": null,
+              [`_or:
+                [
+                  { _and:
+                    [
+                      { person: { unit: { unit_desc_id: { _eq: 177 } } } },
+                      { person: { unit: { veh_body_styl_id: { _eq: 177 } } } }
+                    ]
+                  },
+                  { _and:
+                    [
+                      { primaryperson: { unit: { unit_desc_id: { _eq: 177 } } } },
+                      { primaryperson: { unit: { veh_body_styl_id: { _eq: 177 } } } }
+                    ]
+                  }
+                ]
+              `]: null,
             },
           ],
         },

--- a/atd-vze/src/views/Fatalities/fatalityGridTableParameters.js
+++ b/atd-vze/src/views/Fatalities/fatalityGridTableParameters.js
@@ -194,8 +194,8 @@ export const fatalityGridTableAdvancedFilters = {
         },
       },
       {
-        id: "status_null",
-        label: "Null",
+        id: "status_none",
+        label: "None",
         filter: {
           where: [
             {
@@ -234,7 +234,7 @@ export const fatalityGridTableAdvancedFilters = {
       },
       {
         id: "road_system_null",
-        label: "Null",
+        label: "Unknown",
         filter: {
           where: [
             {


### PR DESCRIPTION
## Associated issues
Closes https://github.com/cityofaustin/atd-data-tech/issues/12413

## Testing
**URL to test:** <!-- VZ URL or Netlify -->
https://deploy-preview-1232--atd-vze-staging.netlify.app/#/fatalities

**Steps to test:**
1. Go to the Fatalities page, click on the advanced search button.
2. Do you like the new toggle names for null values in the on-system and recommendation status cards? The On-system flag is a value we get from CRIS, so "Unknown" as a label to represent null makes sense to me. Recommendation status is a value the VZ team gives to a fatal crash, so "None" makes sense to me bc its not really unknown, they just haven't given it a status yet so it doesn't exist. 
3. Can you think of better labels for these toggles? Leave your thoughts below!

---
#### Ship list
- [ ] Code reviewed
- [x] Product manager approved
