### PR TITLE
[Enhancement] Advanced filter tags shift the UI when the first filter is applied

### DIFF
--- a/atd-vze/src/Components/GridDateRange.js
+++ b/atd-vze/src/Components/GridDateRange.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from "react";
+import { Row } from "reactstrap";
 import { withApollo } from "react-apollo";
 import styled from "styled-components";
 import { format, parseISO } from "date-fns";
@@ -100,7 +101,10 @@ const GridDateRange = ({
   }, [initStartDate, initEndDate]);
 
   return (
-    <>
+    <Row>
+      <h3>
+        <i className="fa fa-calendar ml-3 mr-2"></i>
+      </h3>
       <StyledDatePicker>
         <DatePicker
           selected={startDate}
@@ -126,7 +130,7 @@ const GridDateRange = ({
           strictParsing={true}
         />
       </StyledDatePicker>
-    </>
+    </Row>
   );
 };
 

--- a/atd-vze/src/Components/GridFilters.js
+++ b/atd-vze/src/Components/GridFilters.js
@@ -12,7 +12,7 @@ import { withApollo } from "react-apollo";
 import { AppSwitch } from "@coreui/react";
 
 const GridFilters = ({
-  isCollapsed,
+  isOpen,
   filters,
   filterOptionsState,
   setFilterOptions,
@@ -95,7 +95,7 @@ const GridFilters = ({
 
     return (
       <Col md="6" id={groupName} key={`groupName--${groupName}`}>
-        <Collapse isOpen={isCollapsed}>
+        <Collapse isOpen={isOpen}>
           <div>
             <Card>
               <CardHeader>

--- a/atd-vze/src/Components/GridTable.js
+++ b/atd-vze/src/Components/GridTable.js
@@ -68,7 +68,7 @@ const GridTable = ({
    *      sortColumn {string} - Contains the name of the column being used to sort the data
    *      sortOrder {string} - Contains either 'asc' or 'desc'
    *      searchParameters {object} - Contains the parameters for the text search
-   *      collapseAdvancedFilters {bool} - Contains the filters section status (hidden, display)
+   *      isAdvancedSearchMenuOpen {bool} - Contains the filters section status (hidden, display)
    *      filterOptions {object} - Contains a list of filters and each individual status (enabled, disabled)
    *      dateRangeFilter {object} - Contains the date range (startDate, and endDate)
    */
@@ -84,8 +84,8 @@ const GridTable = ({
   const [searchParameters, setSearchParameters] = useState(
     getSavedState("searchParameters") || {}
   );
-  const [collapseAdvancedFilters, setCollapseAdvancedFilters] = useState(
-    getSavedState("collapseAdvancedFilters") || false
+  const [isAdvancedSearchMenuOpen, setIsAdvancedSearchMenuOpen] = useState(
+    getSavedState("isAdvancedSearchMenuOpen") || false
   );
   const [filterOptions, setFilterOptions] = useState(
     getSavedState("filterOptions") || {}
@@ -103,7 +103,7 @@ const GridTable = ({
       sortColumn,
       sortOrder,
       searchParameters,
-      collapseAdvancedFilters,
+      isAdvancedSearchMenuOpen,
       filterOptions,
       dateRangeFilter,
     };
@@ -162,7 +162,7 @@ const GridTable = ({
    * Shows or hides advanced filters
    */
   const toggleAdvancedFilters = () => {
-    setCollapseAdvancedFilters(!collapseAdvancedFilters);
+    setIsAdvancedSearchMenuOpen(!isAdvancedSearchMenuOpen);
   };
 
   /**
@@ -439,10 +439,9 @@ const GridTable = ({
               <i className="fa fa-car" /> {title}
             </CardHeader>
             <CardBody>
-              {filters && (
+              {filters && !isAdvancedSearchMenuOpen && (
                 <GridTableFilterBadges
                   searchParams={searchParameters}
-                  dateRangeParams={dateRangeFilter}
                   advancedFilterParams={filterOptions}
                   advancedFiltersConfig={filters}
                 />
@@ -493,7 +492,7 @@ const GridTable = ({
                   toggleAdvancedFilters={toggleAdvancedFilters}
                 />
                 <GridFilters
-                  isCollapsed={collapseAdvancedFilters}
+                  isOpen={isAdvancedSearchMenuOpen}
                   filters={filters}
                   filterOptionsState={filterOptions}
                   setFilterOptions={setFilterOptions}

--- a/atd-vze/src/Components/GridTableFilterBadges.js
+++ b/atd-vze/src/Components/GridTableFilterBadges.js
@@ -1,16 +1,13 @@
 import React, { useState, useEffect } from "react";
-import { format, parseISO } from "date-fns";
 
 import { Col, Row, Badge } from "reactstrap";
 
 const GridTableFilterBadges = ({
   searchParams,
-  dateRangeParams,
   advancedFilterParams,
   advancedFiltersConfig,
 }) => {
   const [searchBadgeText, setSearchBadgeText] = useState(null);
-  const [dateRangeBadgeText, setDateRangeBadgeText] = useState(null);
   const [advancedFilterBadgeText, setAdvancedFilterBadgeText] = useState([]);
 
   // Update search badge text
@@ -21,21 +18,6 @@ const GridTableFilterBadges = ({
 
     setSearchBadgeText(searchText);
   }, [searchParams]);
-
-  // Update date range badge text
-  useEffect(() => {
-    const startDateRangeText = format(
-      parseISO(dateRangeParams.startDate),
-      "MM/dd/yyyy"
-    );
-    const endDateRangeText = format(
-      parseISO(dateRangeParams.endDate),
-      "MM/dd/yyyy"
-    );
-    const formattedDateRangeText = `${startDateRangeText} to ${endDateRangeText}`;
-
-    setDateRangeBadgeText(formattedDateRangeText);
-  }, [dateRangeParams]);
 
   // Update advanced filter badges text
   useEffect(() => {
@@ -73,18 +55,6 @@ const GridTableFilterBadges = ({
     <>
       <Row className="mb-2">
         <Col>
-          <h4>
-            <i className="fa fa-calendar mr-2"></i>
-            {dateRangeBadgeText && (
-              <Badge className="mr-1" color="primary">
-                {dateRangeBadgeText}
-              </Badge>
-            )}
-          </h4>
-        </Col>
-      </Row>
-      <Row className="mb-2">
-        <Col>
           {hasFiltersApplied && (
             <h5>
               <i className="fa fa-lg fa-filter mr-2"></i>
@@ -95,7 +65,7 @@ const GridTableFilterBadges = ({
               )}
               {advancedFilterBadgeText &&
                 advancedFilterBadgeText.map(filter => (
-                  <Badge className="mr-1" color="primary">
+                  <Badge key={filter} className="mr-1" color="primary">
                     {filter}
                   </Badge>
                 ))}


### PR DESCRIPTION
## Associated issues
Closes https://github.com/cityofaustin/atd-data-tech/issues/15453

## Testing
**URL to test:** <!-- VZ URL or Netlify -->

**Steps to test:**
1. Go to the crashes page. Open the advanced filters menu, toggle some things. You shouldn't see the filter badges pop up yet.
2. Now close the advanced filters menu, and the filter badges should now show up as indication to the user that they have filters applied.
3. Open up advanced search again, filter badges gone. Close, filter badges appear! [Snip snap snip snap!!](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExdGk0Zmg3Zml1bzk2ZWppYzB4eXl0bDFyYWh1bmYwaDc4OGpibGJmbiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/BmKLItgwfoHbcvVf8n/giphy.gif)

---
#### Ship list
- [ ] Check migrations for any conflicts with latest migrations in master branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved