### PR TITLE
Display annual totals for all, fatalities, and serious injuries for the year

### DIFF
--- a/atd-vzv/src/views/summary/CrashesByMode.js
+++ b/atd-vzv/src/views/summary/CrashesByMode.js
@@ -334,10 +334,6 @@ const CrashesByMode = () => {
                             <div>
                               <hr className="my-0"></hr>
                               <p className="h6 text-center my-0 py-1">
-                                <FontAwesomeIcon
-                                  aria-hidden="true"
-                                  className="block-icon"
-                                />
                                 <span className="sr-only">Total</span>
                                 <span className="mode-label-text"> Total</span>
                               </p>

--- a/atd-vzv/src/views/summary/CrashesByMode.js
+++ b/atd-vzv/src/views/summary/CrashesByMode.js
@@ -174,16 +174,17 @@ const CrashesByMode = () => {
     datasets: !!chartData && createTypeDatasets(),
   };
 
-  const yearTotalsArray = data.datasets
-    ? yearsArray().map((year, index) => {
-        let currentYearTotal = 0;
-        data.datasets.forEach((mode) => {
-          currentYearTotal += mode.data[index];
-        });
-        console.log(currentYearTotal, "current year total");
-        return currentYearTotal;
-      })
-    : null;
+  // Get an array of totals for the selected crash type (all, fatal, injury) for each year
+  const getYearTotalsArray = () => {
+    const yearTotalsArray = yearsArray().map((year, index) => {
+      let currentYearTotal = 0;
+      data.datasets.forEach((mode) => {
+        currentYearTotal += mode.data[index];
+      });
+      return currentYearTotal;
+    });
+    return yearTotalsArray;
+  };
 
   const StyledDiv = styled.div`
     .year-total-div {
@@ -336,8 +337,6 @@ const CrashesByMode = () => {
                                 <FontAwesomeIcon
                                   aria-hidden="true"
                                   className="block-icon"
-                                  // icon={dataset.icon}
-                                  // color={legendColors[i]}
                                 />
                                 <span className="sr-only">Total</span>
                                 <span className="mode-label-text"> Total</span>
@@ -377,8 +376,9 @@ const CrashesByMode = () => {
                                     }
                                   )}
                                   <hr className="my-0"></hr>
-                                  <p className={`h6 text-center my-1 pb-1`}>
-                                    {yearTotalsArray[yearIterator]}
+                                  <p className={`h6 text-center my-1`}>
+                                    {data.datasets &&
+                                      getYearTotalsArray()[yearIterator]}
                                   </p>
                                 </div>
                               </StyledDiv>

--- a/atd-vzv/src/views/summary/CrashesByMode.js
+++ b/atd-vzv/src/views/summary/CrashesByMode.js
@@ -174,6 +174,17 @@ const CrashesByMode = () => {
     datasets: !!chartData && createTypeDatasets(),
   };
 
+  const yearTotalsArray = data.datasets
+    ? yearsArray().map((year, index) => {
+        let currentYearTotal = 0;
+        data.datasets.forEach((mode) => {
+          currentYearTotal += mode.data[index];
+        });
+        console.log(currentYearTotal, "current year total");
+        return currentYearTotal;
+      })
+    : null;
+
   const StyledDiv = styled.div`
     .year-total-div {
       color: ${colors.dark};
@@ -319,6 +330,19 @@ const CrashesByMode = () => {
                                 </div>
                               );
                             })}
+                            <div>
+                              <hr className="my-0"></hr>
+                              <p className="h6 text-center my-0 py-1">
+                                <FontAwesomeIcon
+                                  aria-hidden="true"
+                                  className="block-icon"
+                                  // icon={dataset.icon}
+                                  // color={legendColors[i]}
+                                />
+                                <span className="sr-only">Total</span>
+                                <span className="mode-label-text"> Total</span>
+                              </p>
+                            </div>
                           </StyledDiv>
                         </Col>
                         {chart.data.labels.map((year, yearIterator) => {
@@ -352,6 +376,10 @@ const CrashesByMode = () => {
                                       );
                                     }
                                   )}
+                                  <hr className="my-0"></hr>
+                                  <p className={`h6 text-center my-1 pb-1`}>
+                                    {yearTotalsArray[yearIterator]}
+                                  </p>
                                 </div>
                               </StyledDiv>
                             </Col>

