### PR TITLE
adds e-scooter rider to vzv map

### DIFF
--- a/atd-vzv/src/views/nav/SideMapControl.js
+++ b/atd-vzv/src/views/nav/SideMapControl.js
@@ -19,6 +19,7 @@ import {
   faMotorcycle,
   faHeartbeat,
   faMedkit,
+  faMobileAlt,
   faEllipsisH,
   faCheckSquare,
 } from "@fortawesome/free-solid-svg-icons";
@@ -225,6 +226,15 @@ const SideMapControl = ({ type }) => {
           operator: `OR`,
           default: true,
         },
+        scooter: {
+          text: "E-Scooter Rider",
+          icon: faMobileAlt,
+          fatalSyntax: `micromobility_death_count > 0`,
+          injurySyntax: `micromobility_serious_injury_count > 0`,
+          type: `where`,
+          operator: `OR`,
+          default: true,
+        },
         other: {
           icon: faEllipsisH,
           fatalSyntax: `other_death_count > 0`,
@@ -413,7 +423,7 @@ const SideMapControl = ({ type }) => {
                               color={parameter.iconColor && parameter.iconColor}
                             />
                           )}
-                          {title}
+                          {parameter.text ?? title}
                         </Button>
                       </Col>
                     );


### PR DESCRIPTION
## Associated issues
fixes https://github.com/cityofaustin/atd-data-tech/issues/12013

## Testing
**URL to test:** <!-- VZ URL or Netlify -->
https://deploy-preview-1283--atd-vzv-staging.netlify.app/

**Steps to test:**
- go to the vzv map, you should see a new mode category for 'E-Scooter Rider'
- isolate that toggle and test it out under different categories and filters

---
#### Ship list
- [ ] Code reviewed
- [ ] Product manager approved
