### PR TITLE
Fix WSOD in VZE when interacting with data widgets on crash listing page

### DIFF
--- a/atd-vze/src/Components/GridDateRange.js
+++ b/atd-vze/src/Components/GridDateRange.js
@@ -69,10 +69,10 @@ const GridDateRange = ({
    * @returns {string}
    */
   const formatDate = (date, fallbackValue) => {
-    let formattedDate = format(date, "yyyy-MM-dd");
+    let formattedDate = date ? format(date, "yyyy-MM-dd") : "Invalid date";
 
     if (formattedDate === "Invalid date") {
-      formattedDate = format(fallbackValue, "yyyy-MM-dd");
+      formattedDate = format(new Date(fallbackValue), "yyyy-MM-dd");
     }
     return formattedDate;
   };

--- a/atd-vze/src/Components/GridDateRange.js
+++ b/atd-vze/src/Components/GridDateRange.js
@@ -64,16 +64,15 @@ const GridDateRange = ({
 
   /**
    * Returns a date in a valid SQL format.
-   * @param {string} date - The string to be transformed
-   * @param {string} fallbackValue - The value to use if the formattedDate is invalid
+   * @param {Date} date - The date object to be formatted
+   * @param {string} fallbackValue - The value to use if date is null
    * @returns {string}
    */
   const formatDate = (date, fallbackValue) => {
-    let formattedDate = date ? format(date, "yyyy-MM-dd") : "Invalid date";
+    const formattedDate = date
+      ? format(date, "yyyy-MM-dd")
+      : format(new Date(fallbackValue), "yyyy-MM-dd");
 
-    if (formattedDate === "Invalid date") {
-      formattedDate = format(new Date(fallbackValue), "yyyy-MM-dd");
-    }
     return formattedDate;
   };
 

--- a/atd-vze/src/Components/GridDateRange.js
+++ b/atd-vze/src/Components/GridDateRange.js
@@ -114,6 +114,7 @@ const GridDateRange = ({
           // Prevent user from selecting start date after current date
           maxDate={maxDate}
           minDate={minDate}
+          strictParsing={true}
         />
         <span>{" to "}</span>
         <DatePicker
@@ -126,6 +127,7 @@ const GridDateRange = ({
           // Prevent user from selecting date before startDate (chosen in first DatePicker) or after current date
           minDate={startDate}
           maxDate={maxDate}
+          strictParsing={true}
         />
       </StyledDatePicker>
     </>


### PR DESCRIPTION
## Associated issues
Closes https://github.com/cityofaustin/atd-data-tech/issues/15130

## Testing
**URL to test:** <!-- VZ URL or Netlify -->
https://deploy-preview-1344--atd-vze-staging.netlify.app/#/crashes

**Steps to test:**
1. Go to the crashes page, erase the start date like you are gonna type in a new one, yay no more WSOD. If you click away without typing in a new date it just auto selects the day before the day you already had clicked.
2. Repeat with the end date picker.


---
#### Ship list
- [ ] Check migrations for any conflicts with latest migrations in master branch
- [x] Confirm Hasura role permissions for necessary access
- [x] Code reviewed
- [x] Product manager approved