### PR TITLE
Add confirmation to delete notes on the Location page and Crash page

### DIFF
--- a/atd-vze/src/Components/ConfirmDeleteButton.js
+++ b/atd-vze/src/Components/ConfirmDeleteButton.js
@@ -1,15 +1,14 @@
 import React, { useState } from "react";
 import { Button } from "reactstrap";
-import ConfirmModal from "../ConfirmModal.js";
+import ConfirmModal from "./ConfirmModal.js";
 
-const ConfirmDeleteButton = ({ onConfirmClick }) => {
+const ConfirmDeleteButton = ({ onConfirmClick, modalHeader, modalBody }) => {
   const [showModal, setShowModal] = useState(false);
 
   const toggleModal = () => {
     setShowModal(!showModal);
   };
 
-  // render notes card and table
   return (
     <>
       <Button
@@ -23,8 +22,8 @@ const ConfirmDeleteButton = ({ onConfirmClick }) => {
         <i className="fa fa-trash" />
       </Button>
       <ConfirmModal
-        modalHeader={"Delete Confirmation"}
-        modalBody={`Are you sure you want to delete this note?`}
+        modalHeader={modalHeader}
+        modalBody={modalBody}
         confirmClick={onConfirmClick}
         toggleModal={toggleModal}
         showModal={showModal}

--- a/atd-vze/src/Components/Notes/ConfirmDeleteButton.js
+++ b/atd-vze/src/Components/Notes/ConfirmDeleteButton.js
@@ -1,0 +1,36 @@
+import React, { useState } from "react";
+import { Button } from "reactstrap";
+import ConfirmModal from "../ConfirmModal.js";
+
+const ConfirmDeleteButton = ({ onConfirmClick }) => {
+  const [showModal, setShowModal] = useState(false);
+
+  const toggleModal = () => {
+    setShowModal(!showModal);
+  };
+
+  // render notes card and table
+  return (
+    <>
+      <Button
+        type="submit"
+        color="secondary"
+        className="btn-pill mt-2"
+        size="sm"
+        style={{ width: "50px" }}
+        onClick={toggleModal}
+      >
+        <i className="fa fa-trash" />
+      </Button>
+      <ConfirmModal
+        modalHeader={"Delete Confirmation"}
+        modalBody={`Are you sure you want to delete this note?`}
+        confirmClick={onConfirmClick}
+        toggleModal={toggleModal}
+        showModal={showModal}
+      />
+    </>
+  );
+};
+
+export default ConfirmDeleteButton;

--- a/atd-vze/src/Components/Notes/Notes.js
+++ b/atd-vze/src/Components/Notes/Notes.js
@@ -248,7 +248,12 @@ const Notes = ({
                       <ConfirmDeleteButton
                         onConfirmClick={() => handleDeleteClick(row)}
                         modalHeader={"Delete Confirmation"}
-                        modalBody={`Are you sure you want to delete this note?`}
+                        modalBody={
+                          <div>
+                            Are you sure you want to delete this note?
+                            <p className="mt-2 text-truncate">{row.text}</p>
+                          </div>
+                        }
                       />
                     </td>
                   ) : (

--- a/atd-vze/src/Components/Notes/Notes.js
+++ b/atd-vze/src/Components/Notes/Notes.js
@@ -263,7 +263,7 @@ const Notes = ({
                         <i className="fa fa-trash" />
                       </Button>
                       <ConfirmModal
-                        modalHeader={"Delete Note"}
+                        modalHeader={"Delete Confirmation"}
                         modalBody={"Are you sure you want to delete this note?"}
                         confirmClick={() => {
                           handleDeleteClick(row);

--- a/atd-vze/src/Components/Notes/Notes.js
+++ b/atd-vze/src/Components/Notes/Notes.js
@@ -45,7 +45,7 @@ const Notes = ({
   const [editNote] = useMutation(UPDATE_NOTE);
   const [deleteNote] = useMutation(DELETE_NOTE);
 
-  // Confirm delete note modal
+  // Confirm delete modal
   const [showModal, setShowModal] = useState(false);
 
   const toggleModal = () => {
@@ -105,217 +105,214 @@ const Notes = ({
 
   // function to handle delete note button click
   const handleDeleteClick = row => {
-    toggleModal();
-    // const id = row.id;
-    // deleteNote({
-    //   variables: {
-    //     id: id,
-    //   },
-    // })
-    //   .then(response => {
-    //     refetch();
-    //   })
-    //   .catch(error => console.error(error));
+    const id = row.id;
+    deleteNote({
+      variables: {
+        id: id,
+      },
+    })
+      .then(response => {
+        refetch();
+      })
+      .catch(error => console.error(error));
   };
 
   // render notes card and table
   return (
-    <>
-      <Card>
-        <CardHeader>{fieldConfig.title}</CardHeader>
-        <CardBody style={{ padding: "5px 20px 20px 20px" }}>
-          <Table style={{ width: "100%" }}>
-            <thead>
-              {/* display label for each field in table header*/}
-              <tr>
-                <th
-                  style={{
-                    width: "10%",
-                    borderTop: "0px",
-                    borderBottom: "1px",
-                  }}
-                >
-                  {fieldConfig.fields.date.label}
-                </th>
-                <th
-                  style={{
-                    width: "24%",
-                    borderTop: "0px",
-                    borderBottom: "1px",
-                  }}
-                >
-                  {fieldConfig.fields.user_email.label}
-                </th>
-                <th
-                  style={{
-                    width: "54%",
-                    borderTop: "0px",
-                    borderBottom: "1px",
-                  }}
-                >
-                  {fieldConfig.fields.text.label}
-                </th>
-                {/* only create extra columns if user has edit permissions */}
-                {!isReadOnly(roles) && (
-                  <th
-                    style={{
-                      width: "6%",
-                      borderTop: "0px",
-                      borderBottom: "1px",
-                    }}
-                  ></th>
-                )}
-                {/* only create extra columns if user has edit permissions */}
-                {!isReadOnly(roles) && (
-                  <th
-                    style={{
-                      width: "6%",
-                      borderTop: "0px",
-                      borderBottom: "1px",
-                    }}
-                  ></th>
-                )}
-              </tr>
-            </thead>
-            <tbody>
-              {/* display user input row for users with edit permissions*/}
+    <Card>
+      <CardHeader>{fieldConfig.title}</CardHeader>
+      <CardBody style={{ padding: "5px 20px 20px 20px" }}>
+        <Table style={{ width: "100%" }}>
+          <thead>
+            {/* display label for each field in table header*/}
+            <tr>
+              <th
+                style={{
+                  width: "10%",
+                  borderTop: "0px",
+                  borderBottom: "1px",
+                }}
+              >
+                {fieldConfig.fields.date.label}
+              </th>
+              <th
+                style={{
+                  width: "24%",
+                  borderTop: "0px",
+                  borderBottom: "1px",
+                }}
+              >
+                {fieldConfig.fields.user_email.label}
+              </th>
+              <th
+                style={{
+                  width: "54%",
+                  borderTop: "0px",
+                  borderBottom: "1px",
+                }}
+              >
+                {fieldConfig.fields.text.label}
+              </th>
+              {/* only create extra columns if user has edit permissions */}
               {!isReadOnly(roles) && (
-                <tr>
-                  <td></td>
-                  <td></td>
-                  <td>
-                    <Input
-                      type="textarea"
-                      placeholder="Enter new note here..."
-                      value={newNote}
-                      onChange={e => setNewNote(e.target.value)}
-                    />
-                  </td>
-                  <td style={{ padding: "12px 4px 12px 12px" }}>
-                    <Button
-                      type="submit"
-                      color="primary"
-                      onClick={handleAddNoteClick}
-                      className="btn-pill mt-2"
-                      size="sm"
-                      style={{ width: "50px" }}
-                    >
-                      Add
-                    </Button>
-                  </td>
-                  <td></td>
-                </tr>
+                <th
+                  style={{
+                    width: "6%",
+                    borderTop: "0px",
+                    borderBottom: "1px",
+                  }}
+                ></th>
               )}
-              {/* iterate through each row in notes table */}
-              {data[tableName].map(row => {
-                const isEditing = editRow === row;
-                const isUser = row.user_email === userEmail;
-                return (
-                  <tr key={`table-${tableName}-${row[keyField]}`}>
-                    {/* iterate through each field in the row and render its value */}
-                    {Object.keys(fieldConfig.fields).map((field, i) => {
-                      return (
-                        <td key={i}>
-                          {/* if user is editing display editing input text box */}
-                          {isEditing && field === "text" ? (
-                            <Input
-                              type="textarea"
-                              defaultValue={row.text}
-                              onChange={e => setEditedNote(e.target.value)}
-                            />
-                          ) : field === "date" ? (
-                            format(parseISO(row[field]), "MM/dd/yyyy")
-                          ) : (
-                            row[field]
-                          )}
-                        </td>
-                      );
-                    })}
-                    {/* display edit button if row was created by current user,
+              {/* only create extra columns if user has edit permissions */}
+              {!isReadOnly(roles) && (
+                <th
+                  style={{
+                    width: "6%",
+                    borderTop: "0px",
+                    borderBottom: "1px",
+                  }}
+                ></th>
+              )}
+            </tr>
+          </thead>
+          <tbody>
+            {/* display user input row for users with edit permissions*/}
+            {!isReadOnly(roles) && (
+              <tr>
+                <td></td>
+                <td></td>
+                <td>
+                  <Input
+                    type="textarea"
+                    placeholder="Enter new note here..."
+                    value={newNote}
+                    onChange={e => setNewNote(e.target.value)}
+                  />
+                </td>
+                <td style={{ padding: "12px 4px 12px 12px" }}>
+                  <Button
+                    type="submit"
+                    color="primary"
+                    onClick={handleAddNoteClick}
+                    className="btn-pill mt-2"
+                    size="sm"
+                    style={{ width: "50px" }}
+                  >
+                    Add
+                  </Button>
+                </td>
+                <td></td>
+              </tr>
+            )}
+            {/* iterate through each row in notes table */}
+            {data[tableName].map(row => {
+              const isEditing = editRow === row;
+              const isUser = row.user_email === userEmail;
+              return (
+                <tr key={`table-${tableName}-${row[keyField]}`}>
+                  {/* iterate through each field in the row and render its value */}
+                  {Object.keys(fieldConfig.fields).map((field, i) => {
+                    return (
+                      <td key={i}>
+                        {/* if user is editing display editing input text box */}
+                        {isEditing && field === "text" ? (
+                          <Input
+                            type="textarea"
+                            defaultValue={row.text}
+                            onChange={e => setEditedNote(e.target.value)}
+                          />
+                        ) : field === "date" ? (
+                          format(parseISO(row[field]), "MM/dd/yyyy")
+                        ) : (
+                          row[field]
+                        )}
+                      </td>
+                    );
+                  })}
+                  {/* display edit button if row was created by current user,
                   user has edit permissions, and user is not currently editing */}
-                    {isUser && !isReadOnly(roles) && !isEditing ? (
-                      <td style={{ padding: "12px 4px 12px 12px" }}>
-                        <Button
-                          type="submit"
-                          color="secondary"
-                          size="sm"
-                          className="btn-pill mt-2"
-                          style={{ width: "50px" }}
-                          onClick={e => handleEditClick(row)}
-                        >
-                          <i className="fa fa-pencil edit-toggle" />
-                        </Button>
-                      </td>
-                    ) : (
-                      // else if user has edit permissions and is not editing render empty cell
-                      !isReadOnly(roles) && !isEditing && <td></td>
-                    )}
-                    {/* display delete button if row was created by current user,
+                  {isUser && !isReadOnly(roles) && !isEditing ? (
+                    <td style={{ padding: "12px 4px 12px 12px" }}>
+                      <Button
+                        type="submit"
+                        color="secondary"
+                        size="sm"
+                        className="btn-pill mt-2"
+                        style={{ width: "50px" }}
+                        onClick={e => handleEditClick(row)}
+                      >
+                        <i className="fa fa-pencil edit-toggle" />
+                      </Button>
+                    </td>
+                  ) : (
+                    // else if user has edit permissions and is not editing render empty cell
+                    !isReadOnly(roles) && !isEditing && <td></td>
+                  )}
+                  {/* display delete button if row was created by current user,
                   user has edit permissions, and user is not currently editing */}
-                    {isUser && !isReadOnly(roles) && !isEditing ? (
-                      <td style={{ padding: "12px 4px 12px 4px" }}>
-                        <Button
-                          type="submit"
-                          color="secondary"
-                          className="btn-pill mt-2"
-                          size="sm"
-                          style={{ width: "50px" }}
-                          onClick={e => handleDeleteClick(row)}
-                        >
-                          <i className="fa fa-trash" />
-                        </Button>
-                      </td>
-                    ) : (
-                      // else if user has edit permissions and is not editing render empty cell
-                      !isReadOnly(roles) && !isEditing && <td></td>
-                    )}
-                    {/* display save button if user is editing */}
-                    {!isReadOnly(roles) && isEditing && (
-                      <td style={{ padding: "12px 4px 12px 12px" }}>
-                        <Button
-                          color="primary"
-                          className="btn-pill mt-2"
-                          size="sm"
-                          style={{ width: "50px" }}
-                          onClick={e => handleSaveClick(row)}
-                        >
-                          <i className="fa fa-check edit-toggle" />
-                        </Button>
-                      </td>
-                    )}
-                    {/* display cancel button if user is editing */}
-                    {!isReadOnly(roles) && isEditing && (
-                      <td style={{ padding: "12px 4px 12px 4px" }}>
-                        <Button
-                          type="submit"
-                          color="danger"
-                          className="btn-pill mt-2"
-                          size="sm"
-                          style={{ width: "50px" }}
-                          onClick={e => handleCancelClick(e)}
-                        >
-                          <i className="fa fa-times edit-toggle" />
-                        </Button>
-                      </td>
-                    )}
-                  </tr>
-                );
-              })}
-            </tbody>
-          </Table>
-        </CardBody>
-        <CardFooter></CardFooter>
-      </Card>
-      <ConfirmModal
-        modalHeader={"Delete Note"}
-        modalBody={"Are you sure you want to delete this note?"}
-        confirmClick={() => {
-          console.log("delete note");
-        }}
-        toggleModal={toggleModal}
-        showModal={showModal}
-      />
-    </>
+                  {isUser && !isReadOnly(roles) && !isEditing ? (
+                    <td style={{ padding: "12px 4px 12px 4px" }}>
+                      <Button
+                        type="submit"
+                        color="secondary"
+                        className="btn-pill mt-2"
+                        size="sm"
+                        style={{ width: "50px" }}
+                        onClick={() => toggleModal()}
+                      >
+                        <i className="fa fa-trash" />
+                      </Button>
+                      <ConfirmModal
+                        modalHeader={"Delete Note"}
+                        modalBody={"Are you sure you want to delete this note?"}
+                        confirmClick={() => {
+                          handleDeleteClick(row);
+                        }}
+                        toggleModal={toggleModal}
+                        showModal={showModal}
+                      />
+                    </td>
+                  ) : (
+                    // else if user has edit permissions and is not editing render empty cell
+                    !isReadOnly(roles) && !isEditing && <td></td>
+                  )}
+                  {/* display save button if user is editing */}
+                  {!isReadOnly(roles) && isEditing && (
+                    <td style={{ padding: "12px 4px 12px 12px" }}>
+                      <Button
+                        color="primary"
+                        className="btn-pill mt-2"
+                        size="sm"
+                        style={{ width: "50px" }}
+                        onClick={e => handleSaveClick(row)}
+                      >
+                        <i className="fa fa-check edit-toggle" />
+                      </Button>
+                    </td>
+                  )}
+                  {/* display cancel button if user is editing */}
+                  {!isReadOnly(roles) && isEditing && (
+                    <td style={{ padding: "12px 4px 12px 4px" }}>
+                      <Button
+                        type="submit"
+                        color="danger"
+                        className="btn-pill mt-2"
+                        size="sm"
+                        style={{ width: "50px" }}
+                        onClick={e => handleCancelClick(e)}
+                      >
+                        <i className="fa fa-times edit-toggle" />
+                      </Button>
+                    </td>
+                  )}
+                </tr>
+              );
+            })}
+          </tbody>
+        </Table>
+      </CardBody>
+      <CardFooter></CardFooter>
+    </Card>
   );
 };
 

--- a/atd-vze/src/Components/Notes/Notes.js
+++ b/atd-vze/src/Components/Notes/Notes.js
@@ -9,7 +9,7 @@ import {
   Input,
   Button,
 } from "reactstrap";
-import ConfirmModal from "../ConfirmModal.js";
+import ConfirmDeleteButton from "./ConfirmDeleteButton";
 import { format, parseISO } from "date-fns";
 import { notesDataMap } from "./notesDataMap.js";
 import { useAuth0, isReadOnly } from "../../auth/authContext";
@@ -252,24 +252,8 @@ const Notes = ({
                   user has edit permissions, and user is not currently editing */}
                   {isUser && !isReadOnly(roles) && !isEditing ? (
                     <td style={{ padding: "12px 4px 12px 4px" }}>
-                      <Button
-                        type="submit"
-                        color="secondary"
-                        className="btn-pill mt-2"
-                        size="sm"
-                        style={{ width: "50px" }}
-                        onClick={() => toggleModal()}
-                      >
-                        <i className="fa fa-trash" />
-                      </Button>
-                      <ConfirmModal
-                        modalHeader={"Delete Confirmation"}
-                        modalBody={"Are you sure you want to delete this note?"}
-                        confirmClick={() => {
-                          handleDeleteClick(row);
-                        }}
-                        toggleModal={toggleModal}
-                        showModal={showModal}
+                      <ConfirmDeleteButton
+                        onConfirmClick={() => handleDeleteClick(row)}
                       />
                     </td>
                   ) : (

--- a/atd-vze/src/Components/Notes/Notes.js
+++ b/atd-vze/src/Components/Notes/Notes.js
@@ -9,7 +9,7 @@ import {
   Input,
   Button,
 } from "reactstrap";
-import ConfirmDeleteButton from "./ConfirmDeleteButton";
+import ConfirmDeleteButton from "../ConfirmDeleteButton.js";
 import { format, parseISO } from "date-fns";
 import { notesDataMap } from "./notesDataMap.js";
 import { useAuth0, isReadOnly } from "../../auth/authContext";
@@ -44,13 +44,6 @@ const Notes = ({
   const [addNote] = useMutation(INSERT_NOTE);
   const [editNote] = useMutation(UPDATE_NOTE);
   const [deleteNote] = useMutation(DELETE_NOTE);
-
-  // Confirm delete modal
-  const [showModal, setShowModal] = useState(false);
-
-  const toggleModal = () => {
-    setShowModal(!showModal);
-  };
 
   if (loading) return "Loading...";
   if (error) return `Error! ${error.message}`;
@@ -254,6 +247,8 @@ const Notes = ({
                     <td style={{ padding: "12px 4px 12px 4px" }}>
                       <ConfirmDeleteButton
                         onConfirmClick={() => handleDeleteClick(row)}
+                        modalHeader={"Delete Confirmation"}
+                        modalBody={`Are you sure you want to delete this note?`}
                       />
                     </td>
                   ) : (

--- a/atd-vze/src/Components/Notes/Notes.js
+++ b/atd-vze/src/Components/Notes/Notes.js
@@ -9,6 +9,7 @@ import {
   Input,
   Button,
 } from "reactstrap";
+import ConfirmModal from "../ConfirmModal.js";
 import { format, parseISO } from "date-fns";
 import { notesDataMap } from "./notesDataMap.js";
 import { useAuth0, isReadOnly } from "../../auth/authContext";
@@ -43,6 +44,13 @@ const Notes = ({
   const [addNote] = useMutation(INSERT_NOTE);
   const [editNote] = useMutation(UPDATE_NOTE);
   const [deleteNote] = useMutation(DELETE_NOTE);
+
+  // Confirm delete note modal
+  const [showModal, setShowModal] = useState(false);
+
+  const toggleModal = () => {
+    setShowModal(!showModal);
+  };
 
   if (loading) return "Loading...";
   if (error) return `Error! ${error.message}`;
@@ -97,205 +105,217 @@ const Notes = ({
 
   // function to handle delete note button click
   const handleDeleteClick = row => {
-    const id = row.id;
-    deleteNote({
-      variables: {
-        id: id,
-      },
-    })
-      .then(response => {
-        refetch();
-      })
-      .catch(error => console.error(error));
+    toggleModal();
+    // const id = row.id;
+    // deleteNote({
+    //   variables: {
+    //     id: id,
+    //   },
+    // })
+    //   .then(response => {
+    //     refetch();
+    //   })
+    //   .catch(error => console.error(error));
   };
 
   // render notes card and table
   return (
-    <Card>
-      <CardHeader>{fieldConfig.title}</CardHeader>
-      <CardBody style={{ padding: "5px 20px 20px 20px" }}>
-        <Table style={{ width: "100%" }}>
-          <thead>
-            {/* display label for each field in table header*/}
-            <tr>
-              <th
-                style={{
-                  width: "10%",
-                  borderTop: "0px",
-                  borderBottom: "1px",
-                }}
-              >
-                {fieldConfig.fields.date.label}
-              </th>
-              <th
-                style={{
-                  width: "24%",
-                  borderTop: "0px",
-                  borderBottom: "1px",
-                }}
-              >
-                {fieldConfig.fields.user_email.label}
-              </th>
-              <th
-                style={{
-                  width: "54%",
-                  borderTop: "0px",
-                  borderBottom: "1px",
-                }}
-              >
-                {fieldConfig.fields.text.label}
-              </th>
-              {/* only create extra columns if user has edit permissions */}
-              {!isReadOnly(roles) && (
-                <th
-                  style={{
-                    width: "6%",
-                    borderTop: "0px",
-                    borderBottom: "1px",
-                  }}
-                ></th>
-              )}
-              {/* only create extra columns if user has edit permissions */}
-              {!isReadOnly(roles) && (
-                <th
-                  style={{
-                    width: "6%",
-                    borderTop: "0px",
-                    borderBottom: "1px",
-                  }}
-                ></th>
-              )}
-            </tr>
-          </thead>
-          <tbody>
-            {/* display user input row for users with edit permissions*/}
-            {!isReadOnly(roles) && (
+    <>
+      <Card>
+        <CardHeader>{fieldConfig.title}</CardHeader>
+        <CardBody style={{ padding: "5px 20px 20px 20px" }}>
+          <Table style={{ width: "100%" }}>
+            <thead>
+              {/* display label for each field in table header*/}
               <tr>
-                <td></td>
-                <td></td>
-                <td>
-                  <Input
-                    type="textarea"
-                    placeholder="Enter new note here..."
-                    value={newNote}
-                    onChange={e => setNewNote(e.target.value)}
-                  />
-                </td>
-                <td style={{ padding: "12px 4px 12px 12px" }}>
-                  <Button
-                    type="submit"
-                    color="primary"
-                    onClick={handleAddNoteClick}
-                    className="btn-pill mt-2"
-                    size="sm"
-                    style={{ width: "50px" }}
-                  >
-                    Add
-                  </Button>
-                </td>
-                <td></td>
+                <th
+                  style={{
+                    width: "10%",
+                    borderTop: "0px",
+                    borderBottom: "1px",
+                  }}
+                >
+                  {fieldConfig.fields.date.label}
+                </th>
+                <th
+                  style={{
+                    width: "24%",
+                    borderTop: "0px",
+                    borderBottom: "1px",
+                  }}
+                >
+                  {fieldConfig.fields.user_email.label}
+                </th>
+                <th
+                  style={{
+                    width: "54%",
+                    borderTop: "0px",
+                    borderBottom: "1px",
+                  }}
+                >
+                  {fieldConfig.fields.text.label}
+                </th>
+                {/* only create extra columns if user has edit permissions */}
+                {!isReadOnly(roles) && (
+                  <th
+                    style={{
+                      width: "6%",
+                      borderTop: "0px",
+                      borderBottom: "1px",
+                    }}
+                  ></th>
+                )}
+                {/* only create extra columns if user has edit permissions */}
+                {!isReadOnly(roles) && (
+                  <th
+                    style={{
+                      width: "6%",
+                      borderTop: "0px",
+                      borderBottom: "1px",
+                    }}
+                  ></th>
+                )}
               </tr>
-            )}
-            {/* iterate through each row in notes table */}
-            {data[tableName].map(row => {
-              const isEditing = editRow === row;
-              const isUser = row.user_email === userEmail;
-              return (
-                <tr key={`table-${tableName}-${row[keyField]}`}>
-                  {/* iterate through each field in the row and render its value */}
-                  {Object.keys(fieldConfig.fields).map((field, i) => {
-                    return (
-                      <td key={i}>
-                        {/* if user is editing display editing input text box */}
-                        {isEditing && field === "text" ? (
-                          <Input
-                            type="textarea"
-                            defaultValue={row.text}
-                            onChange={e => setEditedNote(e.target.value)}
-                          />
-                        ) : field === "date" ? (
-                          format(parseISO(row[field]), "MM/dd/yyyy")
-                        ) : (
-                          row[field]
-                        )}
-                      </td>
-                    );
-                  })}
-                  {/* display edit button if row was created by current user,
-                  user has edit permissions, and user is not currently editing */}
-                  {isUser && !isReadOnly(roles) && !isEditing ? (
-                    <td style={{ padding: "12px 4px 12px 12px" }}>
-                      <Button
-                        type="submit"
-                        color="secondary"
-                        size="sm"
-                        className="btn-pill mt-2"
-                        style={{ width: "50px" }}
-                        onClick={e => handleEditClick(row)}
-                      >
-                        <i className="fa fa-pencil edit-toggle" />
-                      </Button>
-                    </td>
-                  ) : (
-                    // else if user has edit permissions and is not editing render empty cell
-                    !isReadOnly(roles) && !isEditing && <td></td>
-                  )}
-                  {/* display delete button if row was created by current user,
-                  user has edit permissions, and user is not currently editing */}
-                  {isUser && !isReadOnly(roles) && !isEditing ? (
-                    <td style={{ padding: "12px 4px 12px 4px" }}>
-                      <Button
-                        type="submit"
-                        color="secondary"
-                        className="btn-pill mt-2"
-                        size="sm"
-                        style={{ width: "50px" }}
-                        onClick={e => handleDeleteClick(row)}
-                      >
-                        <i className="fa fa-trash" />
-                      </Button>
-                    </td>
-                  ) : (
-                    // else if user has edit permissions and is not editing render empty cell
-                    !isReadOnly(roles) && !isEditing && <td></td>
-                  )}
-                  {/* display save button if user is editing */}
-                  {!isReadOnly(roles) && isEditing && (
-                    <td style={{ padding: "12px 4px 12px 12px" }}>
-                      <Button
-                        color="primary"
-                        className="btn-pill mt-2"
-                        size="sm"
-                        style={{ width: "50px" }}
-                        onClick={e => handleSaveClick(row)}
-                      >
-                        <i className="fa fa-check edit-toggle" />
-                      </Button>
-                    </td>
-                  )}
-                  {/* display cancel button if user is editing */}
-                  {!isReadOnly(roles) && isEditing && (
-                    <td style={{ padding: "12px 4px 12px 4px" }}>
-                      <Button
-                        type="submit"
-                        color="danger"
-                        className="btn-pill mt-2"
-                        size="sm"
-                        style={{ width: "50px" }}
-                        onClick={e => handleCancelClick(e)}
-                      >
-                        <i className="fa fa-times edit-toggle" />
-                      </Button>
-                    </td>
-                  )}
+            </thead>
+            <tbody>
+              {/* display user input row for users with edit permissions*/}
+              {!isReadOnly(roles) && (
+                <tr>
+                  <td></td>
+                  <td></td>
+                  <td>
+                    <Input
+                      type="textarea"
+                      placeholder="Enter new note here..."
+                      value={newNote}
+                      onChange={e => setNewNote(e.target.value)}
+                    />
+                  </td>
+                  <td style={{ padding: "12px 4px 12px 12px" }}>
+                    <Button
+                      type="submit"
+                      color="primary"
+                      onClick={handleAddNoteClick}
+                      className="btn-pill mt-2"
+                      size="sm"
+                      style={{ width: "50px" }}
+                    >
+                      Add
+                    </Button>
+                  </td>
+                  <td></td>
                 </tr>
-              );
-            })}
-          </tbody>
-        </Table>
-      </CardBody>
-      <CardFooter></CardFooter>
-    </Card>
+              )}
+              {/* iterate through each row in notes table */}
+              {data[tableName].map(row => {
+                const isEditing = editRow === row;
+                const isUser = row.user_email === userEmail;
+                return (
+                  <tr key={`table-${tableName}-${row[keyField]}`}>
+                    {/* iterate through each field in the row and render its value */}
+                    {Object.keys(fieldConfig.fields).map((field, i) => {
+                      return (
+                        <td key={i}>
+                          {/* if user is editing display editing input text box */}
+                          {isEditing && field === "text" ? (
+                            <Input
+                              type="textarea"
+                              defaultValue={row.text}
+                              onChange={e => setEditedNote(e.target.value)}
+                            />
+                          ) : field === "date" ? (
+                            format(parseISO(row[field]), "MM/dd/yyyy")
+                          ) : (
+                            row[field]
+                          )}
+                        </td>
+                      );
+                    })}
+                    {/* display edit button if row was created by current user,
+                  user has edit permissions, and user is not currently editing */}
+                    {isUser && !isReadOnly(roles) && !isEditing ? (
+                      <td style={{ padding: "12px 4px 12px 12px" }}>
+                        <Button
+                          type="submit"
+                          color="secondary"
+                          size="sm"
+                          className="btn-pill mt-2"
+                          style={{ width: "50px" }}
+                          onClick={e => handleEditClick(row)}
+                        >
+                          <i className="fa fa-pencil edit-toggle" />
+                        </Button>
+                      </td>
+                    ) : (
+                      // else if user has edit permissions and is not editing render empty cell
+                      !isReadOnly(roles) && !isEditing && <td></td>
+                    )}
+                    {/* display delete button if row was created by current user,
+                  user has edit permissions, and user is not currently editing */}
+                    {isUser && !isReadOnly(roles) && !isEditing ? (
+                      <td style={{ padding: "12px 4px 12px 4px" }}>
+                        <Button
+                          type="submit"
+                          color="secondary"
+                          className="btn-pill mt-2"
+                          size="sm"
+                          style={{ width: "50px" }}
+                          onClick={e => handleDeleteClick(row)}
+                        >
+                          <i className="fa fa-trash" />
+                        </Button>
+                      </td>
+                    ) : (
+                      // else if user has edit permissions and is not editing render empty cell
+                      !isReadOnly(roles) && !isEditing && <td></td>
+                    )}
+                    {/* display save button if user is editing */}
+                    {!isReadOnly(roles) && isEditing && (
+                      <td style={{ padding: "12px 4px 12px 12px" }}>
+                        <Button
+                          color="primary"
+                          className="btn-pill mt-2"
+                          size="sm"
+                          style={{ width: "50px" }}
+                          onClick={e => handleSaveClick(row)}
+                        >
+                          <i className="fa fa-check edit-toggle" />
+                        </Button>
+                      </td>
+                    )}
+                    {/* display cancel button if user is editing */}
+                    {!isReadOnly(roles) && isEditing && (
+                      <td style={{ padding: "12px 4px 12px 4px" }}>
+                        <Button
+                          type="submit"
+                          color="danger"
+                          className="btn-pill mt-2"
+                          size="sm"
+                          style={{ width: "50px" }}
+                          onClick={e => handleCancelClick(e)}
+                        >
+                          <i className="fa fa-times edit-toggle" />
+                        </Button>
+                      </td>
+                    )}
+                  </tr>
+                );
+              })}
+            </tbody>
+          </Table>
+        </CardBody>
+        <CardFooter></CardFooter>
+      </Card>
+      <ConfirmModal
+        modalHeader={"Delete Note"}
+        modalBody={"Are you sure you want to delete this note?"}
+        confirmClick={() => {
+          console.log("delete note");
+        }}
+        toggleModal={toggleModal}
+        showModal={showModal}
+      />
+    </>
   );
 };
 

--- a/atd-vze/src/containers/DefaultLayout/DefaultHeader.js
+++ b/atd-vze/src/containers/DefaultLayout/DefaultHeader.js
@@ -105,7 +105,7 @@ const DefaultHeader = props => {
                 target="_blank"
                 rel="noreferrer"
               >
-                <i class="fa fa-briefcase" /> CR3 code sheet&nbsp;&nbsp; <i className="fa fa-external-link" />
+                <i className="fa fa-briefcase" /> CR3 code sheet&nbsp;&nbsp; <i className="fa fa-external-link" />
               </DropdownItem>
             </DropdownMenu>
         </UncontrolledDropdown>


### PR DESCRIPTION
## Associated issues
https://github.com/cityofaustin/atd-data-tech/issues/14771

This PR adds an existing `ConfirmModal` component to the `Notes` component so a confirm modal appears when deleting a crash or location note.

## Testing
**URL to test:** <!-- VZ URL or Netlify -->
https://deploy-preview-1339--atd-vze-staging.netlify.app/

**Steps to test:**
1. Log in to the deploy preview with either editor, admin, or IT supervisor permissions
2. Go to a crash page like [this one](https://deploy-preview-1339--atd-vze-staging.netlify.app/#/crashes/19329553) and add a note to the crash
3. Click the trash can icon and you should see a confirm modal pop up
4. Click **Cancel** or the **X icon** and the modal should close without deleting the note
5. Try to delete again and, this time, click **Confirm**, and the note should delete
6. Repeat the previous steps on a location page like [this one](https://deploy-preview-1339--atd-vze-staging.netlify.app/editor/#/locations/05186FFEDB)

---
#### Ship list
- [ ] ~Check migrations for any conflicts with latest migrations in master branch~
- [x] Confirm Hasura role permissions for necessary access
- [x] Code reviewed
- [x] Product manager approved