### PR TITLE
Fix issue with VZE reaching local Hasura engine

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,11 +8,9 @@ services:
     ports:
       - 8084:8080
     environment:
-      HASURA_GRAPHQL_ADMIN_SECRET: "thisisasecret"
       HASURA_GRAPHQL_DATABASE_URL: postgres://visionzero:visionzero@postgis:5432/atd_vz_data
       HASURA_GRAPHQL_ENABLE_CONSOLE: "true"
       HASURA_GRAPHQL_CONSOLE_ASSETS_DIR: /srv/console-assets
-      HASURA_TRIGGER_API_KEY: "thisisasecret"
   db-tools:
     container_name: visionzero_download_db_data
     logging:


### PR DESCRIPTION
## Associated issues
n/a - **not super urgent! no rush here**

We made this change in the LDM collector branch, and I think it should be made here. See https://austininnovation.slack.com/archives/CHZE6BC6L/p1694546030904709 for when this first came up. I had introduced the admin secret due to an error that happened during migration initialization and didn't realize that it prevented local VZE from talking to the local stack.

`HASURA_TRIGGER_API_KEY` was a remnant from the Hasura event triggers. It is no longer used.

## Testing
**URL to test:** <!-- VZ URL or Netlify -->
Local

**Steps to test:**
1. Spin up the local DB and Hasura engine (`./vision-zero replicate-db` for example) and then start VZE too
2. VZE should have no issues reaching Hasura anymore. All views should load data from the local stack.

---
#### Ship list
- [ ] ~Run migration steps in readme in /atd-vzd/ if needed~
- [x] Code reviewed
- [x] Product manager approved
