### PR TITLE
Update crash table unit metadata trigger to fire on any unit table row change

### DIFF
--- a/atd-vzd/migrations/default/1708558749621_update_unit_metadata_trigger/down.sql
+++ b/atd-vzd/migrations/default/1708558749621_update_unit_metadata_trigger/down.sql
@@ -1,9 +1,9 @@
-DROP TRIGGER IF EXISTS atd_txdot_units_mode_category_metadata_update on public.atd_txdot_units;
+DROP TRIGGER IF EXISTS atd_txdot_units_mode_category_metadata_update ON public.atd_txdot_units;
 
 CREATE TRIGGER atd_txdot_units_mode_category_metadata_update
-	AFTER UPDATE ON public.atd_txdot_units
-	FOR EACH ROW
-	WHEN (old.atd_mode_category IS DISTINCT FROM new.atd_mode_category)
-	EXECUTE FUNCTION public.atd_txdot_units_mode_category_metadata_update ();
+AFTER UPDATE ON public.atd_txdot_units
+FOR EACH ROW
+WHEN (old.atd_mode_category IS DISTINCT FROM new.atd_mode_category)
+EXECUTE FUNCTION public.atd_txdot_units_mode_category_metadata_update();
 
 COMMENT ON TRIGGER atd_txdot_units_mode_category_metadata_update ON public.atd_txdot_units IS 'Updates the associated crash table atd_mode_category_metadata column when a unit atd_mode_category is updated.';

--- a/atd-vzd/migrations/default/1708558749621_update_unit_metadata_trigger/down.sql
+++ b/atd-vzd/migrations/default/1708558749621_update_unit_metadata_trigger/down.sql
@@ -5,3 +5,5 @@ CREATE TRIGGER atd_txdot_units_mode_category_metadata_update
 	FOR EACH ROW
 	WHEN (old.atd_mode_category IS DISTINCT FROM new.atd_mode_category)
 	EXECUTE FUNCTION public.atd_txdot_units_mode_category_metadata_update ();
+
+COMMENT ON TRIGGER atd_txdot_units_mode_category_metadata_update ON public.atd_txdot_units IS 'Updates the associated crash table atd_mode_category_metadata column when a unit atd_mode_category is updated.';

--- a/atd-vzd/migrations/default/1708558749621_update_unit_metadata_trigger/down.sql
+++ b/atd-vzd/migrations/default/1708558749621_update_unit_metadata_trigger/down.sql
@@ -1,0 +1,7 @@
+DROP TRIGGER IF EXISTS atd_txdot_units_mode_category_metadata_update on public.atd_txdot_units;
+
+CREATE TRIGGER atd_txdot_units_mode_category_metadata_update
+	AFTER UPDATE ON public.atd_txdot_units
+	FOR EACH ROW
+	WHEN (old.atd_mode_category IS DISTINCT FROM new.atd_mode_category)
+	EXECUTE FUNCTION public.atd_txdot_units_mode_category_metadata_update ();

--- a/atd-vzd/migrations/default/1708558749621_update_unit_metadata_trigger/up.sql
+++ b/atd-vzd/migrations/default/1708558749621_update_unit_metadata_trigger/up.sql
@@ -1,0 +1,6 @@
+DROP TRIGGER IF EXISTS atd_txdot_units_mode_category_metadata_update on public.atd_txdot_units;
+
+CREATE TRIGGER atd_txdot_units_mode_category_metadata_update
+	AFTER UPDATE ON public.atd_txdot_units
+	FOR EACH ROW
+	EXECUTE FUNCTION public.atd_txdot_units_mode_category_metadata_update ();

--- a/atd-vzd/migrations/default/1708558749621_update_unit_metadata_trigger/up.sql
+++ b/atd-vzd/migrations/default/1708558749621_update_unit_metadata_trigger/up.sql
@@ -4,3 +4,5 @@ CREATE TRIGGER atd_txdot_units_mode_category_metadata_update
 	AFTER UPDATE ON public.atd_txdot_units
 	FOR EACH ROW
 	EXECUTE FUNCTION public.atd_txdot_units_mode_category_metadata_update ();
+
+COMMENT ON TRIGGER atd_txdot_units_mode_category_metadata_update ON public.atd_txdot_units IS 'Updates the associated crash table atd_mode_category_metadata column when a unit row is updated.';

--- a/atd-vzd/migrations/default/1708558749621_update_unit_metadata_trigger/up.sql
+++ b/atd-vzd/migrations/default/1708558749621_update_unit_metadata_trigger/up.sql
@@ -1,8 +1,8 @@
-DROP TRIGGER IF EXISTS atd_txdot_units_mode_category_metadata_update on public.atd_txdot_units;
+DROP TRIGGER IF EXISTS atd_txdot_units_mode_category_metadata_update ON public.atd_txdot_units;
 
 CREATE TRIGGER atd_txdot_units_mode_category_metadata_update
-	AFTER UPDATE ON public.atd_txdot_units
-	FOR EACH ROW
-	EXECUTE FUNCTION public.atd_txdot_units_mode_category_metadata_update ();
+AFTER UPDATE ON public.atd_txdot_units
+FOR EACH ROW
+EXECUTE FUNCTION public.atd_txdot_units_mode_category_metadata_update();
 
 COMMENT ON TRIGGER atd_txdot_units_mode_category_metadata_update ON public.atd_txdot_units IS 'Updates the associated crash table atd_mode_category_metadata column when a unit row is updated.';


### PR DESCRIPTION
## Associated issues
https://github.com/cityofaustin/atd-data-tech/issues/15509

This PR updates a trigger that recalculates the `atd_mode_category_metadata` column of a crash when a unit associated with its `crash_id` is updated. It will now fire when any unit column is changed.

## Testing
**URL to test:** <!-- VZ URL or Netlify -->
Local

**Steps to test:**
1. Start up the local DB and local VZE. Go to http://localhost:3000/editor/#/crashes/19113648 and find this crash row in the local database.
2. Look at the `atd_mode_category_metadata` of this crash, and you should see one unit with a fatality (`death_cnt > 0`) in the json array. There should also be one unit with a fatality in the VZE crash page accordion. If there is a mismatch here, don't worry - this PR is to fix that.
3. Make an edit to the fatality count of a unit and check the `atd_mode_category_metadata` column again. There should be no change. Try with many units and you should see the counts still do not change.
4. Apply the migration in this PR using the Hasura CLI: `hasura migrate apply --up 1`
5. Now, update a unit fatality count or type in VZE again. You can change all units to pedestrian type to more easily see the change.
6. You should see the `atd_mode_category_metadata` now reflects the count and type in the unit accordion.
7. Test the down migration in this PR using the Hasura CLI: `hasura migrate apply --down 1`

---
#### Ship list
- [x] Check migrations for any conflicts with latest migrations in master branch
- [x] Confirm Hasura role permissions for necessary access
- [x] Code reviewed
- [x] Product manager approved