### PR TITLE
Remove Crash page map editing capabilities for Read Only Users

### DIFF
--- a/atd-vze/src/views/Crashes/Crash.js
+++ b/atd-vze/src/views/Crashes/Crash.js
@@ -11,7 +11,12 @@ import {
 } from "reactstrap";
 import { withApollo } from "react-apollo";
 import { useQuery } from "@apollo/react-hooks";
-import { useAuth0, isAdmin, isItSupervisor } from "../../auth/authContext";
+import {
+  useAuth0,
+  isAdmin,
+  isItSupervisor,
+  isReadOnly,
+} from "../../auth/authContext";
 
 import CrashCollapses from "./CrashCollapses";
 import CrashMap from "./Maps/CrashMap";
@@ -237,7 +242,7 @@ function Crash(props) {
                     : "No Primary Coordinates"}
                 </Col>
                 <Col>
-                  {!isEditingCoords && (
+                  {!isEditingCoords && !isReadOnly(roles) && (
                     <Button
                       color="primary"
                       style={{ float: "right" }}


### PR DESCRIPTION
## Associated issues
Closes https://github.com/cityofaustin/atd-data-tech/issues/15456

## Testing
**URL to test:** <!-- VZ URL or Netlify -->
https://deploy-preview-1389--atd-vze-staging.netlify.app/

**Steps to test:**
1. Login as a read only user, you shouldn't see the `Edit Coordinates` button on the crash page anymore!

---
#### Ship list
- [x] Check migrations for any conflicts with latest migrations in master branch
- [x] Confirm Hasura role permissions for necessary access
- [x] Code reviewed
- [x] Product manager approved