### PR TITLE
Create a new field peh_fl in the database for a Person Experiencing Homelessness

### DIFF
--- a/atd-vzd/migrations/default/1699990226463_alter_table_public_atd_txdot_person_add_column_peh_fl/down.sql
+++ b/atd-vzd/migrations/default/1699990226463_alter_table_public_atd_txdot_person_add_column_peh_fl/down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE public.atd_txdot_person
+DROP COLUMN IF EXISTS peh_fl;

--- a/atd-vzd/migrations/default/1699990226463_alter_table_public_atd_txdot_person_add_column_peh_fl/up.sql
+++ b/atd-vzd/migrations/default/1699990226463_alter_table_public_atd_txdot_person_add_column_peh_fl/up.sql
@@ -1,0 +1,4 @@
+alter table "public"."atd_txdot_person" add column "peh_fl" boolean
+ null;
+
+COMMENT ON COLUMN public.atd_txdot_person.peh_fl IS 'Boolean flag that indicates whether the person was experiencing homelessness at the time of the crash.';

--- a/atd-vzd/migrations/default/1699990248367_alter_table_public_atd_txdot_primaryperson_add_column_peh_fl/down.sql
+++ b/atd-vzd/migrations/default/1699990248367_alter_table_public_atd_txdot_primaryperson_add_column_peh_fl/down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE public.atd_txdot_primaryperson
+DROP COLUMN IF EXISTS peh_fl;

--- a/atd-vzd/migrations/default/1699990248367_alter_table_public_atd_txdot_primaryperson_add_column_peh_fl/up.sql
+++ b/atd-vzd/migrations/default/1699990248367_alter_table_public_atd_txdot_primaryperson_add_column_peh_fl/up.sql
@@ -1,0 +1,4 @@
+alter table "public"."atd_txdot_primaryperson" add column "peh_fl" boolean
+ null;
+
+COMMENT ON COLUMN public.atd_txdot_primaryperson.peh_fl IS 'Boolean flag that indicates whether the person was experiencing homelessness at the time of the crash.';

--- a/atd-vze/src/queries/people.js
+++ b/atd-vze/src/queries/people.js
@@ -25,6 +25,7 @@ export const GET_PEOPLE = gql`
         ethnicity_desc
       }
       unit_nbr
+      peh_fl
     }
     atd_txdot_person(where: { crash_id: { _eq: $crashId } }) {
       prsn_age
@@ -47,6 +48,7 @@ export const GET_PEOPLE = gql`
         ethnicity_desc
       }
       unit_nbr
+      peh_fl
     }
   }
 `;

--- a/atd-vze/src/views/Crashes/RelatedRecordsTable.js
+++ b/atd-vze/src/views/Crashes/RelatedRecordsTable.js
@@ -79,6 +79,10 @@ const RelatedRecordsTable = ({
     if (typeof data[field] === "object") {
       fieldValue =
         data[field] && data[field][fieldConfig.fields[field].lookup_desc];
+    } else if (data[field] === true) {
+      fieldValue = "YES";
+    } else if (data[field] === false) {
+      fieldValue = "NO";
     }
 
     // Display null values as blanks, but allow 0
@@ -237,8 +241,8 @@ const RelatedRecordsTable = ({
                                     }
                                   >
                                     <option value={""}>NO DATA</option>
-                                    <option value={true}>TRUE</option>
-                                    <option value={false}>FALSE</option>
+                                    <option value={true}>YES</option>
+                                    <option value={false}>NO</option>
                                   </Input>
                                 )}
                                 <div className="d-flex">

--- a/atd-vze/src/views/Crashes/RelatedRecordsTable.js
+++ b/atd-vze/src/views/Crashes/RelatedRecordsTable.js
@@ -228,6 +228,19 @@ const RelatedRecordsTable = ({
                                     })}
                                   </Input>
                                 )}
+                                {uiType === "boolean" && (
+                                  <Input
+                                    defaultValue={row[field]}
+                                    type="select"
+                                    onChange={e =>
+                                      handleInputChange(e, updateFieldKey)
+                                    }
+                                  >
+                                    <option value={""}>NO DATA</option>
+                                    <option value={true}>TRUE</option>
+                                    <option value={false}>FALSE</option>
+                                  </Input>
+                                )}
                                 <div className="d-flex">
                                   <Button
                                     type="submit"

--- a/atd-vze/src/views/Crashes/personDataMap.js
+++ b/atd-vze/src/views/Crashes/personDataMap.js
@@ -108,7 +108,7 @@ export const primaryPersonDataMap = [
         editable: false,
       },
       peh_fl: {
-        label: "Experiencing Homelessness",
+        label: "Unhoused",
         editable: true,
         format: "boolean",
         mutationVariableKey: "personId",
@@ -189,7 +189,7 @@ export const personDataMap = [
         mutationVariableKey: "personId",
       },
       peh_fl: {
-        label: "Experiencing Homelessness",
+        label: "Unhoused",
         editable: true,
         format: "boolean",
         mutationVariableKey: "personId",

--- a/atd-vze/src/views/Crashes/personDataMap.js
+++ b/atd-vze/src/views/Crashes/personDataMap.js
@@ -21,12 +21,12 @@ const getInjurySeverityColor = personRecord => {
     case 4: // FATAL INJURY: red
       return "danger";
     case 99: // KILLED: red
-      return "secondary"
-    default: // Other cases: Not reported, Reported invalid, Not injured
+      return "secondary";
+    default:
+      // Other cases: Not reported, Reported invalid, Not injured
       return "secondary";
   }
 };
-
 
 export const primaryPersonDataMap = [
   {
@@ -107,6 +107,12 @@ export const primaryPersonDataMap = [
         label: "ZIP",
         editable: false,
       },
+      peh_fl: {
+        label: "Experiencing Homelessness",
+        editable: true,
+        format: "boolean",
+        mutationVariableKey: "personId",
+      },
     },
   },
 ];
@@ -180,6 +186,12 @@ export const personDataMap = [
         lookupOptions: "atd_txdot__ethnicity_lkp",
         lookupPrefix: "ethnicity",
         updateFieldKey: "prsn_ethnicity_id",
+        mutationVariableKey: "personId",
+      },
+      peh_fl: {
+        label: "Experiencing Homelessness",
+        editable: true,
+        format: "boolean",
         mutationVariableKey: "personId",
       },
     },


### PR DESCRIPTION
## Associated issues
Closes https://github.com/cityofaustin/atd-data-tech/issues/13561

This issue didn't have specs for what the UI interaction should be, but there really is no other place in the editor for editing the fields of the persons table that makes sense other than the Related Records section, so I put the functionality there.

## Testing
**URL to test:** <!-- VZ URL or Netlify -->
Local!

**Steps to test:**
1. Checkout this branch, start up your local db and run the new migrations in this branch:
```bash
hasura migrate apply --envfile .env.local
hasura metadata apply --envfile .env.local
``` 
3. Load up the VZE pointing to your local db
4. Go to a crash, you should now see the "Experiencing Homelessness" field in the People section of the Related Records table.
5. Test editing the field to be True, False, and back to No Data (null in the db).


---
#### Ship list
- [ ] Check migrations for any conflicts with latest migrations in master branch
- [ ] Code reviewed
- [x] Product manager approved
