### PR TITLE
Fix bug where searching without a column chosen doesn't show warning on first search

### DIFF
--- a/atd-vze/src/Components/GridTable.js
+++ b/atd-vze/src/Components/GridTable.js
@@ -45,6 +45,7 @@ const GridTable = ({
   minDate,
   roleSpecificColumns,
   hasSpecificRole,
+  defaultSearchField,
 }) => {
   // Load table filters from localStorage by title
   const savedFilterState = JSON.parse(
@@ -491,6 +492,7 @@ const GridTable = ({
                   resetPage={resetPageOnSearch}
                   filters={filters}
                   toggleAdvancedFilters={toggleAdvancedFilters}
+                  defaultSearchField={defaultSearchField}
                 />
                 <GridFilters
                   isCollapsed={collapseAdvancedFilters}

--- a/atd-vze/src/Components/GridTableSearch.js
+++ b/atd-vze/src/Components/GridTableSearch.js
@@ -89,12 +89,6 @@ const GridTableSearch = ({
   return (
     <Col md={12}>
       <Form className="form-horizontal" onSubmit={handleSearchSubmission}>
-        {!isFieldSelected && isSearchValueEntered && (
-          <Alert color="warning">Please provide a field to search.</Alert>
-        )}
-        {isFieldSelected && !isSearchValueEntered && (
-          <Alert color="warning">Please enter a value to search.</Alert>
-        )}
         <FormGroup>
           <InputGroup>
             <Input

--- a/atd-vze/src/Components/GridTableSearch.js
+++ b/atd-vze/src/Components/GridTableSearch.js
@@ -88,8 +88,11 @@ const GridTableSearch = ({
   return (
     <Col md={12}>
       <Form className="form-horizontal" onSubmit={handleSearchSubmission}>
-        {!isFieldSelected && searchFieldValue && (
+        {!isFieldSelected && isSearchValueEntered && (
           <Alert color="warning">Please provide a field to search.</Alert>
+        )}
+        {isFieldSelected && !isSearchValueEntered && (
+          <Alert color="warning">Please enter a value to search.</Alert>
         )}
         <FormGroup>
           <InputGroup>

--- a/atd-vze/src/Components/GridTableSearch.js
+++ b/atd-vze/src/Components/GridTableSearch.js
@@ -33,6 +33,7 @@ const GridTableSearch = ({
     (searchParameters && searchParameters.column) || ""
   );
   const isFieldSelected = !!fieldToSearch || false;
+  const isSearchValueEntered = !!searchFieldValue || false;
 
   const fieldsToSearch = query.searchableFields;
 
@@ -121,7 +122,11 @@ const GridTableSearch = ({
               </DropdownMenu>
             </InputGroupButtonDropdown>
             <InputGroupAddon addonType="append">
-              <Button type="submit" color="primary">
+              <Button
+                type="submit"
+                color="primary"
+                disabled={!isFieldSelected || !isSearchValueEntered}
+              >
                 <i className="fa fa-search" /> Search
               </Button>
               <Button

--- a/atd-vze/src/Components/GridTableSearch.js
+++ b/atd-vze/src/Components/GridTableSearch.js
@@ -32,9 +32,7 @@ const GridTableSearch = ({
   const [fieldToSearch, setFieldToSearch] = useState(
     (searchParameters && searchParameters.column) || ""
   );
-  const [isFieldSelected, setIsFieldSelected] = useState(
-    !!searchParameters || false
-  );
+  const isFieldSelected = !!fieldToSearch || false;
 
   const fieldsToSearch = query.searchableFields;
 
@@ -60,7 +58,6 @@ const GridTableSearch = ({
     clearFilters();
     setSearchFieldValue("");
     setFieldToSearch("");
-    setIsFieldSelected(false);
   };
 
   /**
@@ -75,7 +72,6 @@ const GridTableSearch = ({
    * @param {object} e - the event object
    */
   const handleFieldSelect = e => {
-    setIsFieldSelected(true);
     setFieldToSearch(e.target.value);
   };
 

--- a/atd-vze/src/Components/GridTableSearch.js
+++ b/atd-vze/src/Components/GridTableSearch.js
@@ -24,13 +24,14 @@ const GridTableSearch = ({
   resetPage,
   filters,
   toggleAdvancedFilters,
+  defaultSearchField = "",
 }) => {
   const [searchFieldValue, setSearchFieldValue] = useState(
     (searchParameters && searchParameters.value) || ""
   );
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
   const [fieldToSearch, setFieldToSearch] = useState(
-    (searchParameters && searchParameters.column) || ""
+    (searchParameters && searchParameters.column) || defaultSearchField
   );
   const isFieldSelected = !!fieldToSearch || false;
   const isSearchValueEntered = !!searchFieldValue || false;
@@ -58,7 +59,7 @@ const GridTableSearch = ({
   const handleClearSearchResults = () => {
     clearFilters();
     setSearchFieldValue("");
-    setFieldToSearch("");
+    setFieldToSearch(defaultSearchField);
   };
 
   /**
@@ -137,7 +138,7 @@ const GridTableSearch = ({
                 color="danger"
                 onClick={handleClearSearchResults}
               >
-                <i className="fa fa-ban" /> Clear
+                <i className="fa fa-ban" /> Reset
               </Button>
               {(filters || null) !== null && (
                 <Button

--- a/atd-vze/src/views/Crashes/Crashes.js
+++ b/atd-vze/src/views/Crashes/Crashes.js
@@ -54,6 +54,7 @@ const Crashes = () => {
       minDate={minDate}
       roleSpecificColumns={adminColumns}
       hasSpecificRole={isAdminOrItSupervisor}
+      defaultSearchField="crash_id"
     />
   );
 };


### PR DESCRIPTION
## Associated issues
https://github.com/cityofaustin/atd-data-tech/issues/15454

This fixes a bug where the GridTable search didn't show the expected messages or search behavior until a local storage configuration was initialized in the browser local storage.

## Testing
**URL to test:** <!-- VZ URL or Netlify -->
https://deploy-preview-1409--atd-vze-staging.netlify.app/#/crashes

**Steps to test:**
1. Go to the test link and then delete the key called `jestersavedCrashesConfig`. I think that we should capture the debt around this saved config that I mentioned [here](https://github.com/cityofaustin/atd-data-tech/issues/15454#issuecomment-2010765513). Frank and John had some good ideas when we patched this back in the day, and we've addressed something like this in Moped now too.
2. Refresh the crashes page, and you should see that crash ID is selected in the search dropdown. You should also see that the search button is disabled since the search value input isn't complete. There will also be a warning message to enter a search value.
3. Change the chosen field in the dropdown to Case ID, and the click the **Reset** button. The dropdown should reset to show the default field, crash ID, and the warning message will be back.
4. Try these same steps in staging, and you will see that the UI lets you search before selecting a field and does not show a message about the missing field until the local storage search config is initialized.
5. Check the Locations list loads normally since this PR makes a small update to GridTable.

---
#### Ship list
- [ ] Check migrations for any conflicts with latest migrations in master branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved