### PR TITLE
Replication of LDM staging into the local stack

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,11 +8,9 @@ services:
     ports:
       - 8084:8080
     environment:
-      HASURA_GRAPHQL_ADMIN_SECRET: "thisisasecret"
       HASURA_GRAPHQL_DATABASE_URL: postgres://visionzero:visionzero@postgis:5432/atd_vz_data
       HASURA_GRAPHQL_ENABLE_CONSOLE: "true"
       HASURA_GRAPHQL_CONSOLE_ASSETS_DIR: /srv/console-assets
-      HASURA_TRIGGER_API_KEY: "thisisasecret"
   db-tools:
     container_name: visionzero_download_db_data
     logging:

--- a/env_template
+++ b/env_template
@@ -7,8 +7,14 @@ POSTGRES_DB="atd_vz_data"
 POSTGRES_HOST_AUTH_METHOD="trust"
 PGDATA="/var/lib/postgresql/data/pgdata"
 
-# developer's personal credentials to VZ read reaplica
+# developer's personal credentials to production VZ read reaplica
 RR_USERNAME=""
 RR_PASSWORD=""
 RR_HOSTNAME=""
 RR_DATABASE=""
+
+# credentials to LDM Staging database
+LDM_USERNAME=""
+LDM_PASSWORD=""
+LDM_HOSTNAME=""
+LDM_DATABASE=""

--- a/vision-zero
+++ b/vision-zero
@@ -104,18 +104,18 @@ def removeSnapshots(args):
         print ("Removing " + f)
         os.remove("atd-vzd/snapshots/" + f)
 
-# def replicateDb(includeChangeLogData=False):
 def replicateDb(args):
     graphqlEngineDown(args)
 
     # print(tool_runner_command + replicate_command)
     snapshotFilename = ""
+    prefix = "ldm" if args.ldm else "visionzero"
     if(args.filename):
         snapshotFilename = args.filename
     else:
         today = date.today().strftime("%Y-%m-%d")
         snapshotFilename = (
-            "visionzero_" + today + "_" + (
+            prefix + "_" + today + "_" + (
                 "with-change-log" if args.include_change_log_data else "without-change-log") + ".sql"
         )
     

--- a/vision-zero
+++ b/vision-zero
@@ -41,9 +41,8 @@ def checkDockerComposeAvailability():
         print("Neither `docker-compose` nor `docker compose` is available.")
         exit()
 
-def exportEnvVars(args):
+def setEnvVars(args):
     if(args.ldm):
-        print("ldm")
         os.environ["TARGET_HOSTNAME"] = os.environ["LDM_HOSTNAME"]
         os.environ["TARGET_DATABASE"] = os.environ["LDM_DATABASE"]
         os.environ["TARGET_USERNAME"] = os.environ["LDM_USERNAME"]
@@ -423,7 +422,7 @@ if __name__ == "__main__":
     parser = get_main_parser()
     args = parser.parse_args()
 
-    exportEnvVars(args)
+    setEnvVars(args)
 
-    # docker_compose_invocation = checkDockerComposeAvailability() # global .. 👎
-    # doCommand(args)
+    docker_compose_invocation = checkDockerComposeAvailability() # global .. 👎
+    doCommand(args)

--- a/vision-zero
+++ b/vision-zero
@@ -42,10 +42,27 @@ def checkDockerComposeAvailability():
         exit()
 
 def exportEnvVars(args):
+    export_env_var_command = []
+
     if(args.ldm):
         print("ldm")
+        export_env_var_command = [
+            "export",
+            "TARGET_HOSTNAME=" + os.environ["LDM_HOSTNAME"],
+            "TARGET_DATABASE=" + os.environ["LDM_DATABASE"],
+            "TARGET_USERNAME=" + os.environ["LDM_USERNAME"],
+            "TARGET_PASSWORD=" + os.environ["LDM_PASSWORD"],
+        ]
     else:
-        print("not ldm")
+        export_env_var_command = [
+            "export",
+            "TARGET_HOSTNAME=" + os.environ["RR_HOSTNAME"],
+            "TARGET_DATABASE=" + os.environ["RR_DATABASE"],
+            "TARGET_USERNAME=" + os.environ["RR_USERNAME"],
+            "TARGET_PASSWORD=" + os.environ["RR_PASSWORD"],
+        ]
+
+    subprocess.run(export_env_var_command)
 
 
 def doCommand(args):
@@ -121,10 +138,10 @@ def replicateDb(args):
         "docker-compose-ram-disk.yml" if args.ram_disk else "docker-compose-docker-volume.yml",
         "run",
         "--rm",
-        "-e", "PGHOST=" + os.environ["RR_HOSTNAME"],
-        "-e", "PGDATABASE=" + os.environ["RR_DATABASE"],
-        "-e", "PGUSER=" + os.environ["RR_USERNAME"],
-        "-e", "PGPASSWORD=" + os.environ["RR_PASSWORD"],
+        "-e", "PGHOST=" + os.environ["TARGET_HOSTNAME"],
+        "-e", "PGDATABASE=" + os.environ["TARGET_DATABASE"],
+        "-e", "PGUSER=" + os.environ["TARGET_USERNAME"],
+        "-e", "PGPASSWORD=" + os.environ["TARGET_PASSWORD"],
         "db-tools",
     ]
 

