### PR TITLE
Refine field edit inputs

### DIFF
--- a/atd-vze/src/Components/DataTable.js
+++ b/atd-vze/src/Components/DataTable.js
@@ -16,8 +16,6 @@ import {
   Button,
 } from "reactstrap";
 
-import "./dataTable.css";
-
 import { GET_LOOKUPS } from "../queries/lookups";
 
 const DataTable = ({
@@ -35,6 +33,7 @@ const DataTable = ({
   // Disable edit features if only role is "readonly"
   const { getRoles } = useAuth0();
   const roles = getRoles();
+  const isReadOnlyUser = isReadOnly(roles);
 
   const [showModal, setShowModal] = useState(false);
 
@@ -75,11 +74,6 @@ const DataTable = ({
                       const fieldConfigObject = section.fields[field];
 
                       const fieldLabel = fieldConfigObject.label;
-
-                      // Disable editing if user is only "readonly"
-                      if (fieldConfigObject.editable && isReadOnly(roles)) {
-                        fieldConfigObject.editable = false;
-                      }
 
                       // Set data table (alternate if defined in data map)
                       const fieldDataTable =
@@ -151,25 +145,17 @@ const DataTable = ({
                       };
 
                       const fieldValueDisplay = renderLookupDescString();
+                      const canClickToEdit =
+                        !isReadOnlyUser &&
+                        fieldConfigObject.editable &&
+                        !isEditing;
 
                       return (
                         <tr
                           key={i}
-                          className={
-                            fieldConfigObject.editable && !isEditing
-                              ? "data-table-editable"
-                              : ""
-                          }
-                          onClick={() =>
-                            fieldConfigObject.editable &&
-                            !isEditing &&
-                            setEditField(field)
-                          }
+                          onClick={() => canClickToEdit && setEditField(field)}
                           style={{
-                            cursor:
-                              fieldConfigObject.editable && !isEditing
-                                ? "pointer"
-                                : "auto",
+                            cursor: canClickToEdit ? "pointer" : "auto",
                           }}
                         >
                           <td className="align-middle">
@@ -237,7 +223,7 @@ const DataTable = ({
                           </td>
                           {!isEditing && (
                             <td style={{ textAlign: "right" }}>
-                              {fieldConfigObject.editable && !isEditing && (
+                              {canClickToEdit && (
                                 <i className="fa fa-pencil edit-toggle" />
                               )}
                             </td>

--- a/atd-vze/src/Components/DataTable.js
+++ b/atd-vze/src/Components/DataTable.js
@@ -155,7 +155,19 @@ const DataTable = ({
                           <td>
                             <strong>{fieldLabel}</strong>
                           </td>
-                          <td>
+                          <td
+                            style={{
+                              cursor:
+                                fieldConfigObject.editable && !isEditing
+                                  ? "pointer"
+                                  : "auto",
+                            }}
+                            onClick={() =>
+                              fieldConfigObject.editable &&
+                              !isEditing &&
+                              setEditField(field)
+                            }
+                          >
                             {isEditing ? (
                               <form
                                 onSubmit={e =>
@@ -164,6 +176,7 @@ const DataTable = ({
                               >
                                 {fieldUiType === "select" && (
                                   <Input
+                                    autoFocus
                                     name={field}
                                     id={field}
                                     onChange={e => handleInputChange(e)}
@@ -181,6 +194,7 @@ const DataTable = ({
                                 )}
                                 {fieldUiType === "text" && (
                                   <input
+                                    autoFocus
                                     type="text"
                                     defaultValue={fieldValue}
                                     onChange={e => handleInputChange(e)}
@@ -201,12 +215,21 @@ const DataTable = ({
                               fieldValueDisplay
                             )}
                           </td>
-                          <td>
+                          <td
+                            style={{
+                              cursor:
+                                fieldConfigObject.editable && !isEditing
+                                  ? "pointer"
+                                  : "auto",
+                            }}
+                            onClick={() =>
+                              fieldConfigObject.editable &&
+                              !isEditing &&
+                              setEditField(field)
+                            }
+                          >
                             {fieldConfigObject.editable && !isEditing && (
-                              <i
-                                className="fa fa-pencil edit-toggle"
-                                onClick={() => setEditField(field)}
-                              />
+                              <i className="fa fa-pencil edit-toggle" />
                             )}
                           </td>
                         </tr>

--- a/atd-vze/src/Components/DataTable.js
+++ b/atd-vze/src/Components/DataTable.js
@@ -14,7 +14,6 @@ import {
   Input,
   Table,
   Button,
-  Row,
 } from "reactstrap";
 
 import "./dataTable.css";
@@ -183,8 +182,8 @@ const DataTable = ({
                                   handleFieldUpdate(e, section.fields, field)
                                 }
                               >
-                                <Row className="m-0 y-0">
-                                  <Col>
+                                <div className="d-flex">
+                                  <div className="flex-grow-1">
                                     {fieldUiType === "select" && (
                                       <Input
                                         autoFocus
@@ -213,19 +212,21 @@ const DataTable = ({
                                         onChange={e => handleInputChange(e)}
                                       />
                                     )}
-                                  </Col>
-                                  <Col className="col-sm-auto px-0">
+                                  </div>
+                                  <div className="my-auto">
                                     <button type="submit">
                                       <i className="fa fa-check edit-toggle" />
                                     </button>
+                                  </div>
+                                  <div className="my-auto">
                                     <button type="cancel">
                                       <i
                                         className="fa fa-times edit-toggle"
                                         onClick={e => handleCancelClick(e)}
                                       ></i>
                                     </button>
-                                  </Col>
-                                </Row>
+                                  </div>
+                                </div>
                               </form>
                             ) : (
                               fieldValueDisplay

--- a/atd-vze/src/Components/DataTable.js
+++ b/atd-vze/src/Components/DataTable.js
@@ -202,7 +202,7 @@ const DataTable = ({
                                       />
                                     )}
                                   </div>
-                                  <div className="my-auto">
+                                  <div className="my-auto pl-2">
                                     <button type="submit">
                                       <i className="fa fa-check edit-toggle" />
                                     </button>

--- a/atd-vze/src/Components/DataTable.js
+++ b/atd-vze/src/Components/DataTable.js
@@ -14,7 +14,10 @@ import {
   Input,
   Table,
   Button,
+  Row,
 } from "reactstrap";
+
+import "./dataTable.css";
 
 import { GET_LOOKUPS } from "../queries/lookups";
 
@@ -151,87 +154,90 @@ const DataTable = ({
                       const fieldValueDisplay = renderLookupDescString();
 
                       return (
-                        <tr key={i}>
-                          <td>
+                        <tr
+                          key={i}
+                          className={
+                            fieldConfigObject.editable && !isEditing
+                              ? "data-table-editable"
+                              : ""
+                          }
+                          onClick={() =>
+                            fieldConfigObject.editable &&
+                            !isEditing &&
+                            setEditField(field)
+                          }
+                          style={{
+                            cursor:
+                              fieldConfigObject.editable && !isEditing
+                                ? "pointer"
+                                : "auto",
+                          }}
+                        >
+                          <td className="align-middle">
                             <strong>{fieldLabel}</strong>
                           </td>
-                          <td
-                            style={{
-                              cursor:
-                                fieldConfigObject.editable && !isEditing
-                                  ? "pointer"
-                                  : "auto",
-                            }}
-                            onClick={() =>
-                              fieldConfigObject.editable &&
-                              !isEditing &&
-                              setEditField(field)
-                            }
-                          >
+                          <td colSpan={isEditing ? 2 : 1}>
                             {isEditing ? (
                               <form
                                 onSubmit={e =>
                                   handleFieldUpdate(e, section.fields, field)
                                 }
                               >
-                                {fieldUiType === "select" && (
-                                  <Input
-                                    autoFocus
-                                    name={field}
-                                    id={field}
-                                    onChange={e => handleInputChange(e)}
-                                    defaultValue={fieldValue}
-                                    type="select"
-                                  >
-                                    {selectOptions.map(option => (
-                                      <option
-                                        value={option[`${lookupPrefix}_id`]}
+                                <Row className="m-0 y-0">
+                                  <Col>
+                                    {fieldUiType === "select" && (
+                                      <Input
+                                        autoFocus
+                                        name={field}
+                                        id={field}
+                                        onChange={e => handleInputChange(e)}
+                                        defaultValue={fieldValue}
+                                        type="select"
                                       >
-                                        {option[`${lookupPrefix}_desc`]}
-                                      </option>
-                                    ))}
-                                  </Input>
-                                )}
-                                {fieldUiType === "text" && (
-                                  <input
-                                    autoFocus
-                                    type="text"
-                                    defaultValue={fieldValue}
-                                    onChange={e => handleInputChange(e)}
-                                  />
-                                )}
-
-                                <button type="submit">
-                                  <i className="fa fa-check edit-toggle" />
-                                </button>
-                                <button type="cancel">
-                                  <i
-                                    className="fa fa-times edit-toggle"
-                                    onClick={e => handleCancelClick(e)}
-                                  ></i>
-                                </button>
+                                        {selectOptions.map(option => (
+                                          <option
+                                            value={option[`${lookupPrefix}_id`]}
+                                          >
+                                            {option[`${lookupPrefix}_desc`]}
+                                          </option>
+                                        ))}
+                                      </Input>
+                                    )}
+                                    {fieldUiType === "text" && (
+                                      <Input
+                                        autoFocus
+                                        name={field}
+                                        id={field}
+                                        type="text"
+                                        defaultValue={fieldValue}
+                                        onChange={e => handleInputChange(e)}
+                                      />
+                                    )}
+                                  </Col>
+                                  <Col className="col-sm-auto px-0">
+                                    <button type="submit">
+                                      <i className="fa fa-check edit-toggle" />
+                                    </button>
+                                    <button type="cancel">
+                                      <i
+                                        className="fa fa-times edit-toggle"
+                                        onClick={e => handleCancelClick(e)}
+                                      ></i>
+                                    </button>
+                                  </Col>
+                                </Row>
                               </form>
                             ) : (
                               fieldValueDisplay
                             )}
                           </td>
-                          <td
-                            style={{
-                              cursor:
-                                fieldConfigObject.editable && !isEditing
-                                  ? "pointer"
-                                  : "auto",
-                            }}
-                            onClick={() =>
-                              fieldConfigObject.editable &&
-                              !isEditing &&
-                              setEditField(field)
-                            }
-                          >
-                            {fieldConfigObject.editable && !isEditing && (
-                              <i className="fa fa-pencil edit-toggle" />
-                            )}
-                          </td>
+                          {!isEditing && (
+                            <td style={{ textAlign: "right" }}>
+                              {fieldConfigObject.editable && !isEditing && (
+                                <i className="fa fa-pencil edit-toggle" />
+                              )}
+                            </td>
+                          )}
                         </tr>
                       );
                     })}

--- a/atd-vze/src/Components/DataTable.js
+++ b/atd-vze/src/Components/DataTable.js
@@ -210,6 +210,9 @@ const DataTable = ({
                                         type="text"
                                         defaultValue={fieldValue}
                                         onChange={e => handleInputChange(e)}
+                                        autoComplete="off"
+                                        // disable 1password autofill
+                                        data-1p-ignore
                                       />
                                     )}
                                   </div>

--- a/atd-vze/src/Components/DataTable.js
+++ b/atd-vze/src/Components/DataTable.js
@@ -6,6 +6,7 @@ import get from "lodash.get";
 import { formatCostToDollars, formatDateTimeString } from "../helpers/format";
 
 import {
+  Button,
   Card,
   CardHeader,
   CardBody,
@@ -13,7 +14,6 @@ import {
   Col,
   Input,
   Table,
-  Button,
 } from "reactstrap";
 
 import { GET_LOOKUPS } from "../queries/lookups";
@@ -202,18 +202,24 @@ const DataTable = ({
                                       />
                                     )}
                                   </div>
-                                  <div className="my-auto pl-2">
-                                    <button type="submit">
+                                  <div className="my-auto pl-2 d-flex">
+                                    <Button
+                                      type="submit"
+                                      color="primary"
+                                      size="sm"
+                                      className="btn-pill mr-1"
+                                    >
                                       <i className="fa fa-check edit-toggle" />
-                                    </button>
-                                  </div>
-                                  <div className="my-auto">
-                                    <button type="cancel">
-                                      <i
-                                        className="fa fa-times edit-toggle"
-                                        onClick={e => handleCancelClick(e)}
-                                      ></i>
-                                    </button>
+                                    </Button>
+                                    <Button
+                                      type="cancel"
+                                      color="danger"
+                                      size="sm"
+                                      className="btn-pill"
+                                      onClick={e => handleCancelClick(e)}
+                                    >
+                                      <i className="fa fa-times edit-toggle"></i>
+                                    </Button>
                                   </div>
                                 </div>
                               </form>

--- a/atd-vze/src/Components/dataTable.css
+++ b/atd-vze/src/Components/dataTable.css
@@ -1,0 +1,3 @@
+.data-table-editable:hover {
+    background-color: rgba(32,168,216, .2) !important;
+}

--- a/atd-vze/src/Components/dataTable.css
+++ b/atd-vze/src/Components/dataTable.css
@@ -1,3 +1,0 @@
-.data-table-editable:hover {
-    background-color: rgba(32,168,216, .2) !important;
-}

--- a/atd-vze/src/views/Crashes/RelatedRecordsTable.js
+++ b/atd-vze/src/views/Crashes/RelatedRecordsTable.js
@@ -182,6 +182,7 @@ const RelatedRecordsTable = ({
                               >
                                 {uiType === "text" && (
                                   <Input
+                                    autoFocus
                                     type="text"
                                     defaultValue={row[field]}
                                     onChange={e =>
@@ -191,6 +192,7 @@ const RelatedRecordsTable = ({
                                 )}
                                 {uiType === "select" && (
                                   <Input
+                                    autoFocus
                                     name={field}
                                     id={field}
                                     onChange={e =>
@@ -230,6 +232,7 @@ const RelatedRecordsTable = ({
                                 )}
                                 {uiType === "boolean" && (
                                   <Input
+                                    autoFocus
                                     defaultValue={row[field]}
                                     type="select"
                                     onChange={e =>


### PR DESCRIPTION
## Associated issues
- https://github.com/cityofaustin/atd-data-tech/issues/16117

## Testing
**URL to test:** [Netlify](https://deploy-preview-1390--atd-vze-staging.netlify.app/)

**Steps to test:**
1. Go to the crash page and edit a unit and person record. Notice that when you click the pencil button, the editable field is auto-focused ✅ 
2. Scroll down the page and edit some crash fields. Notice that when you hover over an editable field, the cursor is a `pointer`, you can click anywhere in the field's row to toggle editing, and field input is auto-focused ✅ 
3. Log in as a read-only user and verify that you cannot edit any fields ✅ 

---
#### Ship list
- [ ] Check migrations for any conflicts with latest migrations in master branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved