### PR TITLE
Escape double quotes and ensure properly formatted CSV

### DIFF
--- a/atd-vze/src/Components/GridExportData.js
+++ b/atd-vze/src/Components/GridExportData.js
@@ -112,36 +112,12 @@ const GridExportData = ({
     });
 
     const cleanedAndFlattenedData = flattenedData.map(item => {
-      // Some fields are presenting issues when they are exported as .csv and
-      // imported into MSFT Excel, Acces & Power BI. For now, we're just going to
-      // modify the data for export to solve issues related to returns and double-quotes
-      // In the future, we may choose to clean these values at the database level.
-
-      const columnsToClean = [
-        "rpt_street_name",
-        "rpt_street_desc",
-        "rpt_sec_street_desc",
-        "rpt_sec_street_name",
-      ];
-
-      // These columns contain user input which may contain double
-      // quotes that need to be escaped for proper csv formatting
-      const columnsToEscapeDoubleQuotes = ["rec_text", "rec_update"];
-
-      columnsToClean.forEach(col => {
-        if (item[col]) {
-          // remove return carriage and replace with space
-          item[col] = item[col].replace(/(\r\n|\n|\r|")/gm, " ");
-          // remove double-quotes
-          item[col] = item[col].replace(/"/g, "");
-        }
-      });
-
-      columnsToEscapeDoubleQuotes.forEach(col => {
-        if (item[col]) {
-          // Replace all double quotes with two double quotes
-          // This escapes double quotes in a csv file
-          item[col] = item[col].replace(/"/g, '""');
+      // We want to escape any instances of double quotes by preceding
+      // them with another double quote. This will put us in compliance
+      // with CSV formatting guidelines https://www.rfc-editor.org/rfc/rfc4180
+      Object.keys(item).forEach(key => {
+        if (typeof item[key] === "string" && item[key].includes('"')) {
+          item[key] = item[key].replace(/"/g, '""');
         }
       });
 

--- a/atd-vze/src/Components/GridExportData.js
+++ b/atd-vze/src/Components/GridExportData.js
@@ -111,19 +111,6 @@ const GridExportData = ({
       return flattenedRow;
     });
 
-    const cleanedAndFlattenedData = flattenedData.map(item => {
-      // We want to escape any instances of double quotes by preceding
-      // them with another double quote. This will put us in compliance
-      // with CSV formatting guidelines https://www.rfc-editor.org/rfc/rfc4180
-      Object.keys(item).forEach(key => {
-        if (typeof item[key] === "string" && item[key].includes('"')) {
-          item[key] = item[key].replace(/"/g, '""');
-        }
-      });
-
-      return item;
-    });
-
     // Create array of columns that should be displayed in the table
     let columnsToExportParsed = [];
 
@@ -142,7 +129,7 @@ const GridExportData = ({
       }
     });
 
-    const cleanedFlattenedAndParsedData = cleanedAndFlattenedData.map(item => {
+    const flattenedAndParsedData = flattenedData.map(item => {
       // Parse out unnecessary columns before exporting table, rename one column
       Object.keys(item).forEach(col => {
         if (!columnsToExportParsed.includes(col)) {
@@ -154,6 +141,19 @@ const GridExportData = ({
           delete item["death_cnt"];
         }
       });
+      return item;
+    });
+
+    const cleanedFlattenedAndParsedData = flattenedAndParsedData.map(item => {
+      // We want to escape any instances of double quotes by preceding
+      // them with another double quote. This will put us in compliance
+      // with CSV formatting guidelines https://www.rfc-editor.org/rfc/rfc4180
+      Object.keys(item).forEach(key => {
+        if (typeof item[key] === "string" && item[key].includes('"')) {
+          item[key] = item[key].replace(/"/g, '""');
+        }
+      });
+
       return item;
     });
 

--- a/atd-vze/src/Components/GridExportData.js
+++ b/atd-vze/src/Components/GridExportData.js
@@ -124,6 +124,8 @@ const GridExportData = ({
         "rpt_sec_street_name",
       ];
 
+      // These columns contain user input which may contain double
+      // quotes that need to be escaped for proper csv formatting
       const columnsToEscapeDoubleQuotes = ["rec_text", "rec_update"];
 
       columnsToClean.forEach(col => {
@@ -137,6 +139,8 @@ const GridExportData = ({
 
       columnsToEscapeDoubleQuotes.forEach(col => {
         if (item[col]) {
+          // Replace all double quotes with two double quotes
+          // This escapes double quotes in a csv file
           item[col] = item[col].replace(/"/g, '""');
         }
       });
@@ -176,8 +180,6 @@ const GridExportData = ({
       });
       return item;
     });
-
-    console.log("data", cleanedFlattenedAndParsedData);
 
     return cleanedFlattenedAndParsedData;
   };

--- a/atd-vze/src/Components/GridExportData.js
+++ b/atd-vze/src/Components/GridExportData.js
@@ -124,12 +124,20 @@ const GridExportData = ({
         "rpt_sec_street_name",
       ];
 
+      const columnsToEscapeDoubleQuotes = ["rec_text", "rec_update"];
+
       columnsToClean.forEach(col => {
         if (item[col]) {
           // remove return carriage and replace with space
           item[col] = item[col].replace(/(\r\n|\n|\r|")/gm, " ");
           // remove double-quotes
           item[col] = item[col].replace(/"/g, "");
+        }
+      });
+
+      columnsToEscapeDoubleQuotes.forEach(col => {
+        if (item[col]) {
+          item[col] = item[col].replace(/"/g, '""');
         }
       });
 
@@ -168,6 +176,8 @@ const GridExportData = ({
       });
       return item;
     });
+
+    console.log("data", cleanedFlattenedAndParsedData);
 
     return cleanedFlattenedAndParsedData;
   };


### PR DESCRIPTION
## Associated issues
Closes https://github.com/cityofaustin/atd-data-tech/issues/12541

The `rec_text` and `rec_update` columns were formatting weird when opening the exported csv from the Crashes or Fatalities pages in a spreadsheet app. This is because VZE users often use double quotes within their inputs for these columns. We weren't properly escaping these double quotes so that apps like Excel can consume the csv without formatting issues.

https://datatracker.ietf.org/doc/html/rfc4180 Lays out the format for CSVs and how to properly escape double quotes

## Testing
**URL to test:** <!-- VZ URL or Netlify -->
https://deploy-preview-1248--atd-vze-staging.netlify.app/#/fatalities

**Steps to test:**
1. Go to the Fatalities tab, click on the save/export csv option.
2. Open the csv in your spreadsheet app of choice (Excel, I use LibreOffice Calc, etc)
3. Are the columns formatted correctly? Is any weird behavior happening? Specifically `rec_text` and `rec_update` were the ones causing issues before, so check that those values look right.

---
#### Ship list
- [ ] Code reviewed
- [ ] Product manager approved
