### PR TITLE
Fix typo in default role name

### DIFF
--- a/atd-vze/package.json
+++ b/atd-vze/package.json
@@ -1,6 +1,6 @@
 {
   "name": "atd-vz-data",
-  "version": "1.42.0",
+  "version": "1.41.1",
   "homepage": "./",
   "description": "ATD Vision Zero Editor",
   "author": "ATD Data & Technology Services",

--- a/atd-vze/src/views/Users/UserForm.js
+++ b/atd-vze/src/views/Users/UserForm.js
@@ -34,7 +34,7 @@ const UserForm = ({ type, id = null }) => {
     connection: "Username-Password-Authentication", // Set account type
     verify_email: true, // Send email verification
     app_metadata: {
-      roles: ["readOnly"], // Default to lowest level access
+      roles: ["readonly"], // Default to lowest level access
     },
   };
 

--- a/atd-vze/src/views/Users/Users.js
+++ b/atd-vze/src/views/Users/Users.js
@@ -96,7 +96,7 @@ const UserRow = ({ user }) => {
           ? format(parseISO(user.last_login), "MM/dd/yyyy")
           : "Never"}
       </td>
-      <td>{rules[user.app_metadata.roles[0]].label}</td>
+      <td>{rules[user.app_metadata.roles[0]]?.label}</td>
       <td>
         <Link to={userLink}>
           <Badge color={getBadge(user.blocked)}>


### PR DESCRIPTION
## Associated issues

/none/

Slack discussion here: https://austininnovation.slack.com/archives/CM9MK950S/p1708539841539509.

## H/T

Thanks to @mddilley for diagnosing this and getting it fixed in production ⚡ fast.

## Testing

https://deploy-preview-1378--atd-vze-staging.netlify.app/#/

* You would need to add a user to the VZE application, and opt to not specify a role.
  * In doing so, the default will be used, which is now going to be `readonly` and not `readOnly`. 
* If this works as intended, and the users page does not fail with a runtime error, then ✅.
* Be sure to clean up any changes you make in Auth0.

Due to the very small amount of code that changed, I also am comfortable with y'all 👀ing this one and not making changes in Auth0, but either is great with me.

---
#### Ship list
- [x] Check migrations for any conflicts with latest migrations in master branch
- [x] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved