### PR TITLE
[Enhancement] Increase change log modal width and wrap text

### DIFF
--- a/atd-vze/src/views/Crashes/CrashChangeLog.js
+++ b/atd-vze/src/views/Crashes/CrashChangeLog.js
@@ -165,8 +165,12 @@ class CrashChangeLog extends Component {
       content = <p>No changes found for this record.</p>;
     } else {
       modal = (
-        <Modal isOpen={this.state.modal} className="mw-100 mx-5">
-          <ModalHeader>Record Differences</ModalHeader>
+        <Modal
+          isOpen={this.state.modal}
+          toggle={this.closeModal}
+          className="mw-100 mx-5"
+        >
+          <ModalHeader toggle={this.closeModal}>Record Differences</ModalHeader>
           <ModalBody>{this.state.modalBody}</ModalBody>
           <ModalFooter>
             <Button color="secondary" onClick={this.closeModal}>

--- a/atd-vze/src/views/Crashes/CrashChangeLog.js
+++ b/atd-vze/src/views/Crashes/CrashChangeLog.js
@@ -148,10 +148,14 @@ class CrashChangeLog extends Component {
         <tr key={`recordHistory-${i}`}>
           <td>{item.original_record_key}</td>
           <td>
-            <Badge color="primary">{String(item.original_record_value)}</Badge>
+            <Badge color="primary" className="text-wrap">
+              {String(item.original_record_value)}
+            </Badge>
           </td>
           <td>
-            <Badge color="danger">{String(item.archived_record_value)}</Badge>
+            <Badge color="danger" className="text-wrap">
+              {String(item.archived_record_value)}
+            </Badge>
           </td>
         </tr>
       );
@@ -193,7 +197,7 @@ class CrashChangeLog extends Component {
       content = <p>No changes found for this record.</p>;
     } else {
       modal = (
-        <Modal isOpen={this.state.modal} className={this.props.className}>
+        <Modal isOpen={this.state.modal} className="mw-100">
           <ModalHeader>Record Differences</ModalHeader>
           <ModalBody>{this.state.modalBody}</ModalBody>
           <ModalFooter>

--- a/atd-vze/src/views/Crashes/CrashChangeLog.js
+++ b/atd-vze/src/views/Crashes/CrashChangeLog.js
@@ -148,12 +148,12 @@ class CrashChangeLog extends Component {
         <tr key={`recordHistory-${i}`}>
           <td>{item.original_record_key}</td>
           <td>
-            <Badge color="primary" className="text-wrap">
+            <Badge color="primary" className="text-wrap text-break">
               {String(item.original_record_value)}
             </Badge>
           </td>
           <td>
-            <Badge color="danger" className="text-wrap">
+            <Badge color="danger" className="text-wrap text-break">
               {String(item.archived_record_value)}
             </Badge>
           </td>
@@ -197,7 +197,7 @@ class CrashChangeLog extends Component {
       content = <p>No changes found for this record.</p>;
     } else {
       modal = (
-        <Modal isOpen={this.state.modal} className="mw-100">
+        <Modal isOpen={this.state.modal} className="mw-100 mx-5">
           <ModalHeader>Record Differences</ModalHeader>
           <ModalBody>{this.state.modalBody}</ModalBody>
           <ModalFooter>

--- a/atd-vze/src/views/Crashes/CrashChangeLog.js
+++ b/atd-vze/src/views/Crashes/CrashChangeLog.js
@@ -168,7 +168,7 @@ class CrashChangeLog extends Component {
         <h6>Edited Date: {this.timeConverter(record.update_timestamp)}</h6>
         <h6>Updated by: {record.updated_by || "Unavailable"}</h6>
         &nbsp;
-        <Table responsive>
+        <Table responsive className="overflow-hidden">
           <thead>
             <tr className="d-flex">
               <td className="col-2">Field</td>

--- a/atd-vze/src/views/Crashes/CrashChangeLog.js
+++ b/atd-vze/src/views/Crashes/CrashChangeLog.js
@@ -145,14 +145,14 @@ class CrashChangeLog extends Component {
       }
 
       return (
-        <tr key={`recordHistory-${i}`}>
-          <td>{item.original_record_key}</td>
-          <td>
+        <tr key={`recordHistory-${i}`} className="d-flex">
+          <td className="col-2 text-break">{item.original_record_key}</td>
+          <td className="col-5">
             <Badge color="primary" className="text-wrap text-break">
               {String(item.original_record_value)}
             </Badge>
           </td>
-          <td>
+          <td className="col-5">
             <Badge color="danger" className="text-wrap text-break">
               {String(item.archived_record_value)}
             </Badge>
@@ -165,15 +165,15 @@ class CrashChangeLog extends Component {
     modalBody = (
       <section>
         <h6>Crash ID: {record.record_crash_id}</h6>
-        <h6>Edited Date: {record.update_timestamp}</h6>
+        <h6>Edited Date: {this.timeConverter(record.update_timestamp)}</h6>
         <h6>Updated by: {record.updated_by || "Unavailable"}</h6>
         &nbsp;
         <Table responsive>
           <thead>
-            <tr>
-              <td>Field</td>
-              <td>Current Value</td>
-              <td>Previous Value</td>
+            <tr className="d-flex">
+              <td className="col-2">Field</td>
+              <td className="col-5">Current Value</td>
+              <td className="col-5">Previous Value</td>
               <td></td>
             </tr>
           </thead>

--- a/atd-vze/src/views/Crashes/CrashChangeLog.js
+++ b/atd-vze/src/views/Crashes/CrashChangeLog.js
@@ -118,37 +118,43 @@ class CrashChangeLog extends Component {
     // Define a function to pass to JSON.stringify which will skip over
     // the __typename key in the JS object being stringified.
     const stringifyReplacer = (key, value) => {
-      if (key === '__typename') {
+      if (key === "__typename") {
         return undefined;
       }
       return value;
-    }
+    };
 
     // For each entry created in the diff array, generate an HTML table row.
-    let modalItems = diff.map(item => {
+    let modalItems = diff.map((item, i) => {
       // The following two conditions check if an the current or archived value to
       // to be shown in the crach's changelog are objects, such as found when a jsonb
-      // field is pulled from the database. In this case, they are stringified for 
+      // field is pulled from the database. In this case, they are stringified for
       // human-readble output.
-      if (typeof item.original_record_value === 'object') {
-        item.original_record_value = JSON.stringify(item.original_record_value, stringifyReplacer);
+      if (typeof item.original_record_value === "object") {
+        item.original_record_value = JSON.stringify(
+          item.original_record_value,
+          stringifyReplacer
+        );
       }
 
-      if (typeof item.archived_record_value === 'object') {
-        item.archived_record_value = JSON.stringify(item.archived_record_value, stringifyReplacer);
+      if (typeof item.archived_record_value === "object") {
+        item.archived_record_value = JSON.stringify(
+          item.archived_record_value,
+          stringifyReplacer
+        );
       }
 
       return (
-      <tr key={`recordHistory-${record.id}`}>
-        <td>{item.original_record_key}</td>
-        <td>
-          <Badge color="primary">{String(item.original_record_value)}</Badge>
-        </td>
-        <td>
-          <Badge color="danger">{String(item.archived_record_value)}</Badge>
-        </td>
-      </tr>
-      )
+        <tr key={`recordHistory-${i}`}>
+          <td>{item.original_record_key}</td>
+          <td>
+            <Badge color="primary">{String(item.original_record_value)}</Badge>
+          </td>
+          <td>
+            <Badge color="danger">{String(item.archived_record_value)}</Badge>
+          </td>
+        </tr>
+      );
     });
 
     // Generate the body of the modal box
@@ -211,7 +217,7 @@ class CrashChangeLog extends Component {
             </thead>
             <tbody>
               {this.props.data.atd_txdot_change_log.map(record => (
-                <tr key={`changelog-${record.id}`}>
+                <tr key={`changelog-${record.change_log_id}`}>
                   <td>
                     <Badge color="warning">
                       {this.timeConverter(record.update_timestamp)}

--- a/atd-vze/src/views/Crashes/CrashChangeLog.js
+++ b/atd-vze/src/views/Crashes/CrashChangeLog.js
@@ -14,6 +14,7 @@ import {
   ModalBody,
   ModalFooter,
 } from "reactstrap";
+import { formatDateTimeString } from "../../helpers/format";
 
 class CrashChangeLog extends Component {
   constructor(props) {
@@ -26,39 +27,6 @@ class CrashChangeLog extends Component {
       dataTo: null,
       data: this.props.data,
     };
-  }
-
-  /**
-   * Converts a PostgreSQL Timestamp string into a human readable date-time
-   * @param {String} the timestamp as provided by postgres
-   */
-  timeConverter(UNIX_timestamp) {
-    let a = new Date(`${UNIX_timestamp}`.replace(" ", "T"));
-    let months = [
-      "Jan",
-      "Feb",
-      "Mar",
-      "Apr",
-      "May",
-      "Jun",
-      "Jul",
-      "Aug",
-      "Sep",
-      "Oct",
-      "Nov",
-      "Dec",
-    ];
-    return (
-      a.getDate() +
-      " " +
-      months[a.getMonth()] +
-      " " +
-      a.getFullYear() +
-      " " +
-      a.getHours() +
-      ":" +
-      a.getMinutes()
-    );
   }
 
   /**
@@ -165,7 +133,7 @@ class CrashChangeLog extends Component {
     modalBody = (
       <section>
         <h6>Crash ID: {record.record_crash_id}</h6>
-        <h6>Edited Date: {this.timeConverter(record.update_timestamp)}</h6>
+        <h6>Edited Date: {formatDateTimeString(record.update_timestamp)}</h6>
         <h6>Updated by: {record.updated_by || "Unavailable"}</h6>
         &nbsp;
         <Table responsive className="overflow-hidden">
@@ -224,7 +192,7 @@ class CrashChangeLog extends Component {
                 <tr key={`changelog-${record.change_log_id}`}>
                   <td>
                     <Badge color="warning">
-                      {this.timeConverter(record.update_timestamp)}
+                      {formatDateTimeString(record.update_timestamp)}
                     </Badge>
                   </td>
                   <td>


### PR DESCRIPTION
## Associated issues
https://github.com/cityofaustin/atd-data-tech/issues/15894

This makes a few updates to the change log modal to prevent horizontal scrolling from happening on screens with plenty of real estate to show the change log data.

## Testing
**URL to test:** <!-- VZ URL or Netlify -->
https://deploy-preview-1403--atd-vze-staging.netlify.app/

**Steps to test:**
1. Find a crash with change log entries like: https://deploy-preview-1403--atd-vze-staging.netlify.app/#/crashes/19448665
2. Go to the bottom of the page and click **Compare** on one of the change log rows
3. When the modal opens, notice that it takes up the majority of the width available in your browser window
4. Also, notice as you decrease the browser width, the text in the current and previous columns wrap and break to prevent side-scrolling early on. `cr3_file_metadata` and `investigator_narrative_ocr` are a good indicators of this behavior. The OCR narrative was specifically causing uneven table column widths between the current and previous values.

---
#### Ship list
- [x] Check migrations for any conflicts with latest migrations in master branch
- [x] Confirm Hasura role permissions for necessary access
- [x] Code reviewed
- [x] Product manager approved