### PR TITLE
Updates fetch policy to use cache-and-network everywhere

### DIFF
--- a/atd-vze/src/views/Crashes/Crashes.js
+++ b/atd-vze/src/views/Crashes/Crashes.js
@@ -21,6 +21,11 @@ let queryConf = {
   where: {},
   limit: 25,
   offset: 0,
+  options: {
+    useQuery: {
+      fetchPolicy: "cache-and-network",
+    },
+  },
 };
 
 let crashesQuery = new gqlAbstract(queryConf);

--- a/atd-vze/src/views/Fatalities/Fatalities.js
+++ b/atd-vze/src/views/Fatalities/Fatalities.js
@@ -12,11 +12,6 @@ import {
 
 // Our initial query configuration
 let queryConf = {
-  options: {
-    useQuery: {
-      fetchPolicy: "no-cache",
-    },
-  },
   table: "view_fatalities",
   single_item: "crashes",
   showDateRange: true,
@@ -25,6 +20,11 @@ let queryConf = {
   where: {},
   limit: 25,
   offset: 0,
+  options: {
+    useQuery: {
+      fetchPolicy: "cache-and-network",
+    },
+  },
 };
 
 const minDate = subYears(new Date(), 10);

--- a/atd-vze/src/views/Locations/Locations.js
+++ b/atd-vze/src/views/Locations/Locations.js
@@ -66,6 +66,11 @@ let queryConf = {
   where: {},
   limit: 25,
   offset: 0,
+  options: {
+    useQuery: {
+      fetchPolicy: "cache-and-network",
+    },
+  },
 };
 
 const dateRangeStart = format(subYears(new Date(), 5), "MM/dd/yyyy");


### PR DESCRIPTION
## Associated issues

- https://github.com/cityofaustin/atd-data-tech/issues/15884

I noticed the Crashes and Locations never refetch, so I went ahead and updated the policy everywhere. Here are the [Apollo docs](https://www.apollographql.com/docs/react/data/queries/#setting-a-fetch-policy) on this topic.


## Testing
**URL to test:** Netlify

Bounce around between the various pages and views in the app, making sure hit the Crashes, Locations, and Fatalities lists. Those pages should remain hydrated as you navigate away and then back to them.


---
#### Ship list
- [ ] Check migrations for any conflicts with latest migrations in master branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved