### PR TITLE
Update local Hasura port from 8080 to 8084

### DIFF
--- a/atd-toolbox/engineering_areas_load/secrets_template.js
+++ b/atd-toolbox/engineering_areas_load/secrets_template.js
@@ -1,6 +1,6 @@
 const HASURA_AUTH = {
   hasura_graphql_endpoint: {
-    local: "http://localhost:8080/v1/graphql",
+    local: "http://localhost:8084/v1/graphql",
   },
   hasura_graphql_admin_secret: {
     local: "hasurapassword",

--- a/atd-vze/.env
+++ b/atd-vze/.env
@@ -1,5 +1,5 @@
 REACT_APP_HASURA_ENDPOINT="https://vzd-staging.austinmobility.io/v1/graphql"
-# REACT_APP_HASURA_ENDPOINT="http://localhost:8080/v1/graphql"
+# REACT_APP_HASURA_ENDPOINT="http://localhost:8084/v1/graphql"
 REACT_APP_AUTH0_DOMAIN=atd-datatech.auth0.com
 REACT_APP_AUTH0_CLIENT_ID=2qbqz2sf8L9idBOwn0d5YA9efNgQbL7c
 REACT_APP_MAPBOX_TOKEN="pk.eyJ1Ijoiam9obmNsYXJ5IiwiYSI6ImNqemU4OGQzaTBlZjczYm1rZWg1c2lidTcifQ.2eooq4Q7dv_1Le5la9D96Q"

--- a/atd-vze/.env
+++ b/atd-vze/.env
@@ -1,5 +1,5 @@
-REACT_APP_HASURA_ENDPOINT="https://vzd-staging.austinmobility.io/v1/graphql"
-# REACT_APP_HASURA_ENDPOINT="http://localhost:8084/v1/graphql"
+# REACT_APP_HASURA_ENDPOINT="https://vzd-staging.austinmobility.io/v1/graphql"
+REACT_APP_HASURA_ENDPOINT="http://localhost:8084/v1/graphql"
 REACT_APP_AUTH0_DOMAIN=atd-datatech.auth0.com
 REACT_APP_AUTH0_CLIENT_ID=2qbqz2sf8L9idBOwn0d5YA9efNgQbL7c
 REACT_APP_MAPBOX_TOKEN="pk.eyJ1Ijoiam9obmNsYXJ5IiwiYSI6ImNqemU4OGQzaTBlZjczYm1rZWg1c2lidTcifQ.2eooq4Q7dv_1Le5la9D96Q"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - ./atd-vzd/graphql-engine-metadata:/metadata
     container_name: visionzero-graphql-engine
     ports:
-      - 8080:8080
+      - 8084:8080
     environment:
       HASURA_GRAPHQL_DATABASE_URL: postgres://visionzero:visionzero@postgis:5432/atd_vz_data
       HASURA_GRAPHQL_ENABLE_CONSOLE: "true"


### PR DESCRIPTION
## Associated issues
**_This is not urgent_**

This is an update to make it easier to run the VZ local stack and the local Airflow stack at the same time. See https://austininnovation.slack.com/archives/CHZE6BC6L/p1690229808701409. Hasura [defaults to serving up the GraphQL endpoint at 8080](https://hasura.io/docs/latest/deployment/graphql-engine-flags/reference/#server-port) which conflicts with the local Airflow dashboard webserver on port 8080 so this update to the Docker compose file maps 8080 in the container to 8084 locally.

## Testing
**URL to test:** <!-- VZ URL or Netlify -->

**Steps to test:**
1. Update `.env` by commenting out line 1 and uncommenting line 2
2. Start the local VZ stack and make sure that the app is sending requests to `http://localhost:8084/v1/graphql`
3. You agree with `8084` and see that [this 1Password entry](https://start.1password.com/open/i?a=RPNXYTT5QNABRL3IE5XBV3362I&v=dgumte7pqvqkpsm7ihg4ni63ke&i=tzlu67ntmpb4gdnpkfdpnmrmrm&h=austintransportation.1password.com) shows `8084` in the **DEVELOPMENT** section endpoints.

---
#### Ship list
- [x] Make sure that 1Password entries that contain this local endpoint all have their ports updated
- [x] Code reviewed
- [x] Product manager approved
