### PR TITLE
Reposition Fatality and Serious Injury counts pop-up when boundary box is activated

### DIFF
--- a/atd-vzv/src/views/map/InfoBox/MapPolygonInfoBox.js
+++ b/atd-vzv/src/views/map/InfoBox/MapPolygonInfoBox.js
@@ -1,6 +1,6 @@
 import React from "react";
 import InfoCard from "./InfoCard";
-import { StyledDesktopInfo } from "./infoBoxStyles";
+import { StyledPoylgonInfo } from "./infoBoxStyles";
 
 const MapPolygonInfoBox = ({ crashCounts, isMapTypeSet }) => {
   const createCrashContent = (crashCounts) => {
@@ -8,12 +8,12 @@ const MapPolygonInfoBox = ({ crashCounts, isMapTypeSet }) => {
     isMapTypeSet.fatal &&
       content.push({
         title: "Fatalities",
-        content: `${crashCounts.fatality || 0}`,
+        content: `${crashCounts?.fatality || 0}`,
       });
     isMapTypeSet.injury &&
       content.push({
         title: "Serious Injuries",
-        content: `${crashCounts.injury || 0}`,
+        content: `${crashCounts?.injury || 0}`,
       });
     return content;
   };
@@ -22,7 +22,7 @@ const MapPolygonInfoBox = ({ crashCounts, isMapTypeSet }) => {
 
   const infoCard = <InfoCard content={content} />;
 
-  return <StyledDesktopInfo>{infoCard}</StyledDesktopInfo>;
+  return <StyledPoylgonInfo>{infoCard}</StyledPoylgonInfo>;
 };
 
 export default MapPolygonInfoBox;

--- a/atd-vzv/src/views/map/InfoBox/infoBoxStyles.js
+++ b/atd-vzv/src/views/map/InfoBox/infoBoxStyles.js
@@ -4,15 +4,6 @@ import { responsive } from "../../../constants/responsive";
 export const popupMarginsWidth = 20;
 export const maxInfoBoxWidth = responsive.drawerWidth - popupMarginsWidth;
 
-export const StyledDesktopInfo = styled.div`
-  position: absolute;
-  margin: 8px;
-  padding: 2px;
-  max-width: ${maxInfoBoxWidth}px;
-  z-index: 9 !important;
-  pointer-events: none;
-`;
-
 export const StyledPoylgonInfo = styled.div`
   position: absolute;
   margin: 6px;

--- a/atd-vzv/src/views/map/InfoBox/infoBoxStyles.js
+++ b/atd-vzv/src/views/map/InfoBox/infoBoxStyles.js
@@ -10,7 +10,12 @@ export const StyledPoylgonInfo = styled.div`
   max-width: ${maxInfoBoxWidth}px;
   z-index: 9 !important;
   pointer-events: none;
+  // Combining the height of the geocoder box and 10px Mapbox spacing here
   top: 46px;
+  // Combining the mobile height of the geocoder box and 10px Mapbox spacing here
+  @media (max-width: 640px) {
+    top: 60px;
+  }
 `;
 
 export const StyledMobileInfo = styled.div`

--- a/atd-vzv/src/views/map/InfoBox/infoBoxStyles.js
+++ b/atd-vzv/src/views/map/InfoBox/infoBoxStyles.js
@@ -10,10 +10,10 @@ export const StyledPoylgonInfo = styled.div`
   max-width: ${maxInfoBoxWidth}px;
   z-index: 9 !important;
   pointer-events: none;
-  // Combining the height of the geocoder box and 10px Mapbox spacing here
+  /* Combine the height of the geocoder box and 10px Mapbox spacing */
   top: 46px;
-  // Combining the mobile height of the geocoder box and 10px Mapbox spacing here
-  @media (max-width: 640px) {
+  /* Combine the mobile height of the geocoder box and 10px Mapbox spacing */
+  @media (max-width: 639px) {
     top: 60px;
   }
 `;

--- a/atd-vzv/src/views/map/InfoBox/infoBoxStyles.js
+++ b/atd-vzv/src/views/map/InfoBox/infoBoxStyles.js
@@ -13,6 +13,15 @@ export const StyledDesktopInfo = styled.div`
   pointer-events: none;
 `;
 
+export const StyledPoylgonInfo = styled.div`
+  position: absolute;
+  margin: 6px;
+  max-width: ${maxInfoBoxWidth}px;
+  z-index: 9 !important;
+  pointer-events: none;
+  top: 46px;
+`;
+
 export const StyledMobileInfo = styled.div`
   .card {
     background: none;


### PR DESCRIPTION
## Associated issues
https://github.com/cityofaustin/atd-data-tech/issues/15182

This fixes the overlapping geocoder input and polygon tool info box that happens in VZV.

## Testing
**URL to test:** <!-- VZ URL or Netlify -->
https://deploy-preview-1350--atd-vzv-staging.netlify.app/

**Steps to test:**
1. Go the VZV map in the preview link
2. Use the polygon tool to select an area to show the fatality and serious injury totals info box
3. Notice that the info box with the totals no longer overlaps the geocoder input
4. Test that the info box responds to the height change of the geocoder input that happens at 640px width or less

---
#### Ship list
- [x] Check migrations for any conflicts with latest migrations in master branch
- [x] Confirm Hasura role permissions for necessary access
- [x] Code reviewed
- [x] Product manager approved