### PR TITLE
Update timeout in the read replica haproxy configuration

### DIFF
--- a/atd-toolbox/read_replica_proxy/haproxy.cfg.template
+++ b/atd-toolbox/read_replica_proxy/haproxy.cfg.template
@@ -4,9 +4,9 @@ global
 defaults
   log global
   mode tcp
-  timeout connect 5000ms
-  timeout client 600000ms
-  timeout server 600000ms
+  timeout connect 5s
+  timeout client 10m
+  timeout server 10m
 
 frontend postgresql_front
   bind 0.0.0.0:5432

--- a/atd-toolbox/read_replica_proxy/haproxy.cfg.template
+++ b/atd-toolbox/read_replica_proxy/haproxy.cfg.template
@@ -5,8 +5,8 @@ defaults
   log global
   mode tcp
   timeout connect 5000ms
-  timeout client 300000ms
-  timeout server 300000ms
+  timeout client 600000ms
+  timeout server 600000ms
 
 frontend postgresql_front
   bind 0.0.0.0:5432

--- a/atd-toolbox/read_replica_proxy/haproxy.cfg.template
+++ b/atd-toolbox/read_replica_proxy/haproxy.cfg.template
@@ -5,8 +5,8 @@ defaults
   log global
   mode tcp
   timeout connect 5000ms
-  timeout client 50000ms
-  timeout server 50000ms
+  timeout client 300000ms
+  timeout server 300000ms
 
 frontend postgresql_front
   bind 0.0.0.0:5432


### PR DESCRIPTION
## Associated issues

This PR aims to close both https://github.com/cityofaustin/atd-data-tech/issues/14987 and https://github.com/cityofaustin/atd-data-tech/issues/16226.

## Clarification :reminder_ribbon: 

I had stated that I had not yet pushed up and merged this configuration, but I had. I just didn't remember doing it. It's been in the toolbox all along, and this PR is an update to that configuration.

## Testing

#### This is deployed in production already.

* [ ] If you can use the read replica for VZ, then this is working. 
* [ ] Additionally, you can test to see if you don't have your connection dropped until [10 minutes of being idle](https://github.com/cityofaustin/atd-vz-data/commit/f75648d9e16ee0fd090b198e14f13b5487894419).

---
#### Ship list

- [ ] Code reviewed
- [ ] Product manager approved