### PR TITLE
 [Enhancement] Change the default landing page to Crashes instead of Dashboard

### DIFF
--- a/atd-vze/src/containers/DefaultLayout/DefaultLayout.js
+++ b/atd-vze/src/containers/DefaultLayout/DefaultLayout.js
@@ -77,7 +77,7 @@ const DefaultLayout = props => {
                     />
                   ) : null;
                 })}
-                <Redirect from="/" to="/dashboard" />
+                <Redirect from="/" to="/crashes" />
               </Switch>
             </Suspense>
           </Container>


### PR DESCRIPTION
## Associated issues
Closes https://github.com/cityofaustin/atd-data-tech/issues/16124

## Testing
**URL to test:** <!-- VZ URL or Netlify -->
[Netlify](https://deploy-preview-1410--atd-vze-staging.netlify.app/#/crashes)

**Steps to test:**
1. Log out and log back in, you should immediately be taken to the crashes page instead of the Dashboard.

This has the effect of also rerouting you to the crashes page when the path is just '/', is that okay?

---
#### Ship list
- [x] Check migrations for any conflicts with latest migrations in master branch
- [x] Confirm Hasura role permissions for necessary access
- [x] Code reviewed
- [x] Product manager approved