### PR TITLE
Fix the location listing view such that a location is represented if it has one of, but not both, CR3 & non-CR3 crashes

### DIFF
--- a/atd-vzd/migrations/default/1698093746763_fix-location-view/down.sql
+++ b/atd-vzd/migrations/default/1698093746763_fix-location-view/down.sql
@@ -1,0 +1,40 @@
+-- public.locations_with_crash_injury_counts source
+
+CREATE OR REPLACE VIEW public.locations_with_crash_injury_counts
+AS WITH crashes AS (
+         WITH cris_crashes AS (
+                 SELECT crashes_1.location_id,
+                    count(crashes_1.crash_id) AS crash_count,
+                    COALESCE(sum(crashes_1.est_comp_cost_crash_based), 0::numeric) AS total_est_comp_cost,
+                    COALESCE(sum(crashes_1.death_cnt), 0::bigint) AS fatality_count,
+                    COALESCE(sum(crashes_1.sus_serious_injry_cnt), 0::bigint) AS suspected_serious_injury_count
+                   FROM atd_txdot_crashes crashes_1
+                  WHERE true AND crashes_1.location_id IS NOT NULL AND crashes_1.crash_date > (now() - '5 years'::interval)
+                  GROUP BY crashes_1.location_id
+                ), apd_crashes AS (
+                 SELECT crashes_1.location_id,
+                    count(crashes_1.case_id) AS crash_count,
+                    COALESCE(sum(crashes_1.est_comp_cost), 0::numeric) AS total_est_comp_cost,
+                    0 AS fatality_count,
+                    0 AS suspected_serious_injury_count
+                   FROM atd_apd_blueform crashes_1
+                  WHERE true AND crashes_1.location_id IS NOT NULL AND crashes_1.date > (now() - '5 years'::interval)
+                  GROUP BY crashes_1.location_id
+                )
+         SELECT cris_crashes.location_id,
+            cris_crashes.crash_count + apd_crashes.crash_count AS crash_count,
+            cris_crashes.total_est_comp_cost + (10000 * apd_crashes.crash_count)::numeric AS total_est_comp_cost,
+            cris_crashes.fatality_count + apd_crashes.fatality_count AS fatalities_count,
+            cris_crashes.suspected_serious_injury_count + apd_crashes.suspected_serious_injury_count AS serious_injury_count
+           FROM cris_crashes
+             FULL JOIN apd_crashes ON cris_crashes.location_id::text = apd_crashes.location_id::text
+        )
+ SELECT locations.description,
+    locations.location_id,
+    COALESCE(crashes.crash_count, 0::bigint) AS crash_count,
+    COALESCE(crashes.total_est_comp_cost, 0::numeric) AS total_est_comp_cost,
+    COALESCE(crashes.fatalities_count, 0::bigint) AS fatalities_count,
+    COALESCE(crashes.serious_injury_count, 0::bigint) AS serious_injury_count
+   FROM atd_txdot_locations locations
+     LEFT JOIN crashes ON locations.location_id::text = crashes.location_id::text
+  WHERE true AND locations.council_district > 0 AND locations.location_group = 1;

