### PR TITLE
Update Socrata ETL GitHub Action

### DIFF
--- a/.github/workflows/build_docker_images.yml
+++ b/.github/workflows/build_docker_images.yml
@@ -91,4 +91,4 @@ jobs:
           platforms: linux/amd64,linux/arm64
           context: atd-etl/socrata_export
           push: true
-          tags: atddocker/vz-socrata-export:${{ github.ref == 'refs/heads/master' && 'production' || 'latest' }}
+          tags: atddocker/vz-socrata-export:${{ github.ref == 'refs/heads/production' && 'production' || 'development' }}


### PR DESCRIPTION
## Associated issues
Since this ETL queries the production VZ database, we need the production Airflow DAG to run production code only. Otherwise, a schema change in staging (like adding a new column, etc) could break the ETL. This happened when the GraphQL query to get crash data had `in_austin_full_purpose` in the filters in staging while the production database still uses `austin_full_purpose`.

See https://austininnovation.slack.com/archives/C013G4RNJ01/p1690432638099059?thread_ts=1690431847.716579&cid=C013G4RNJ01

## Testing
**URL to test:** <!-- VZ URL or Netlify -->
n/a

**Steps to test:**
1. Give me a sanity check on the logic in this change please 🙏

I read the action as:
- Runs when code is pushed to `master` or `production` branch
- if there is a code change within `atd-etl/socrata_export/**`:
    - if the push was from `production` then update Docker image tagged with `production`
    - otherwise, update Docker image tagged with `development` (for Airflow local testing - I realize that I am breaking the convention we started and can change this back to `latest` if anyone feels strongly)

---
#### Ship list
- [x] Code reviewed
- [x] Product manager approved
