### PR TITLE
expands cr3 export permissions

### DIFF
--- a/atd-vzd/metadata/databases/default/tables/public_atd__coordination_partners_lkp.yaml
+++ b/atd-vzd/metadata/databases/default/tables/public_atd__coordination_partners_lkp.yaml
@@ -9,3 +9,18 @@ array_relationships:
         table:
           name: recommendations_partners
           schema: public
+select_permissions:
+  - role: editor
+    permission:
+      columns:
+        - coord_partner_desc
+        - id
+      filter: {}
+    comment: ""
+  - role: readonly
+    permission:
+      columns:
+        - coord_partner_desc
+        - id
+      filter: {}
+    comment: ""

--- a/atd-vzd/metadata/databases/default/tables/public_atd__mode_category_lkp.yaml
+++ b/atd-vzd/metadata/databases/default/tables/public_atd__mode_category_lkp.yaml
@@ -1,3 +1,20 @@
 table:
   name: atd__mode_category_lkp
   schema: public
+select_permissions:
+  - role: editor
+    permission:
+      columns:
+        - atd_mode_category_desc
+        - atd_mode_category_mode_name
+        - id
+      filter: {}
+    comment: ""
+  - role: readonly
+    permission:
+      columns:
+        - atd_mode_category_desc
+        - atd_mode_category_mode_name
+        - id
+      filter: {}
+    comment: ""

--- a/atd-vzd/metadata/databases/default/tables/public_atd__recommendation_status_lkp.yaml
+++ b/atd-vzd/metadata/databases/default/tables/public_atd__recommendation_status_lkp.yaml
@@ -9,3 +9,18 @@ array_relationships:
         table:
           name: recommendations
           schema: public
+select_permissions:
+  - role: editor
+    permission:
+      columns:
+        - id
+        - rec_status_desc
+      filter: {}
+    comment: ""
+  - role: readonly
+    permission:
+      columns:
+        - id
+        - rec_status_desc
+      filter: {}
+    comment: ""


### PR DESCRIPTION
## Associated issues
fixes https://github.com/cityofaustin/atd-data-tech/issues/15103

the cr3 export was crashing for editor and read-only user types because they did not have sufficient permissions to access all the lookup tables exported in the cr3 csv, so i added read permissions for the three ``atd__`` lookup tables

## Testing
**URL to test:** <!-- VZ URL or Netlify -->
local because it includes database changes

**Steps to test:**
- apply metadata
- log into vzv using the test editor account
- go to the locations page and select a location
- scroll down to the crash list and click the export button
- try exporting all columns, then try exporting a selection
- repeat the steps above using a read-only account

---
#### Ship list
- [ ] Check migrations for any conflicts with latest migrations in master branch
- [ ] Confirm Hasura role permissions for necessary access
- [x] Code reviewed
- [x] Product manager approved