### PR TITLE
Make manner of collision editable on temp records

### DIFF
--- a/atd-vze/src/views/Crashes/crashDataMap.js
+++ b/atd-vze/src/views/Crashes/crashDataMap.js
@@ -45,7 +45,7 @@ export const createCrashDataMap = isTempRecord => {
         },
         fhe_collsn_id: {
           label: "Manner of Collision ID",
-          editable: false,
+          editable: isTempRecord,
           uiType: "select",
           lookupOptions: "atd_txdot__collsn_lkp",
           lookupPrefix: "collsn", // We need this field so we can reference the collsn_id & collsn_desc fields in the lookup table


### PR DESCRIPTION
## Associated issues
Closes https://github.com/cityofaustin/atd-data-tech/issues/7741

## Testing
**URL to test:** <!-- VZ URL or Netlify -->
https://deploy-preview-1317--atd-vze-staging.netlify.app/#/

**Steps to test:**
1. Go to a non-temp crash, the Manner of collision field should not be editable.
2. Go to a temp crash (can find them on the Create crash record tab), you should be able to edit and change the Manner of collision field.


---
#### Ship list
- [ ] Check migrations for any conflicts with latest migrations in master branch
- [ ] Code reviewed
- [x] Product manager approved
