### PR TITLE
Disable one password plug-in from the date-picker field

### DIFF
--- a/atd-vze/src/Components/GridDateRange.js
+++ b/atd-vze/src/Components/GridDateRange.js
@@ -51,7 +51,6 @@ const GridDateRange = ({
   setDateRangeFilter,
   initStartDate,
   initEndDate,
-  uniqueKey,
   minDate,
 }) => {
   /**
@@ -104,7 +103,6 @@ const GridDateRange = ({
     <>
       <StyledDatePicker>
         <DatePicker
-          id={`start-date-${uniqueKey}`}
           selected={startDate}
           onChange={date => setStartDate(date)}
           selectsStart
@@ -117,7 +115,6 @@ const GridDateRange = ({
         />
         <span>{" to "}</span>
         <DatePicker
-          id={`end-date-${uniqueKey}`}
           selected={endDate}
           onChange={date => setEndDate(date)}
           selectsEnd

--- a/atd-vze/src/Components/GridTable.js
+++ b/atd-vze/src/Components/GridTable.js
@@ -508,7 +508,6 @@ const GridTable = ({
                       initStartDate={dateRangeFilter.startDate}
                       initEndDate={dateRangeFilter.endDate}
                       minDate={minDate}
-                      uniqueKey={query.table}
                     />
                   </ButtonGroup>
                 )}

--- a/atd-vze/src/Components/GridTableHeader.js
+++ b/atd-vze/src/Components/GridTableHeader.js
@@ -40,8 +40,8 @@ const GridTableHeader = ({
       <thead>
         {helperText && (
           <tr>
-            <th colspan={colspan}>
-              <small class="pull-right">{helperText}</small>
+            <th colSpan={colspan}>
+              <small className="pull-right">{helperText}</small>
             </th>
           </tr>
         )}

--- a/atd-vze/src/views/Locations/Location.js
+++ b/atd-vze/src/views/Locations/Location.js
@@ -72,7 +72,7 @@ function Location(props) {
   };
 
   const downloadAllData = (
-    <div class={"float-right"}>
+    <div className={"float-right"}>
       <LocationDownloadGlobal locationId={locationId} />
     </div>
   );


### PR DESCRIPTION
## Associated issues
https://github.com/cityofaustin/atd-data-tech/issues/15321

This PR removes the id props that were set on the date picker components used in `GridTableDateRange`. [This](https://1password.community/discussion/117501/as-a-web-developer-how-can-i-disable-1password-filling-for-a-specific-field) is a fun thread about how 1PW recommends disabling autofill by the extension. A workaround mentioned adding `search` to ids in DOM elements so I tried removing them altogether which worked.

## Testing
**URL to test:** <!-- VZ URL or Netlify -->

**Steps to test:**
1. Go to a list view like the Crashes page and see that the 1PW icon doesn't appear in the end date input and the extension doesn't try to autofill
2. Check the other small changes that I made to fix console errors about invalid DOM properties

---
#### Ship list
- [x] Check migrations for any conflicts with latest migrations in master branch
- [x] Confirm Hasura role permissions for necessary access
- [x] Code reviewed
- [x] Product manager approved