### PR TITLE
Add crash ID 144720068 to skip list in CR3 download script

### DIFF
--- a/atd-etl/cr3_download/cr3_download.py
+++ b/atd-etl/cr3_download/cr3_download.py
@@ -101,7 +101,7 @@ skipped_uploads_and_updates = []
 # CR3s for these crash IDs are not available in the CRIS database.
 # We can skip requesting them.
 # See https://github.com/cityofaustin/atd-data-tech/issues/9786
-known_skips = [180290542]
+known_skips = [180290542, 144720068]
 
 crashes_list_without_skips = []
 


### PR DESCRIPTION
## Associated issues
n/a

There is a crash from 3-14-2014 that we cannot retrieve a pdf for from CRIS. This adds it to the download script's skip list. See https://visionzero.austin.gov/editor/#/crashes/144720068 for the crash details.

## Testing
**URL to test:** <!-- VZ URL or Netlify -->
n/a

**Steps to test:**
1. [Run the CR3 download script](https://app.gitbook.com/o/-LzDQOVGhTudbKRDGpUA/s/-M4Ul-hSBiM-3KkOynqS/vision-zero-crash-database/cr3-download-script) from this branch with and/or without this change. You should see the script skip this crash ID (or fail to download it if you remove it from the skip list)

---
#### Ship list
- [x] Code reviewed
- [x] Product manager approved
