### PR TITLE
Add thousands separator to crashes and locations lists

### DIFF
--- a/atd-vze/src/Components/GridTablePagination.js
+++ b/atd-vze/src/Components/GridTablePagination.js
@@ -47,9 +47,9 @@ const GridTablePagination = ({
           </Button>
           <StyledDisableClick>
             <Button color="light">
-              Page {pageNumber}/{totalPages === 0 ? 1 : totalPages}
+              Page {pageNumber.toLocaleString()}/{totalPages === 0 ? 1 : totalPages.toLocaleString()}
             </Button>
-            <Button color="light">Results: {totalRecords}</Button>
+            <Button color="light">Results: {totalRecords.toLocaleString()}</Button>
           </StyledDisableClick>
 
           <Button

--- a/atd-vze/src/queries/gqlAbstract.js
+++ b/atd-vze/src/queries/gqlAbstract.js
@@ -307,7 +307,7 @@ gqlAbstractTableAggregateName (
         return `${dateValue}`;
       }
       case "currency": {
-        return `$${value.toLocaleString()}`;
+        return `$${parseFloat(value).toLocaleString()}`;
       }
       case "boolean": {
         return value ? "True" : "False";

--- a/atd-vze/src/queries/gqlAbstract.js
+++ b/atd-vze/src/queries/gqlAbstract.js
@@ -1,4 +1,5 @@
 import { gql } from "apollo-boost";
+import { formatCostToDollars } from "../helpers/format";
 
 class gqlAbstract {
   /**
@@ -307,7 +308,7 @@ gqlAbstractTableAggregateName (
         return `${dateValue}`;
       }
       case "currency": {
-        return `$${parseFloat(value).toLocaleString()}`;
+        return formatCostToDollars(parseFloat(value));
       }
       case "boolean": {
         return value ? "True" : "False";


### PR DESCRIPTION
## Associated issues
Closes https://github.com/cityofaustin/atd-data-tech/issues/15866

## Testing
**URL to test:** <!-- VZ URL or Netlify -->
[Netlify
](https://deploy-preview-1404--atd-vze-staging.netlify.app/#/dashboard)
**Steps to test:**
1. Check out the crashes and locations page, observe and admire the comma separators making numbers in the thousands more readable :sparkles:

---
#### Ship list
- [x] Check migrations for any conflicts with latest migrations in master branch
- [x] Confirm Hasura role permissions for necessary access
- [x] Code reviewed
- [x] Product manager approved