### PR TITLE
Locally provided CRIS extract support for import ETL

### DIFF
--- a/atd-etl/cris_import/development_extracts/README.md
+++ b/atd-etl/cris_import/development_extracts/README.md
@@ -1,0 +1,3 @@
+# CRIS extracts used for development go in here.
+
+If you run the `cris_import.py` program in such a way that there are files which match the `/app/development_extracts/*zip` pattern, the program will use those and not attempt to find extracts on the SFTP endpoint. Additionally, the program will not remove the zip file from the local directory.

--- a/atd-etl/cris_import/lib/sql.py
+++ b/atd-etl/cris_import/lib/sql.py
@@ -6,7 +6,7 @@ import pprint
 pp = pprint.PrettyPrinter(indent=4)
 
 # This library is /not/ designed for reuse in other projects. It is designed to increase the
-# readability of the `cris_import.py` prefect flow by pulling logical groups of code out
+# readability of the `cris_import.py` ETL process by pulling logical groups of code out
 # and replacing them with a descriptively named function. The code was reviewed with an
 # eye for getting 100% of the code which forms SQL directly into this file, as code which writes
 # code is universally hard to read and grok. If one considers that each of these functions is called


### PR DESCRIPTION
## Associated issues

_none_, please see https://austininnovation.slack.com/archives/CHZE6BC6L/p1695994302956589. I needed the functionality this morning, and since I had already hit a road bump via leaving a file on the SFTP server yesterday, I went ahead and coded up this feature to use today.

## Purpose

Add support to CRIS import script to process locally provided zip files instead of pulling them via `rsync` from the SFTP server. This is particularly helpful in local development.

## Testing

**Steps to test:**

* Place a CRIS extract zip file in the `atd-etl/cris_import/development_extracts/` folder.
* Spin up local VZDB
* Start the `cris_import` container with `docker compose run cris-import bash`
* Run the export and observe that it doesn't access the SFTP endpoint, but rather uses the local file.

---
#### Ship list
- [ ] Run migration steps in readme in /atd-vzd/ if needed
- [ ] Code reviewed
- [ ] Product manager approved
