### PR TITLE
Update Unhoused description in People card

### DIFF
--- a/atd-vze/src/views/Crashes/RelatedRecordsTable.js
+++ b/atd-vze/src/views/Crashes/RelatedRecordsTable.js
@@ -79,10 +79,6 @@ const RelatedRecordsTable = ({
     if (typeof data[field] === "object") {
       fieldValue =
         data[field] && data[field][fieldConfig.fields[field].lookup_desc];
-    } else if (data[field] === true) {
-      fieldValue = "YES";
-    } else if (data[field] === false) {
-      fieldValue = "NO";
     }
 
     // Display null values as blanks, but allow 0
@@ -241,8 +237,8 @@ const RelatedRecordsTable = ({
                                     }
                                   >
                                     <option value={""}>NO DATA</option>
-                                    <option value={true}>YES</option>
-                                    <option value={false}>NO</option>
+                                    <option value={true}>TRUE</option>
+                                    <option value={false}>FALSE</option>
                                   </Input>
                                 )}
                                 <div className="d-flex">

--- a/atd-vze/src/views/Crashes/personDataMap.js
+++ b/atd-vze/src/views/Crashes/personDataMap.js
@@ -108,7 +108,7 @@ export const primaryPersonDataMap = [
         editable: false,
       },
       peh_fl: {
-        label: "Unhoused",
+        label: "Suspected Unhoused",
         editable: true,
         format: "boolean",
         mutationVariableKey: "personId",
@@ -189,7 +189,7 @@ export const personDataMap = [
         mutationVariableKey: "personId",
       },
       peh_fl: {
-        label: "Unhoused",
+        label: "Suspected Unhoused",
         editable: true,
         format: "boolean",
         mutationVariableKey: "personId",


### PR DESCRIPTION
## Associated issues
Closes https://github.com/cityofaustin/atd-data-tech/issues/15043

Idk if Xavier realized that the data type for this field already was boolean in the database and we just made the front end say "Yes/No" from a UI/UX point of view, but I updated the wording anyways and also updated the label.

## Testing
**URL to test:** <!-- VZ URL or Netlify -->
[Netlify](https://deploy-preview-1332--atd-vze-staging.netlify.app/#/)

**Steps to test:**
1. Go to a crash with both primary and other people
2. Update their "Suspected Unhoused" columns. Make sure the update persists. Options should be No Data, True, or False.


---
#### Ship list
- [ ] Check migrations for any conflicts with latest migrations in master branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [x] Product manager approved