--- a/atd-vzd/migrations/default/1698093746763_fix-location-view/up.sql
+++ b/atd-vzd/migrations/default/1698093746763_fix-location-view/up.sql
@@ -1,0 +1,40 @@
+CREATE OR REPLACE VIEW public.locations_with_crash_injury_counts
+AS
+WITH crashes AS (
+         WITH cris_crashes AS (
+                 SELECT cr3_crashes.location_id,
+                    count(cr3_crashes.crash_id) AS crash_count,
+                    COALESCE(sum(cr3_crashes.est_comp_cost_crash_based), 0::numeric) AS total_est_comp_cost,
+                    COALESCE(sum(cr3_crashes.death_cnt), 0::bigint) AS fatality_count,
+                    COALESCE(sum(cr3_crashes.sus_serious_injry_cnt), 0::bigint) AS suspected_serious_injury_count
+                   FROM atd_txdot_crashes cr3_crashes
+                  WHERE true AND cr3_crashes.location_id IS NOT NULL AND cr3_crashes.crash_date > (now() - '5 years'::interval)
+                  GROUP BY cr3_crashes.location_id
+                ), apd_crashes AS (
+                 SELECT non_cr3_crashes.location_id,
+                    count(non_cr3_crashes.case_id) AS crash_count,
+                    COALESCE(sum(non_cr3_crashes.est_comp_cost), 0::numeric) AS total_est_comp_cost,
+                    0 AS fatality_count,
+                    0 AS suspected_serious_injury_count
+                   FROM atd_apd_blueform non_cr3_crashes
+                  WHERE true AND non_cr3_crashes.location_id IS NOT NULL AND non_cr3_crashes.date > (now() - '5 years'::interval)
+                  GROUP BY non_cr3_crashes.location_id
+                )
+         SELECT cris_crashes.location_id,
+            coalesce(cris_crashes.crash_count, 0) + coalesce(apd_crashes.crash_count, 0) AS crash_count,
+            coalesce(cris_crashes.total_est_comp_cost, 0) + (10000 * coalesce(apd_crashes.crash_count, 0))::numeric AS total_est_comp_cost,
+            coalesce(cris_crashes.fatality_count, 0) + coalesce(apd_crashes.fatality_count, 0) AS fatalities_count,
+            coalesce(cris_crashes.suspected_serious_injury_count, 0) + coalesce(apd_crashes.suspected_serious_injury_count, 0) AS serious_injury_count
+           FROM cris_crashes
+             FULL JOIN apd_crashes ON cris_crashes.location_id::text = apd_crashes.location_id::text
+        )
+ SELECT locations.description,
+    locations.location_id,
+    COALESCE(crashes.crash_count, 0) AS crash_count,
+    COALESCE(crashes.total_est_comp_cost, 0::numeric) AS total_est_comp_cost,
+    COALESCE(crashes.fatalities_count, 0) AS fatalities_count,
+    COALESCE(crashes.serious_injury_count, 0) AS serious_injury_count
+   FROM atd_txdot_locations locations
+     LEFT JOIN crashes ON locations.location_id::text = crashes.location_id::text
+  WHERE true 
+  AND locations.council_district > 0 AND locations.location_group = 1;

--- a/atd-vzd/views/locations_with_crash_injury_counts.sql
+++ b/atd-vzd/views/locations_with_crash_injury_counts.sql
@@ -33,10 +33,11 @@ create or replace view locations_with_crash_injury_counts as
     -- use the two sets of crashes above to build up a set of locations with crash counts and injury counts.
     select  -- think of this as step 2 of the query
       cris_crashes.location_id,
-      cris_crashes.crash_count + apd_crashes.crash_count as crash_count,
-      cris_crashes.total_est_comp_cost + (10000 * apd_crashes.crash_count) as total_est_comp_cost,
-      cris_crashes.fatality_count + apd_crashes.fatality_count as fatalities_count,
-      cris_crashes.suspected_serious_injury_count + apd_crashes.suspected_serious_injury_count as serious_injury_count
+           SELECT cris_crashes.location_id,
+            coalesce(cris_crashes.crash_count, 0) + coalesce(apd_crashes.crash_count, 0) AS crash_count,
+            coalesce(cris_crashes.total_est_comp_cost, 0) + (10000 * coalesce(apd_crashes.crash_count, 0))::numeric AS total_est_comp_cost,
+            coalesce(cris_crashes.fatality_count, 0) + coalesce(apd_crashes.fatality_count, 0) AS fatalities_count,
+            coalesce(cris_crashes.suspected_serious_injury_count, 0) + coalesce(apd_crashes.suspected_serious_injury_count, 0) AS serious_injury_count
     from cris_crashes
     -- this unions the sets, over location_id, such that a location is represented if it has either/or/and a cris and blueform crash(s).
     full outer join apd_crashes


### PR DESCRIPTION
## Associated issues

This PR squashes https://github.com/cityofaustin/atd-data-tech/issues/14354.

## Testing
Testing is best done in your local database.

### Basic Testing

* Get a fresh copy of the production VZ DB. `./vision-zero replicate-db`
* Open up your fav SQL client and work your way through this script. Make sure you agree with and observe what the comments suggest.

