### PR TITLE
Add tooltip to reset crash diagram zoom button

### DIFF
--- a/atd-vze/src/containers/DefaultLayout/DefaultHeader.js
+++ b/atd-vze/src/containers/DefaultLayout/DefaultHeader.js
@@ -105,7 +105,7 @@ const DefaultHeader = props => {
                 target="_blank"
                 rel="noreferrer"
               >
-                <i class="fa fa-briefcase" /> CR3 code sheet&nbsp;&nbsp; <i className="fa fa-external-link" />
+                <i className="fa fa-briefcase" /> CR3 code sheet&nbsp;&nbsp; <i className="fa fa-external-link" />
               </DropdownItem>
             </DropdownMenu>
         </UncontrolledDropdown>

--- a/atd-vze/src/views/Crashes/CrashDiagram.js
+++ b/atd-vze/src/views/Crashes/CrashDiagram.js
@@ -8,6 +8,7 @@ import {
   ButtonGroup,
   Col,
   Row,
+  UncontrolledTooltip,
 } from "reactstrap";
 import axios from "axios";
 import { TransformWrapper, TransformComponent } from "react-zoom-pan-pinch";
@@ -84,9 +85,19 @@ const CrashDiagram = props => {
                     </ButtonGroup>
                   </Col>
                   <Col className="d-flex justify-content-end">
-                    <Button color="primary" onClick={resetTransform}>
+                    <Button
+                      id="reset-zoom-button"
+                      color="primary"
+                      onClick={resetTransform}
+                    >
                       <i className="fa fa-repeat"></i>
                     </Button>
+                    <UncontrolledTooltip
+                      placement="top"
+                      target="reset-zoom-button"
+                    >
+                      Reset Zoom
+                    </UncontrolledTooltip>
                   </Col>
                 </Row>
                 <Row className="d-flex align-items-center">


### PR DESCRIPTION
## Associated issues
https://github.com/cityofaustin/atd-data-tech/issues/14772

This PR adds a tooltip to the reset button that shows in the top right of the crash diagram on the Crash page.

## Testing
**URL to test:** <!-- VZ URL or Netlify -->
https://deploy-preview-1334--atd-vze-staging.netlify.app/

**Steps to test:**
1. Go to a crash with a crash diagram like [this one](https://deploy-preview-1334--atd-vze-staging.netlify.app/#/crashes/19344859)
2. Use the crash diagram zoom buttons to zoom in or out from the default
3. Hover the reset button to the top right of the diagram, and you should see a tooltip appear
4. Click the button to reset zoom to make sure it still works

---
#### Ship list
- [ ] Check migrations for any conflicts with latest migrations in master branch
- [ ] Confirm Hasura role permissions for necessary access
- [x] Code reviewed
- [x] Product manager approved