### PR TITLE
Fix broken manual trigger of DB migration/metadata workflow

### DIFF
--- a/.github/workflows/apply_db_migrations_and_metadata.yml
+++ b/.github/workflows/apply_db_migrations_and_metadata.yml
@@ -12,10 +12,10 @@ on:
       - "atd-vzd/**"
       - ".github/workflows/apply_db_migrations_and_metadata.yml" 
       - ".github/workflows/migration-helper.sh"
-    workflow_dispatch:
-      inputs:
-        description:
-          default: ""
+  workflow_dispatch:
+    inputs:
+      description:
+        default: ""
 
 jobs:
   apply:


### PR DESCRIPTION
## Associated issues
I checked this config side-by-side in an editor and saw that the `workflow_dispatch` config was indented too far and was falling into the `push` config when I originally added it to this workflow. 🙃

## Testing
**URL to test:** <!-- VZ URL or Netlify -->
n/a

**Steps to test:**
Compare this change to make sure it matches up with what is in `atd-vz-data/.github/workflows/deploy_vz_api.yml`.

We should be able to manually trigger this after merge to master.

---
#### Ship list
- [ ] Check migrations for any conflicts with latest migrations in master branch
- [x] Code reviewed
- [x] Product manager approved
