### PR TITLE
Control access to certain information by user email domain

### DIFF
--- a/atd-vze/src/auth/authContext.js
+++ b/atd-vze/src/auth/authContext.js
@@ -68,7 +68,7 @@ export const Auth0Provider = ({
           user?.email &&
           user.email.toLowerCase().endsWith("@austintexas.gov")
         ) {
-          // setIsCOA(true);
+          setIsCOA(true);
         }
 
         const claims = await auth0FromHook.getIdTokenClaims();

--- a/atd-vze/src/auth/authContext.js
+++ b/atd-vze/src/auth/authContext.js
@@ -37,6 +37,7 @@ export const Auth0Provider = ({
   const [userClaims, setUserClaims] = useState();
   const [auth0Client, setAuth0] = useState();
   const [loading, setLoading] = useState(true);
+  const [isCOA, setIsCOA] = useState(false);
 
   // Instantiate Auth0, handle auth callback, and set loading and user params
   useEffect(() => {
@@ -63,6 +64,12 @@ export const Auth0Provider = ({
       if (isAuthenticated) {
         const user = await auth0FromHook.getUser();
         setUser(user);
+        if (
+          user?.email &&
+          user.email.toLowerCase().endsWith("@austintexas.gov")
+        ) {
+          // setIsCOA(true);
+        }
 
         const claims = await auth0FromHook.getIdTokenClaims();
         setUserClaims(claims);
@@ -111,6 +118,7 @@ export const Auth0Provider = ({
       value={{
         isAuthenticated,
         user,
+        isCOA,
         loading,
         handleRedirectCallback,
         userClaims,

--- a/atd-vze/src/views/Crashes/Crash.js
+++ b/atd-vze/src/views/Crashes/Crash.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { Link } from "react-router-dom";
 import {
   Card,
@@ -55,6 +55,16 @@ const calculateYearsLifeLost = people => {
 };
 
 function Crash(props) {
+  const [isCOA, setIsCOA] = useState(false);
+  useEffect(() => {
+    const storedEmail = window.localStorage.getItem("hasura_user_email");
+    if (storedEmail) {
+      if (storedEmail.toLowerCase().endsWith("@austintexas.gov")) {
+        setIsCOA(true);
+      }
+    }
+  }, []);
+
   const crashId = props.match.params.id;
   const { loading, error, data, refetch } = useQuery(GET_CRASH, {
     variables: { crashId },
@@ -283,6 +293,7 @@ function Crash(props) {
         </Col>
         <Col xs="12" md="6" className="mb-4">
           <CrashDiagram
+            isCOA={isCOA}
             crashId={crashId}
             isCr3Stored={cr3StoredFlag === "Y"}
             isTempRecord={tempRecord}
@@ -304,7 +315,7 @@ function Crash(props) {
           <CrashCollapses data={data} props={props} />
         </Col>
       </Row>
-      {shouldShowFatalityRecommendations && (
+      {isCOA && shouldShowFatalityRecommendations && (
         <Row>
           <Col>
             <Recommendations crashId={props.match.params.id} />

--- a/atd-vze/src/views/Crashes/Crash.js
+++ b/atd-vze/src/views/Crashes/Crash.js
@@ -292,7 +292,7 @@ function Crash(props) {
           />
         </Col>
       </Row>
-      {!!investigatorNarrative ? (
+      {isCOA && !!investigatorNarrative ? (
         <Row>
           <Col>
             <CrashNarrative investigatorNarrative={investigatorNarrative} />

--- a/atd-vze/src/views/Crashes/Crash.js
+++ b/atd-vze/src/views/Crashes/Crash.js
@@ -62,7 +62,7 @@ function Crash(props) {
         setIsCOA(true);
       }
     }
-  }, []);
+  }, [user]);
 
   const crashId = props.match.params.id;
   const { loading, error, data, refetch } = useQuery(GET_CRASH, {

--- a/atd-vze/src/views/Crashes/Crash.js
+++ b/atd-vze/src/views/Crashes/Crash.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
 import { Link } from "react-router-dom";
 import {
   Card,
@@ -56,14 +56,9 @@ const calculateYearsLifeLost = people => {
 
 function Crash(props) {
   const { getRoles, user } = useAuth0();
-  const [isCOA, setIsCOA] = useState(false);
-  useEffect(() => {
-    if (user && user.email) {
-      if (user.email.toLowerCase().endsWith("@austintexas.gov")) {
-        setIsCOA(true);
-      }
-    }
-  }, [user]);
+
+  const isCOA =
+    !user?.email && user.email.toLowerCase().endsWith("@austintexas.gov");
 
   const crashId = props.match.params.id;
   const { loading, error, data, refetch } = useQuery(GET_CRASH, {

--- a/atd-vze/src/views/Crashes/Crash.js
+++ b/atd-vze/src/views/Crashes/Crash.js
@@ -58,7 +58,7 @@ function Crash(props) {
   const { getRoles, user } = useAuth0();
 
   const isCOA =
-    user?.email && user.email.toLowerCase().endsWith("@austintexas.gov");
+    !!user?.email && user.email.toLowerCase().endsWith("@austintexas.gov");
 
   const crashId = props.match.params.id;
   const { loading, error, data, refetch } = useQuery(GET_CRASH, {

--- a/atd-vze/src/views/Crashes/Crash.js
+++ b/atd-vze/src/views/Crashes/Crash.js
@@ -55,6 +55,7 @@ const calculateYearsLifeLost = people => {
 };
 
 function Crash(props) {
+  const { getRoles, user } = useAuth0();
   const [isCOA, setIsCOA] = useState(false);
   useEffect(() => {
     if (user && user.email) {
@@ -80,7 +81,6 @@ function Crash(props) {
   const [formData, setFormData] = useState({});
   const [isEditingCoords, setIsEditingCoords] = useState(false);
 
-  const { getRoles, user } = useAuth0();
   const roles = getRoles();
 
   const isCrashFatal =

--- a/atd-vze/src/views/Crashes/Crash.js
+++ b/atd-vze/src/views/Crashes/Crash.js
@@ -57,7 +57,6 @@ const calculateYearsLifeLost = people => {
 function Crash(props) {
   const [isCOA, setIsCOA] = useState(false);
   useEffect(() => {
-    console.log("user: ", user.email);
     if (user && user.email) {
       if (user.email.toLowerCase().endsWith("@austintexas.gov")) {
         setIsCOA(true);

--- a/atd-vze/src/views/Crashes/Crash.js
+++ b/atd-vze/src/views/Crashes/Crash.js
@@ -55,10 +55,7 @@ const calculateYearsLifeLost = people => {
 };
 
 function Crash(props) {
-  const { getRoles, user } = useAuth0();
-
-  const isCOA =
-    !!!user?.email && user.email.toLowerCase().endsWith("@austintexas.gov");
+  const { getRoles, isCOA } = useAuth0();
 
   const crashId = props.match.params.id;
   const { loading, error, data, refetch } = useQuery(GET_CRASH, {

--- a/atd-vze/src/views/Crashes/Crash.js
+++ b/atd-vze/src/views/Crashes/Crash.js
@@ -58,7 +58,7 @@ function Crash(props) {
   const { getRoles, user } = useAuth0();
 
   const isCOA =
-    !!user?.email && user.email.toLowerCase().endsWith("@austintexas.gov");
+    !!!user?.email && user.email.toLowerCase().endsWith("@austintexas.gov");
 
   const crashId = props.match.params.id;
   const { loading, error, data, refetch } = useQuery(GET_CRASH, {
@@ -316,18 +316,20 @@ function Crash(props) {
           </Col>
         </Row>
       )}
-      <Row>
-        <Col>
-          <Notes
-            recordId={props.match.params.id}
-            tableName={"crash_notes"}
-            GET_NOTES={GET_NOTES}
-            INSERT_NOTE={INSERT_NOTE}
-            UPDATE_NOTE={UPDATE_NOTE}
-            DELETE_NOTE={DELETE_NOTE}
-          />
-        </Col>
-      </Row>
+      {isCOA && (
+        <Row>
+          <Col>
+            <Notes
+              recordId={props.match.params.id}
+              tableName={"crash_notes"}
+              GET_NOTES={GET_NOTES}
+              INSERT_NOTE={INSERT_NOTE}
+              UPDATE_NOTE={UPDATE_NOTE}
+              DELETE_NOTE={DELETE_NOTE}
+            />
+          </Col>
+        </Row>
+      )}
       <Row>
         <DataTable
           dataMap={createCrashDataMap(tempRecord)}

--- a/atd-vze/src/views/Crashes/Crash.js
+++ b/atd-vze/src/views/Crashes/Crash.js
@@ -58,7 +58,7 @@ function Crash(props) {
   const { getRoles, user } = useAuth0();
 
   const isCOA =
-    !user?.email && user.email.toLowerCase().endsWith("@austintexas.gov");
+    user?.email && user.email.toLowerCase().endsWith("@austintexas.gov");
 
   const crashId = props.match.params.id;
   const { loading, error, data, refetch } = useQuery(GET_CRASH, {

--- a/atd-vze/src/views/Crashes/Crash.js
+++ b/atd-vze/src/views/Crashes/Crash.js
@@ -57,9 +57,9 @@ const calculateYearsLifeLost = people => {
 function Crash(props) {
   const [isCOA, setIsCOA] = useState(false);
   useEffect(() => {
-    const storedEmail = window.localStorage.getItem("hasura_user_email");
-    if (storedEmail) {
-      if (storedEmail.toLowerCase().endsWith("@austintexas.gov")) {
+    console.log("user: ", user.email);
+    if (user && user.email) {
+      if (user.email.toLowerCase().endsWith("@austintexas.gov")) {
         setIsCOA(true);
       }
     }
@@ -81,7 +81,7 @@ function Crash(props) {
   const [formData, setFormData] = useState({});
   const [isEditingCoords, setIsEditingCoords] = useState(false);
 
-  const { getRoles } = useAuth0();
+  const { getRoles, user } = useAuth0();
   const roles = getRoles();
 
   const isCrashFatal =

--- a/atd-vze/src/views/Crashes/CrashDiagram.js
+++ b/atd-vze/src/views/Crashes/CrashDiagram.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
 import {
   Card,
   CardHeader,

--- a/atd-vze/src/views/Crashes/CrashDiagram.js
+++ b/atd-vze/src/views/Crashes/CrashDiagram.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import {
   Card,
   CardHeader,
@@ -15,6 +15,18 @@ import { TransformWrapper, TransformComponent } from "react-zoom-pan-pinch";
 
 const CrashDiagram = props => {
   const [rotation, setRotation] = useState(0);
+  const [email, setEmail] = useState("");
+  const [isCOA, setIsCOA] = useState(false);
+
+  useEffect(() => {
+    const storedEmail = window.localStorage.getItem("hasura_user_email");
+    if (storedEmail) {
+      setEmail(storedEmail);
+      if (storedEmail.toLowerCase().endsWith("@austintexas.gov")) {
+        setIsCOA(true);
+      }
+    }
+  }, []);
 
   // Set S3 folder for diagram depending on environment
   const s3Folder =
@@ -50,9 +62,9 @@ const CrashDiagram = props => {
         <Row className="d-flex align-items-center">
           <Col>Crash Diagram</Col>
           <Col className="d-flex justify-content-end">
-            {props.isCr3Stored ? (
+            {isCOA && props.isCr3Stored ? (
               <Button color="primary" onClick={requestCR3}>
-                Download CR-3 PDF
+                Download CR3 PDF
               </Button>
             ) : (
               <div></div>

--- a/atd-vze/src/views/Crashes/CrashDiagram.js
+++ b/atd-vze/src/views/Crashes/CrashDiagram.js
@@ -15,16 +15,6 @@ import { TransformWrapper, TransformComponent } from "react-zoom-pan-pinch";
 
 const CrashDiagram = props => {
   const [rotation, setRotation] = useState(0);
-  const [isCOA, setIsCOA] = useState(false);
-
-  useEffect(() => {
-    const storedEmail = window.localStorage.getItem("hasura_user_email");
-    if (storedEmail) {
-      if (storedEmail.toLowerCase().endsWith("@austintexas.gov")) {
-        setIsCOA(true);
-      }
-    }
-  }, []);
 
   // Set S3 folder for diagram depending on environment
   const s3Folder =
@@ -60,7 +50,7 @@ const CrashDiagram = props => {
         <Row className="d-flex align-items-center">
           <Col>Crash Diagram</Col>
           <Col className="d-flex justify-content-end">
-            {isCOA && props.isCr3Stored ? (
+            {props.isCOA && props.isCr3Stored ? (
               <Button color="primary" onClick={requestCR3}>
                 Download CR3 PDF
               </Button>

--- a/atd-vze/src/views/Crashes/CrashDiagram.js
+++ b/atd-vze/src/views/Crashes/CrashDiagram.js
@@ -15,13 +15,11 @@ import { TransformWrapper, TransformComponent } from "react-zoom-pan-pinch";
 
 const CrashDiagram = props => {
   const [rotation, setRotation] = useState(0);
-  const [email, setEmail] = useState("");
   const [isCOA, setIsCOA] = useState(false);
 
   useEffect(() => {
     const storedEmail = window.localStorage.getItem("hasura_user_email");
     if (storedEmail) {
-      setEmail(storedEmail);
       if (storedEmail.toLowerCase().endsWith("@austintexas.gov")) {
         setIsCOA(true);
       }

--- a/atd-vze/src/views/Crashes/RelatedRecordsTable.js
+++ b/atd-vze/src/views/Crashes/RelatedRecordsTable.js
@@ -21,7 +21,7 @@ const RelatedRecordsTable = ({
   const [formData, setFormData] = useState("");
 
   // Disable edit features if only role is "readonly"
-  const { getRoles } = useAuth0();
+  const { getRoles, isCOA } = useAuth0();
   const roles = getRoles();
 
   const handleEditClick = (field, row) => {
@@ -126,7 +126,7 @@ const RelatedRecordsTable = ({
                     .map((field, i) => {
                       // Render victim name cell in victim name column if row is a fatality
                       if (field === "victim_name") {
-                        if (row.prsn_injry_sev_id === 4) {
+                        if (isCOA && row.prsn_injry_sev_id === 4) {
                           return (
                             <VictimNameField
                               key={`${field}-${i}`}

--- a/atd-vze/src/views/Locations/Location.js
+++ b/atd-vze/src/views/Locations/Location.js
@@ -13,6 +13,7 @@ import LocationNonCR3Crashes from "./LocationNonCR3Crashes";
 import LocationDownloadGlobal from "./LocationDownloadGlobal";
 import Notes from "../../Components/Notes/Notes";
 import Page404 from "../Pages/Page404/Page404";
+import { useAuth0 } from "../../auth/authContext";
 
 import { GET_LOCATION, UPDATE_LOCATION } from "../../queries/Locations";
 import {
@@ -24,6 +25,7 @@ import {
 
 function Location(props) {
   // Set initial variables for GET_LOCATION query
+  const { isCOA } = useAuth0();
   const locationId = props.match.params.id;
 
   const fiveYearsAgo = format(subYears(Date.now(), 5), "yyyy-MM-dd");
@@ -109,18 +111,20 @@ function Location(props) {
           downloadGlobal={downloadAllData}
         />
       </Row>
-      <Row>
-        <Col>
-          <Notes
-            recordId={locationId}
-            tableName={"location_notes"}
-            GET_NOTES={GET_LOCATION_NOTES}
-            INSERT_NOTE={INSERT_LOCATION_NOTE}
-            UPDATE_NOTE={UPDATE_LOCATION_NOTE}
-            DELETE_NOTE={DELETE_LOCATION_NOTE}
-          />
-        </Col>
-      </Row>
+      {isCOA && (
+        <Row>
+          <Col>
+            <Notes
+              recordId={locationId}
+              tableName={"location_notes"}
+              GET_NOTES={GET_LOCATION_NOTES}
+              INSERT_NOTE={INSERT_LOCATION_NOTE}
+              UPDATE_NOTE={UPDATE_LOCATION_NOTE}
+              DELETE_NOTE={DELETE_LOCATION_NOTE}
+            />
+          </Col>
+        </Row>
+      )}
       <Row>
         <Col>
           <LocationCrashes locationId={locationId} />

--- a/atd-vze/src/views/Locations/Location.js
+++ b/atd-vze/src/views/Locations/Location.js
@@ -24,8 +24,9 @@ import {
 } from "../../queries/locationNotes";
 
 function Location(props) {
-  // Set initial variables for GET_LOCATION query
   const { isCOA } = useAuth0();
+
+  // Set initial variables for GET_LOCATION query
   const locationId = props.match.params.id;
 
   const fiveYearsAgo = format(subYears(Date.now(), 5), "yyyy-MM-dd");


### PR DESCRIPTION
## Associated issues

closes https://github.com/cityofaustin/atd-data-tech/issues/15536

## Changed behavior

Hide the CR3 download button and the fatality review board information from non `austintexas.gov` email address holders. Additionally, the notes component is hidden on both the crash and location details page.

## Tag-along change

I adjusted the label for the CR3 download button to read "CR3" instead of "CR-3."

## Local testing

Because we all have an `austintexas.gov` address, the easiest way to test this is to spin it up locally and comment out the line where we `setIsCOA(true)` in `atd-vze/src/auth/authContext.js` to simulate not having an `austintexas.gov` address. The default value of the state variable is false, so not setting it to true simulates a non-COA user.

With that default state value, as if you were a non-`austintexas.gov` user, check to see that the following are not visible to you:

* [ ] Notes component on locations page
* [ ] Notes component on crash page
* [ ] Fatality Review Board component on the crash page
* [ ] Download CR3 button on the crash page

---
#### Ship list
- [ ] ~Check migrations for any conflicts with latest migrations in master branch~
- [ ] ~Confirm Hasura role permissions for necessary access~
- [ ] Code reviewed
- [ ] Product manager approved