### PR TITLE
Update github action versions and change cr3 extract to build on master

### DIFF
--- a/.github/workflows/build_docker_images.yml
+++ b/.github/workflows/build_docker_images.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Login to DockerHub
-        uses: docker/login-action@v1 
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_TOKEN }}
@@ -55,7 +55,7 @@ jobs:
 
       - name: Build and push AFD / EMS image
         if: steps.changes.outputs.afd_ems == 'true'
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           platforms: linux/amd64,linux/arm64
           context: atd-etl/afd_ems_import
@@ -64,7 +64,7 @@ jobs:
 
       - name: Build and push CRIS import image
         if: steps.changes.outputs.cris == 'true'
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           platforms: linux/amd64,linux/arm64
           context: atd-etl/cris_import
@@ -73,9 +73,9 @@ jobs:
 
       - name: Build and push CR3 extract diagram image
         if: steps.changes.outputs.cr3_extract == 'true'
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           platforms: linux/amd64,linux/arm64
           context: atd-etl/cr3_extract_diagram
           push: true
-          tags: atddocker/atd-vz-cr3-extract:${{ github.ref == 'refs/heads/production' && 'production' || 'latest' }}
+          tags: atddocker/atd-vz-cr3-extract:${{ github.ref == 'refs/heads/master' && 'production' || 'latest' }}


### PR DESCRIPTION
## Associated issues

none

The multi architecture image tagged production didn't build because it only builds when the production branch is updated. I changed the workflow to build the production tag when the code is merged to master for the cr3 narrative docker image but didn't touch the other two so Frank could give his input on whether or not those should wait for production releases. 



---
#### Ship list
- [ ] Code reviewed
- [ ] Product manager approved