--- a/atd-vzv/src/views/summary/CrashesByMode.js
+++ b/atd-vzv/src/views/summary/CrashesByMode.js
@@ -361,10 +361,7 @@ const CrashesByMode = () => {
                                   {chart.data.datasets.map(
                                     (mode, modeIterator) => {
                                       return (
-                                        <div
-                                          key={modeIterator}
-                                          style={{ height: "28.7px" }}
-                                        >
+                                        <div key={modeIterator}>
                                           <hr className="my-0"></hr>
                                           <p className={`h6 text-center my-1`}>
                                             {mode.data[yearIterator]}

--- a/atd-vzv/src/views/summary/CrashesByMode.js
+++ b/atd-vzv/src/views/summary/CrashesByMode.js
@@ -361,7 +361,10 @@ const CrashesByMode = () => {
                                   {chart.data.datasets.map(
                                     (mode, modeIterator) => {
                                       return (
-                                        <div key={modeIterator}>
+                                        <div
+                                          key={modeIterator}
+                                          style={{ height: "28.7px" }}
+                                        >
                                           <hr className="my-0"></hr>
                                           <p className={`h6 text-center my-1`}>
                                             {mode.data[yearIterator]}

--- a/atd-vzv/src/views/summary/CrashesByMode.js
+++ b/atd-vzv/src/views/summary/CrashesByMode.js
@@ -358,7 +358,7 @@ const CrashesByMode = () => {
                                   {chart.data.datasets.map(
                                     (mode, modeIterator) => {
                                       let paddingBottom =
-                                        modeIterator === 4 ? "pb-1" : "pb-0";
+                                        modeIterator === 4 ? "pb-0" : "pb-0";
                                       return (
                                         <div key={modeIterator}>
                                           <hr className="my-0"></hr>
@@ -372,7 +372,7 @@ const CrashesByMode = () => {
                                     }
                                   )}
                                   <hr className="my-0"></hr>
-                                  <p className={`h6 text-center my-1`}>
+                                  <p className={`h6 text-center my-1 pb-1`}>
                                     {data.datasets &&
                                       getYearTotalsArray()[yearIterator]}
                                   </p>

--- a/atd-vzv/src/views/summary/CrashesByMode.js
+++ b/atd-vzv/src/views/summary/CrashesByMode.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useRef } from "react";
+import React, { useEffect, useState, useRef, useMemo } from "react";
 import axios from "axios";
 import { Bar } from "react-chartjs-2";
 import { Container, Row, Col } from "reactstrap";
@@ -175,16 +175,19 @@ const CrashesByMode = () => {
   };
 
   // Get an array of annual totals for the selected crash type
-  const getYearTotalsArray = () => {
+  const getYearTotalsArray = useMemo(() => {
     const yearTotalsArray = yearsArray().map((year, index) => {
       let currentYearTotal = 0;
-      data.datasets.forEach((mode) => {
-        currentYearTotal += mode.data[index];
-      });
+      data.datasets &&
+        data.datasets.forEach((mode) => {
+          currentYearTotal += mode.data[index];
+        });
       return currentYearTotal;
     });
     return yearTotalsArray;
-  };
+  }, [data.datasets]);
+
+  const yearTotalsArray = getYearTotalsArray;
 
   const StyledDiv = styled.div`
     .year-total-div {
@@ -357,14 +360,10 @@ const CrashesByMode = () => {
                                   </div>
                                   {chart.data.datasets.map(
                                     (mode, modeIterator) => {
-                                      let paddingBottom =
-                                        modeIterator === 4 ? "pb-0" : "pb-0";
                                       return (
                                         <div key={modeIterator}>
                                           <hr className="my-0"></hr>
-                                          <p
-                                            className={`h6 text-center my-1 ${paddingBottom}`}
-                                          >
+                                          <p className={`h6 text-center my-1`}>
                                             {mode.data[yearIterator]}
                                           </p>
                                         </div>
@@ -374,7 +373,7 @@ const CrashesByMode = () => {
                                   <hr className="my-0"></hr>
                                   <p className={`h6 text-center my-1 pb-1`}>
                                     {data.datasets &&
-                                      getYearTotalsArray()[yearIterator]}
+                                      yearTotalsArray[yearIterator]}
                                   </p>
                                 </div>
                               </StyledDiv>

--- a/atd-vzv/src/views/summary/CrashesByMode.js
+++ b/atd-vzv/src/views/summary/CrashesByMode.js
@@ -335,7 +335,7 @@ const CrashesByMode = () => {
                               <hr className="my-0"></hr>
                               <p className="h6 text-center my-0 py-1">
                                 <span className="sr-only">Total</span>
-                                <span className="mode-label-text"> Total</span>
+                                <span className="mode-label-text">Total</span>
                               </p>
                             </div>
                           </StyledDiv>

--- a/atd-vzv/src/views/summary/CrashesByMode.js
+++ b/atd-vzv/src/views/summary/CrashesByMode.js
@@ -174,7 +174,7 @@ const CrashesByMode = () => {
     datasets: !!chartData && createTypeDatasets(),
   };
 
-  // Get an array of totals for the selected crash type (all, fatal, injury) for each year
+  // Get an array of annual totals for the selected crash type
   const getYearTotalsArray = () => {
     const yearTotalsArray = yearsArray().map((year, index) => {
       let currentYearTotal = 0;


### PR DESCRIPTION
## Associated issues
Closes https://github.com/cityofaustin/atd-data-tech/issues/15047

## Testing
**URL to test:** <!-- VZ URL or Netlify -->
https://deploy-preview-1340--atd-vzv-staging.netlify.app/

**Steps to test:**
1. Go to the summary page, make sure you are seeing the new "Totals" row in the By Travel Mode section.
2. Make sure it shows up for all of the crash types (All, Fatality, Serious Injury)
3. Are they adding up correctly?

Lmk if yall have any design thoughts like if this row should look ~ different ~ from the others somehow.

---
#### Ship list
- [x] Check migrations for any conflicts with latest migrations in master branch
- [x] Confirm Hasura role permissions for necessary access
- [x] Code reviewed
- [ ] Product manager approved