### PR TITLE
Update Comprehensive Cost link

### DIFF
--- a/atd-vze/src/views/VZDashboard/VZDashboard.js
+++ b/atd-vze/src/views/VZDashboard/VZDashboard.js
@@ -129,7 +129,7 @@ function VZDashboard() {
             mainText={`Based on Vision Zero polygons`}
             icon="fa fa-map"
             color="primary"
-            link="https://austin.maps.arcgis.com/apps/mapviewer/index.html?webmap=8427b167da8f4f5da24f6255db075f2b"
+            link="https://austin.maps.arcgis.com/apps/instant/interactivelegend/index.html?appid=23500b2ceae54a69b556a17939b70104"
             target="_compcostmap"
           />
           <VZLinksWidget


### PR DESCRIPTION
## Associated issues
This closes [#12653](https://github.com/cityofaustin/atd-data-tech/issues/12653). The VZ team decided to go with a new webmap link versus their current link, which they requested earlier in the month.

## Testing
**URL to test:** [netlify](https://deploy-preview-1243--atd-vze-staging.netlify.app/#/dashboard)

**Steps to test:**
Confirm that the Comprehensive Cost widget link in VZE goes to [this URL](https://austin.maps.arcgis.com/apps/instant/interactivelegend/index.html?appid=23500b2ceae54a69b556a17939b70104)

---
#### Ship list
- [ ] Code reviewed
- [ ] Product manager approved
