### PR TITLE
 Add Engineering Areas to the FTT Index

### DIFF
--- a/atd-vzd/views/view_fatalities.sql
+++ b/atd-vzd/views/view_fatalities.sql
@@ -37,11 +37,13 @@ CREATE OR REPLACE VIEW view_fatalities AS (
             AS ytd_fatal_crash,
         crashes.case_id,
         crashes.law_enforcement_num
+        engineering_areas.label as engineering_area,
     FROM
         fatalities f
     INNER JOIN atd_txdot_crashes crashes ON f.crash_id = crashes.crash_id
     LEFT JOIN atd_txdot_primaryperson primaryperson ON f.primaryperson_id = primaryperson.primaryperson_id
     LEFT JOIN atd_txdot_person person ON f.person_id = person.person_id
+    LEFT JOIN engineering_areas ON ST_CONTAINS(engineering_areas.geometry, crashes.position)
     WHERE
         crashes.austin_full_purpose = 'Y'
     AND 

--- a/atd-vzd/views/view_fatalities.sql
+++ b/atd-vzd/views/view_fatalities.sql
@@ -43,7 +43,7 @@ CREATE OR REPLACE VIEW view_fatalities AS (
     INNER JOIN atd_txdot_crashes crashes ON f.crash_id = crashes.crash_id
     LEFT JOIN atd_txdot_primaryperson primaryperson ON f.primaryperson_id = primaryperson.primaryperson_id
     LEFT JOIN atd_txdot_person person ON f.person_id = person.person_id
-    LEFT JOIN engineering_areas ON ST_CONTAINS(engineering_areas.geometry, crashes.position)
+    LEFT JOIN engineering_areas ON engineering_areas.geometry && crashes.position AND ST_CONTAINS(engineering_areas.geometry, crashes.position)
     WHERE
         crashes.austin_full_purpose = 'Y'
     AND 

--- a/atd-vzd/views/view_fatalities.sql
+++ b/atd-vzd/views/view_fatalities.sql
@@ -36,8 +36,8 @@ CREATE OR REPLACE VIEW view_fatalities AS (
             ORDER BY crashes.crash_date ASC, crashes.crash_time ASC, crashes.crash_id) 
             AS ytd_fatal_crash,
         crashes.case_id,
-        crashes.law_enforcement_num
-        engineering_areas.label as engineering_area,
+        crashes.law_enforcement_num,
+        engineering_areas.label as engineering_area
     FROM
         fatalities f
     INNER JOIN atd_txdot_crashes crashes ON f.crash_id = crashes.crash_id

--- a/atd-vze/.env
+++ b/atd-vze/.env
@@ -1,5 +1,5 @@
 REACT_APP_HASURA_ENDPOINT="https://vzd-staging.austinmobility.io/v1/graphql"
-#REACT_APP_HASURA_ENDPOINT="https://localhost:8080/v1/graphql"
+# REACT_APP_HASURA_ENDPOINT="http://localhost:8080/v1/graphql"
 REACT_APP_AUTH0_DOMAIN=atd-datatech.auth0.com
 REACT_APP_AUTH0_CLIENT_ID=2qbqz2sf8L9idBOwn0d5YA9efNgQbL7c
 REACT_APP_MAPBOX_TOKEN="pk.eyJ1Ijoiam9obmNsYXJ5IiwiYSI6ImNqemU4OGQzaTBlZjczYm1rZWg1c2lidTcifQ.2eooq4Q7dv_1Le5la9D96Q"

--- a/atd-vze/src/views/Fatalities/fatalityGridTableParameters.js
+++ b/atd-vze/src/views/Fatalities/fatalityGridTableParameters.js
@@ -60,7 +60,7 @@ export const fatalityGridTableColumns = {
   },
   "recommendation { atd__recommendation_status_lkp { rec_status_desc } }": {
     searchable: false,
-    sortable: true,
+    sortable: false,
     label_table: "Current FRB Status",
     type: "String",
   },
@@ -69,6 +69,13 @@ export const fatalityGridTableColumns = {
     sortable: false,
     label_table: "FRB Recommendation",
     type: "String",
+  },
+  engineering_area: {
+    searchable: true,
+    sortable: true,
+    label_table: "Engineering Area",
+    type: "String",
+    label_search: "Search by Engineering Area",
   },
 };
 

--- a/atd-vze/src/views/Fatalities/fatalityGridTableParameters.js
+++ b/atd-vze/src/views/Fatalities/fatalityGridTableParameters.js
@@ -276,4 +276,5 @@ person { unit { unit_description { veh_unit_desc_desc } } }
 primaryperson { unit { body_style { veh_body_styl_desc } } }
 person { unit { body_style { veh_body_styl_desc } } }
 crash { onsys_fl }
+engineering_area
 `;


### PR DESCRIPTION
## Associated issues
Closes https://github.com/cityofaustin/atd-data-tech/issues/12125

## Testing
**URL to test:** <!-- VZ URL or Netlify -->
[Netlify](https://deploy-preview-1239--atd-vze-staging.netlify.app/#/fatalities)

**Steps to test:**
1. Go to the fatalities page, see the engineering areas in the last column now.
2. Note the engineering area of one of the fatalities. Click on the crash id for that fatality, edit the coordinates, move the coordinate to south/north/central austin. Go back to the fatalities page, search by that crash id, see how the engineering area automatically updates after you edit the coordinates. (This is kinda guess work unless you know exactly where the engineering areas are, but i just moved coordinates to super south or super north to test. You can refer to [the arcgis layer](https://austin.maps.arcgis.com/apps/mapviewer/index.html?layers=28c369f7ab534c64a26a646fca3fd6ec) to see where the engineering areas are).
3. Click the save button on the fatalities page to export as csv. The engineering area has been added as a column to be exported.

On merge to prod:

- [ ] Update DB with new `view_fatalities`. Manually add back in the object relationships it has with other tables.

---
#### Ship list
- [ ] Code reviewed
- [ ] Product manager approved
