### PR TITLE
Years of Life Lost is not being displayed on VZ Editor

### DIFF
--- a/atd-vze/src/helpers/people.js
+++ b/atd-vze/src/helpers/people.js
@@ -11,7 +11,6 @@ export const useTotalYearsOfLifeLost = ({
   peopleRecords = [],
 }) =>
   useMemo(() => {
-    console.log("this ran");
     const allPeopleRecords = [...primaryPeopleRecords, ...peopleRecords];
 
     return allPeopleRecords.reduce((acc, person) => {

--- a/atd-vze/src/helpers/people.js
+++ b/atd-vze/src/helpers/people.js
@@ -1,0 +1,21 @@
+import { useMemo } from "react";
+
+/**
+ * Return total years of life lost for all people in a crash using years_of_life_lost field
+ * @param {Array|undefined} primaryPeopleRecords - Array of primary people records
+ * @param {Array|undefined} peopleRecords - Array of people records
+ * @returns
+ */
+export const useTotalYearsOfLifeLost = ({
+  primaryPeopleRecords = [],
+  peopleRecords = [],
+}) =>
+  useMemo(() => {
+    console.log("this ran");
+    const allPeopleRecords = [...primaryPeopleRecords, ...peopleRecords];
+
+    return allPeopleRecords.reduce((acc, person) => {
+      const yearsOfLifeLost = person?.years_of_life_lost || 0;
+      return acc + yearsOfLifeLost;
+    }, 0);
+  }, [primaryPeopleRecords, peopleRecords]);

--- a/atd-vze/src/queries/people.js
+++ b/atd-vze/src/queries/people.js
@@ -26,6 +26,7 @@ export const GET_PEOPLE = gql`
       }
       unit_nbr
       peh_fl
+      years_of_life_lost
     }
     atd_txdot_person(where: { crash_id: { _eq: $crashId } }) {
       prsn_age
@@ -49,6 +50,7 @@ export const GET_PEOPLE = gql`
       }
       unit_nbr
       peh_fl
+      years_of_life_lost
     }
   }
 `;

--- a/atd-vze/src/views/Crashes/Crash.js
+++ b/atd-vze/src/views/Crashes/Crash.js
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from "react";
+import React, { useState } from "react";
 import { Link } from "react-router-dom";
 import {
   Card,
@@ -36,21 +36,7 @@ import {
   UPDATE_NOTE,
   DELETE_NOTE,
 } from "../../queries/crashNotes";
-
-const useTotalYearsOfLifeLost = peopleData =>
-  useMemo(() => {
-    if (!peopleData) return 0;
-
-    console.log(peopleData);
-    const primaryPeople = peopleData?.atd_txdot_primaryperson || [];
-    const people = peopleData?.atd_txdot_person || [];
-    const allPeople = [...primaryPeople, ...people];
-
-    return allPeople.reduce((acc, person) => {
-      const yearsOfLifeLost = parseInt(person.years_of_life_lost);
-      return acc + yearsOfLifeLost;
-    }, 0);
-  }, [peopleData]);
+import { useTotalYearsOfLifeLost } from "../../helpers/people";
 
 function Crash(props) {
   const crashId = props.match.params.id;
@@ -64,7 +50,10 @@ function Crash(props) {
   } = useQuery(GET_PEOPLE, {
     variables: { crashId },
   });
-  const crashYearsOfLifeLostTotal = useTotalYearsOfLifeLost(peopleData);
+  const crashYearsOfLifeLostTotal = useTotalYearsOfLifeLost({
+    primaryPeopleRecords: peopleData?.atd_txdot_primaryperson,
+    peopleRecords: peopleData?.atd_txdot_person,
+  });
 
   const [editField, setEditField] = useState("");
   const [formData, setFormData] = useState({});

--- a/atd-vze/src/views/Crashes/Crash.js
+++ b/atd-vze/src/views/Crashes/Crash.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useMemo, useState } from "react";
 import { Link } from "react-router-dom";
 import {
   Card,
@@ -37,22 +37,20 @@ import {
   DELETE_NOTE,
 } from "../../queries/crashNotes";
 
-const calculateYearsLifeLost = people => {
-  // Assume 75 year life expectancy,
-  // Find the difference between person.prsn_age & 75
-  // Sum over the list of ppl with .reduce
-  return people.reduce((accumulator, person) => {
-    let years = 0;
-    if (person.injury_severity.injry_sev_desc === "KILLED") {
-      let yearsLifeLost = 75 - Number(person.prsn_age);
-      // What if the person is older than 75?
-      // For now, so we don't have negative numbers,
-      // Assume years of life lost is 0
-      years = yearsLifeLost < 0 ? 0 : yearsLifeLost;
-    }
-    return accumulator + years;
-  }, 0); // start with a count at 0 years
-};
+const useTotalYearsOfLifeLost = peopleData =>
+  useMemo(() => {
+    if (!peopleData) return 0;
+
+    console.log(peopleData);
+    const primaryPeople = peopleData?.atd_txdot_primaryperson || [];
+    const people = peopleData?.atd_txdot_person || [];
+    const allPeople = [...primaryPeople, ...people];
+
+    return allPeople.reduce((acc, person) => {
+      const yearsOfLifeLost = parseInt(person.years_of_life_lost);
+      return acc + yearsOfLifeLost;
+    }, 0);
+  }, [peopleData]);
 
 function Crash(props) {
   const crashId = props.match.params.id;
@@ -66,6 +64,7 @@ function Crash(props) {
   } = useQuery(GET_PEOPLE, {
     variables: { crashId },
   });
+  const crashYearsOfLifeLostTotal = useTotalYearsOfLifeLost(peopleData);
 
   const [editField, setEditField] = useState("");
   const [formData, setFormData] = useState({});
@@ -167,9 +166,7 @@ function Crash(props) {
   } = !!data?.atd_txdot_crashes[0] ? data?.atd_txdot_crashes[0] : {};
 
   const mapGeocoderAddress = createGeocoderAddressString(data);
-  const yearsLifeLostCount = calculateYearsLifeLost(
-    peopleData.atd_txdot_primaryperson.concat(peopleData.atd_txdot_person)
-  );
+
   const hasLocation =
     data &&
     data?.atd_txdot_crashes.length > 0 &&
@@ -215,7 +212,9 @@ function Crash(props) {
         <Col xs="12" sm="6" md="4">
           <Widget02
             header={`${
-              yearsLifeLostCount === null ? "--" : yearsLifeLostCount
+              crashYearsOfLifeLostTotal === null
+                ? "--"
+                : crashYearsOfLifeLostTotal
             }`}
             mainText="Years of Life Lost"
             icon="fa fa-hourglass-end"

--- a/atd-vze/src/views/Crashes/Crash.js
+++ b/atd-vze/src/views/Crashes/Crash.js
@@ -50,7 +50,7 @@ function Crash(props) {
   } = useQuery(GET_PEOPLE, {
     variables: { crashId },
   });
-  const crashYearsOfLifeLostTotal = useTotalYearsOfLifeLost({
+  const totalYearsOfLifeLost = useTotalYearsOfLifeLost({
     primaryPeopleRecords: peopleData?.atd_txdot_primaryperson,
     peopleRecords: peopleData?.atd_txdot_person,
   });
@@ -201,9 +201,7 @@ function Crash(props) {
         <Col xs="12" sm="6" md="4">
           <Widget02
             header={`${
-              crashYearsOfLifeLostTotal === null
-                ? "--"
-                : crashYearsOfLifeLostTotal
+              totalYearsOfLifeLost === null ? "--" : totalYearsOfLifeLost
             }`}
             mainText="Years of Life Lost"
             icon="fa fa-hourglass-end"


### PR DESCRIPTION
## Associated issues
https://github.com/cityofaustin/atd-data-tech/issues/15333

This updates the Crash page to show the total years of life lost based on the `years_of_life_lost` column from the person and primary person tables that are populated by a trigger.

## Testing
**URL to test:** <!-- VZ URL or Netlify -->

**Steps to test:**
TBD

---
#### Ship list
- [ ] Check migrations for any conflicts with latest migrations in master branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved