### PR TITLE
Bring local `graphql-engine` version into sync with production / latest version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,14 +1,7 @@
 version: '3.7'
 services:
   graphql-engine:
-    image: hasura/graphql-engine:v2.20.1  # added to patch critical security vulnerability
-
-    # I'm keeping these next two notes around until we're fully up to date with 2.20.1+ in 
-    # production, because I feel it will be prudent to re-test when we upgrade to 2.20.1+.
-    # since we're going to be coming all the way from the 1.* versions.
-
-    # image: hasura/graphql-engine:v2.16.1 # can jump cleanly to this with shorter event names
-    # image: hasura/graphql-engine:v1.3.3 # use this to rename the events
+    image: hasura/graphql-engine:v2.32.1
     volumes:
       - ./atd-vzd/graphql-engine-metadata:/metadata
     container_name: visionzero-graphql-engine


### PR DESCRIPTION
## Associated issues

[This issue](https://github.com/cityofaustin/atd-data-tech/issues/13392) is the root cause of this change, but does not directly address it. 

This is a change that we would normally do during a release party directly into `master`, but due to our recent upgrade to the `graqphql-engine` middleware, this is needed to spin up the local stack with a replicated or copied database from production.

## Testing

**Steps to test:**

* Spin down your `graphql-engine` endpoint locally
* Replicate the production database into your local database via a backup fround on S3 or pulled directly from the read replica. `./vision-zero replicate-db`
* Check to see if your local `graphql-engine` starts up

---
#### Ship list
- [ ] Code reviewed
- [ ] Product manager approved
