### PR TITLE
Fix duplicate filters on VZ Socrata people query

### DIFF
--- a/atd-etl/socrata_export/process/socrata_queries.py
+++ b/atd-etl/socrata_export/process/socrata_queries.py
@@ -85,8 +85,7 @@ people_query_template = Template(
                     {prsn_injry_sev_id: {_eq: 4}}
                 ],
                 _and: {
-                    crash: {crash_date: {_lt: "$date_limit", _gte: "$initial_date_limit" }}
-                    crash: {in_austin_full_purpose: { _eq: true}}
+                    crash: {crash_date: {_lt: "$date_limit", _gte: "$initial_date_limit" }, in_austin_full_purpose: { _eq: true}}
                 }
             }
         ) {
@@ -115,8 +114,7 @@ people_query_template = Template(
                 crash: { private_dr_fl: { _eq: "N" }},
                 _or: [{prsn_injry_sev_id: {_eq: 1}}, {prsn_injry_sev_id: {_eq: 4}}],
                 _and: {
-                    crash: {crash_date: {_lt: "$date_limit", _gte: "$initial_date_limit"}}
-                    crash: {in_austin_full_purpose: { _eq: true}}
+                    crash: {crash_date: {_lt: "$date_limit", _gte: "$initial_date_limit"}, in_austin_full_purpose: { _eq: true}}
                 }
             }
         ) {


### PR DESCRIPTION
## Associated issues
n/a

I should have caught this in review, but there is a duplicate field in the people query filters. Easy fix! We should patch this into production so the ETL can run over the weekend.

```
{
  "errors": [
    {
      "extensions": {
        "path": "$.selectionSet.atd_txdot_person.args.where._and[0]",
        "code": "validation-failed"
      },
      "message": "when parsing a value of type: 'atd_txdot_person_bool_exp', the following fields are duplicated: crash"
    }
  ]
}
```

## Testing
**URL to test:** <!-- VZ URL or Netlify -->

**Steps to test:**
1. I ran the ETL successfully with this update yesterday so double checking the query should be good. This what I tested in the Hasura console:

```
query getPeopleSocrata {
        atd_txdot_person(
            limit: 100,
            offset: 0,
            order_by: {person_id: asc},
            where: {
                crash: { private_dr_fl: { _eq: "N" }},
                _or: [
                    {prsn_injry_sev_id: {_eq: 1}},
                    {prsn_injry_sev_id: {_eq: 4}}
                ],
                _and: {
                    crash: {crash_date: {_lt: "2023-07-27", _gte: "2023-01-01" }, in_austin_full_purpose: { _eq: true}}
                }
            }
        ) {
            person_id
            prsn_injry_sev_id
            prsn_age
            prsn_gndr_id
            prsn_ethnicity_id
            unit_nbr
            crash {
                crash_date
                crash_time
                crash_id
                atd_mode_category_metadata
                units {
                    unit_nbr
                    unit_id
                }
            }
        }
        atd_txdot_primaryperson(
            limit: 100,
            offset: 0,
            order_by: {primaryperson_id: asc},
            where: {
                crash: { private_dr_fl: { _eq: "N" }},
                _or: [{prsn_injry_sev_id: {_eq: 1}}, {prsn_injry_sev_id: {_eq: 4}}],
                _and: {
                    crash: {crash_date: {_lt: "2023-07-27", _gte: "2023-01-01" }, in_austin_full_purpose: { _eq: true}}
                }
            }
        ) {
            primaryperson_id
            prsn_injry_sev_id
            prsn_age
            prsn_gndr_id
            prsn_ethnicity_id
            unit_nbr
            crash {
                crash_date
                crash_time
                crash_id
                atd_mode_category_metadata
                units {
                    unit_nbr
                    unit_id
                }
            }
        }
    }
```


---
#### Ship list
- [ ] Code reviewed
- [ ] Product manager approved