```sql
-- We're going to do our tests by looking at the specific numbers for a location, 8459D52C56.
-- I'll be focusing on the number of crashes, but you can track any or all of the other fields as well.
-- Confirm that this location has both cr3 and non-cr3 crashes:


-- 5 crashes
SELECT cr3_crashes.location_id,
  count(cr3_crashes.crash_id) AS crash_count,
  COALESCE(sum(cr3_crashes.est_comp_cost_crash_based), 0::numeric) AS total_est_comp_cost,
  COALESCE(sum(cr3_crashes.death_cnt), 0::bigint) AS fatality_count,
  COALESCE(sum(cr3_crashes.sus_serious_injry_cnt), 0::bigint) AS suspected_serious_injury_count
FROM atd_txdot_crashes cr3_crashes
WHERE true 
  AND cr3_crashes.location_id IS NOT NULL 
  AND cr3_crashes.crash_date > (now() - '5 years'::interval)
  AND cr3_crashes.location_id = '8459D52C56'
GROUP BY cr3_crashes.location_id;

-- 4 crashes
SELECT non_cr3_crashes.location_id,
  count(non_cr3_crashes.case_id) AS crash_count,
  COALESCE(sum(non_cr3_crashes.est_comp_cost), 0::numeric) AS total_est_comp_cost,
  0 AS fatality_count,
  0 AS suspected_serious_injury_count
FROM atd_apd_blueform non_cr3_crashes
WHERE true 
  AND non_cr3_crashes.location_id IS NOT NULL
  AND non_cr3_crashes.date > (now() - '5 years'::interval)
  AND non_cr3_crashes.location_id = '8459D52C56'
GROUP BY non_cr3_crashes.location_id


-- This is the "old" query that drives the view prior to this PR below.
-- Observe that the counts are the sums of the numbers above. This is good.
--
-- However this only works when there are at least some of both CR3 and non-CR3
-- crashes, otherwise, the sumation at the end ends up adding a number to a null
-- value which is null. The COALESCE functions in the two CTE queries up top do not
-- save us here, because there are 0 rows being returned out of the query to bear that 0.
-- Instead the FULL JOIN fills in nulls for the fields that came from the table that had 
-- no records. FULL JOIN means every row from both tables are in the output, and use null
-- when needed.

WITH crashes AS (
         WITH cris_crashes AS (
                 SELECT cr3_crashes.location_id,
                    count(cr3_crashes.crash_id) AS crash_count,
                    COALESCE(sum(cr3_crashes.est_comp_cost_crash_based), 0::numeric) AS total_est_comp_cost,
                    COALESCE(sum(cr3_crashes.death_cnt), 0::bigint) AS fatality_count,
                    COALESCE(sum(cr3_crashes.sus_serious_injry_cnt), 0::bigint) AS suspected_serious_injury_count
                   FROM atd_txdot_crashes cr3_crashes
                  WHERE true AND cr3_crashes.location_id IS NOT NULL AND cr3_crashes.crash_date > (now() - '5 years'::interval)
                  GROUP BY cr3_crashes.location_id
                ), apd_crashes AS (
                 SELECT non_cr3_crashes.location_id,
                    count(non_cr3_crashes.case_id) AS crash_count,
                    COALESCE(sum(non_cr3_crashes.est_comp_cost), 0::numeric) AS total_est_comp_cost,
                    0 AS fatality_count,
                    0 AS suspected_serious_injury_count
                   FROM atd_apd_blueform non_cr3_crashes
                  WHERE true AND non_cr3_crashes.location_id IS NOT NULL AND non_cr3_crashes.date > (now() - '5 years'::interval)
                  GROUP BY non_cr3_crashes.location_id
                )
         SELECT cris_crashes.location_id,
            cris_crashes.crash_count + apd_crashes.crash_count AS crash_count,
            cris_crashes.total_est_comp_cost + (10000 * apd_crashes.crash_count)::numeric AS total_est_comp_cost,
            cris_crashes.fatality_count + apd_crashes.fatality_count AS fatalities_count,
            cris_crashes.suspected_serious_injury_count + apd_crashes.suspected_serious_injury_count AS serious_injury_count
           FROM cris_crashes
             FULL JOIN apd_crashes ON cris_crashes.location_id::text = apd_crashes.location_id::text
        )
 SELECT locations.description,
    locations.location_id,
    COALESCE(crashes.crash_count, 0) AS crash_count,
    COALESCE(crashes.total_est_comp_cost, 0::numeric) AS total_est_comp_cost,
    COALESCE(crashes.fatalities_count, 0) AS fatalities_count,
    COALESCE(crashes.serious_injury_count, 0) AS serious_injury_count
   FROM atd_txdot_locations locations
     LEFT JOIN crashes ON locations.location_id::text = crashes.location_id::text
  WHERE true 
  AND locations.council_district > 0 AND locations.location_group = 1
  and locations.location_id = '8459D52C56';
  

-- OK so let's break this. 

truncate atd_apd_blueform;

-- We know no that there are no records coming into the above query from the non-cr3 CTE.
-- Try it out on the big query above. You'll get zero for the number
-- of crashes. It *should* read 5 crashes which is the 9 from when we started
-- minus the 4 we deleted when we truncated the blueform table. That's the bug.

-- Here's a fixed copy of the query with every count coalesced into zero if it's null. 
-- The absencese of crashes is 0 crashes not the empty set of crashes in the eyes of addition.
-- This will correctly report 5 crashes.

WITH crashes AS (
         WITH cris_crashes AS (
                 SELECT cr3_crashes.location_id,
                    count(cr3_crashes.crash_id) AS crash_count,
                    COALESCE(sum(cr3_crashes.est_comp_cost_crash_based), 0::numeric) AS total_est_comp_cost,
                    COALESCE(sum(cr3_crashes.death_cnt), 0::bigint) AS fatality_count,
                    COALESCE(sum(cr3_crashes.sus_serious_injry_cnt), 0::bigint) AS suspected_serious_injury_count
                   FROM atd_txdot_crashes cr3_crashes
                  WHERE true AND cr3_crashes.location_id IS NOT NULL AND cr3_crashes.crash_date > (now() - '5 years'::interval)
                  GROUP BY cr3_crashes.location_id
                ), apd_crashes AS (
                 SELECT non_cr3_crashes.location_id,
                    count(non_cr3_crashes.case_id) AS crash_count,
                    COALESCE(sum(non_cr3_crashes.est_comp_cost), 0::numeric) AS total_est_comp_cost,
                    0 AS fatality_count,
                    0 AS suspected_serious_injury_count
                   FROM atd_apd_blueform non_cr3_crashes
                  WHERE true AND non_cr3_crashes.location_id IS NOT NULL AND non_cr3_crashes.date > (now() - '5 years'::interval)
                  GROUP BY non_cr3_crashes.location_id
                )
         SELECT cris_crashes.location_id,
            -- changes here, over the next four lines
            coalesce(cris_crashes.crash_count, 0) + coalesce(apd_crashes.crash_count, 0) AS crash_count,
            coalesce(cris_crashes.total_est_comp_cost, 0) + (10000 * coalesce(apd_crashes.crash_count, 0))::numeric AS total_est_comp_cost,
            coalesce(cris_crashes.fatality_count, 0) + coalesce(apd_crashes.fatality_count, 0) AS fatalities_count,
            coalesce(cris_crashes.suspected_serious_injury_count, 0) + coalesce(apd_crashes.suspected_serious_injury_count, 0) AS serious_injury_count
           FROM cris_crashes
             FULL JOIN apd_crashes ON cris_crashes.location_id::text = apd_crashes.location_id::text
        )
 SELECT locations.description,
    locations.location_id,
    COALESCE(crashes.crash_count, 0) AS crash_count,
    COALESCE(crashes.total_est_comp_cost, 0::numeric) AS total_est_comp_cost,
    COALESCE(crashes.fatalities_count, 0) AS fatalities_count,
    COALESCE(crashes.serious_injury_count, 0) AS serious_injury_count
   FROM atd_txdot_locations locations
     LEFT JOIN crashes ON locations.location_id::text = crashes.location_id::text
  WHERE true 
  AND locations.council_district > 0 AND locations.location_group = 1
  and locations.location_id = '8459D52C56';

```

* If you're satisfied with the problem's demonstration and the proposed solution, then review the code to see that it's implemented correctly. 
* And finally, get a new, fresh copy of that database because the above script emptied out the non-cr3 crashes, and use the `hasura migrate apply` command in your `vzd` directory to see that is applied cleanly. The metadata is unchanged.

### Extra-mile-testing, continuing on:
* Look at the `locations_with_crash_injury_counts` view. Pick some to spot check if you want.
* `truncate` the non-cr3 or cr3 crashes table and see that there are non-zero values in any location's count fields.
* Check that the values returned now are what you'd expect based on what's in the table you didn't truncate.
* Fire up the VZE and observe that the front end app continues to work the way you'd expect.

---
#### Ship list
- [ ] Check migrations for any conflicts with latest migrations in master branch
- [ ] Code reviewed
- [ ] Product manager approved