--- a/vision-zero
+++ b/vision-zero
@@ -42,27 +42,17 @@ def checkDockerComposeAvailability():
         exit()
 
 def exportEnvVars(args):
-    export_env_var_command = []
-
     if(args.ldm):
         print("ldm")
-        export_env_var_command = [
-            "export",
-            "TARGET_HOSTNAME=" + os.environ["LDM_HOSTNAME"],
-            "TARGET_DATABASE=" + os.environ["LDM_DATABASE"],
-            "TARGET_USERNAME=" + os.environ["LDM_USERNAME"],
-            "TARGET_PASSWORD=" + os.environ["LDM_PASSWORD"],
-        ]
+        os.environ["TARGET_HOSTNAME"] = os.environ["LDM_HOSTNAME"]
+        os.environ["TARGET_DATABASE"] = os.environ["LDM_DATABASE"]
+        os.environ["TARGET_USERNAME"] = os.environ["LDM_USERNAME"]
+        os.environ["TARGET_PASSWORD"] = os.environ["LDM_PASSWORD"]
     else:
-        export_env_var_command = [
-            "export",
-            "TARGET_HOSTNAME=" + os.environ["RR_HOSTNAME"],
-            "TARGET_DATABASE=" + os.environ["RR_DATABASE"],
-            "TARGET_USERNAME=" + os.environ["RR_USERNAME"],
-            "TARGET_PASSWORD=" + os.environ["RR_PASSWORD"],
-        ]
-
-    subprocess.run(export_env_var_command)
+        os.environ["TARGET_HOSTNAME"] = os.environ["RR_HOSTNAME"]
+        os.environ["TARGET_DATABASE"] = os.environ["RR_DATABASE"]
+        os.environ["TARGET_USERNAME"] = os.environ["RR_USERNAME"]
+        os.environ["TARGET_PASSWORD"] = os.environ["RR_PASSWORD"]
 
 
 def doCommand(args):

--- a/vision-zero
+++ b/vision-zero
@@ -41,6 +41,12 @@ def checkDockerComposeAvailability():
         print("Neither `docker-compose` nor `docker compose` is available.")
         exit()
 
+def exportEnvVars(args):
+    if(args.ldm):
+        print("ldm")
+    else:
+        print("not ldm")
+
 
 def doCommand(args):
     if args.command == "build":
@@ -402,11 +408,15 @@ def get_main_parser():
         ],
     )
     parser.add_argument("-f", "--filename", required=False)
+    parser.add_argument("-l", "--ldm", action="store_true")
     return parser
 
 
 if __name__ == "__main__":
     parser = get_main_parser()
     args = parser.parse_args()
-    docker_compose_invocation = checkDockerComposeAvailability() # global .. 👎
-    doCommand(args)
+
+    exportEnvVars(args)
+
+    # docker_compose_invocation = checkDockerComposeAvailability() # global .. 👎
+    # doCommand(args)


### PR DESCRIPTION
## Associated issues
https://github.com/cityofaustin/atd-data-tech/issues/14181

This adds local replication from the staging LDM instance. There is still [some discussion](https://austininnovation.slack.com/archives/C05F2052S67/p1697127737874349) about how to handle the name of the `staging` database that is in that instance. Will update when we land on something.

## Testing
**URL to test:** <!-- VZ URL or Netlify -->
Local

**Steps to test:**
1. Run `./vision-zero replicate-db`
2. You should see the local stack spin up with the DB table `atd_vz_data` populated with a snapshot of production VZ
3. Set the LDM staging DB details in your `.env` using the names added to the template from the 1Pass entry called `RDS Instance: LDM staging`
4. Run `./vision-zero -l replicate-db`
5. You should see the local stack spin up with the DB table `atd_vz_data` populated with a snapshot of the current staging LDM
6. The filenames of the snapshots should start with either `visionzero` or `ldm` depending on the ldm flag

---
#### Ship list
- [ ] ~Run migration steps in readme in /atd-vzd/ if needed~
- [x] Code reviewed
- [x] Product manager approved
