### PR TITLE
Thread cr3 downloader & clean-up `stdout` with a verbose flag

### DIFF
--- a/atd-etl/cr3_download/Dockerfile
+++ b/atd-etl/cr3_download/Dockerfile
@@ -10,4 +10,4 @@ COPY . /app
 
 RUN cd /app && pip install -r requirements.txt
 
-CMD python /app/cr3_download.py
+CMD -t 5

--- a/atd-etl/cr3_download/Dockerfile
+++ b/atd-etl/cr3_download/Dockerfile
@@ -10,4 +10,3 @@ COPY . /app
 
 RUN cd /app && pip install -r requirements.txt
 
-CMD -t 5

--- a/atd-etl/cr3_download/cr3_download.py
+++ b/atd-etl/cr3_download/cr3_download.py
@@ -154,14 +154,6 @@ with ThreadPoolExecutor(max_workers=max_workers) as executor:
     for future in futures:
         future.result()
 
-
-# for crash_record in crashes_list_without_skips:
-#     process_crash_cr3(
-#         crash_record,
-#         CRIS_BROWSER_COOKIES,
-#         skipped_uploads_and_updates,
-#     )
-
 print("\nProcess done.")
 
 if skipped_uploads_and_updates:

--- a/atd-etl/cr3_download/cr3_download.py
+++ b/atd-etl/cr3_download/cr3_download.py
@@ -11,156 +11,180 @@ any CR3 files associated.
 
 import os
 import time
-import json
+import argparse
 from concurrent.futures import ThreadPoolExecutor
 
-from process.helpers_cr3 import *
-
-from onepasswordconnectsdk.client import Client, new_client
+from process.helpers_cr3 import process_crash_cr3, get_crash_id_list
+from onepasswordconnectsdk.client import new_client
 import onepasswordconnectsdk
 
 
-# Start timer
-start = time.time()
+def load_secrets(one_password_client, vault_id):
+    """Load required secrets from 1Password."""
+    required_secrets = {
+        "HASURA_ENDPOINT": {
+            "opitem": "Vision Zero graphql-engine Endpoints",
+            "opfield": "production.GraphQL Endpoint",
+            "opvault": vault_id,
+        },
+        "HASURA_ADMIN_KEY": {
+            "opitem": "Vision Zero graphql-engine Endpoints",
+            "opfield": "production.Admin Key",
+            "opvault": vault_id,
+        },
+        "AWS_ACCESS_KEY_ID": {
+            "opitem": "CR3 Download IAM Access Key and Secret",
+            "opfield": "production.accessKeyId",
+            "opvault": vault_id,
+        },
+        "AWS_SECRET_ACCESS_KEY": {
+            "opitem": "CR3 Download IAM Access Key and Secret",
+            "opfield": "production.accessSecret",
+            "opvault": vault_id,
+        },
+        "AWS_DEFAULT_REGION": {
+            "opitem": "CR3 Download IAM Access Key and Secret",
+            "opfield": "production.awsDefaultRegion",
+            "opvault": vault_id,
+        },
+        "ATD_CRIS_CR3_URL": {
+            "opitem": "Vision Zero CRIS CR3 Download",
+            "opfield": "production.ATD_CRIS_CR3_URL",
+            "opvault": vault_id,
+        },
+        "AWS_CRIS_CR3_BUCKET_NAME": {
+            "opitem": "Vision Zero CRIS CR3 Download",
+            "opfield": "production.AWS_CRIS_CR3_BUCKET_NAME",
+            "opvault": vault_id,
+        },
+        "AWS_CRIS_CR3_BUCKET_PATH": {
+            "opitem": "Vision Zero CRIS CR3 Download",
+            "opfield": "production.AWS_CRIS_CR3_BUCKET_PATH",
+            "opvault": vault_id,
+        },
+    }
+
+    return onepasswordconnectsdk.load_dict(one_password_client, required_secrets)
 
 
-# Get 1Password secrets from environment
-ONEPASSWORD_CONNECT_HOST = os.getenv("OP_CONNECT")
-ONEPASSWORD_CONNECT_TOKEN = os.getenv("OP_API_TOKEN")
-VAULT_ID = os.getenv("OP_VAULT_ID")
-
-# Setup 1Password server connection
-one_password_client = new_client(ONEPASSWORD_CONNECT_HOST, ONEPASSWORD_CONNECT_TOKEN)
-
-# Get secrets from 1Password
-REQUIRED_SECRETS = {
-    "HASURA_ENDPOINT": {
-        "opitem": "Vision Zero graphql-engine Endpoints",
-        "opfield": "production.GraphQL Endpoint",
-        "opvault": VAULT_ID,
-    },
-    "HASURA_ADMIN_KEY": {
-        "opitem": "Vision Zero graphql-engine Endpoints",
-        "opfield": "production.Admin Key",
-        "opvault": VAULT_ID,
-    },
-    "AWS_ACCESS_KEY_ID": {
-        "opitem": "CR3 Download IAM Access Key and Secret",
-        "opfield": "production.accessKeyId",
-        "opvault": VAULT_ID,
-    },
-    "AWS_SECRET_ACCESS_KEY": {
-        "opitem": "CR3 Download IAM Access Key and Secret",
-        "opfield": "production.accessSecret",
-        "opvault": VAULT_ID,
-    },
-    "AWS_DEFAULT_REGION": {
-        "opitem": "CR3 Download IAM Access Key and Secret",
-        "opfield": "production.awsDefaultRegion",
-        "opvault": VAULT_ID,
-    },
-    "ATD_CRIS_CR3_URL": {
-        "opitem": "Vision Zero CRIS CR3 Download",
-        "opfield": "production.ATD_CRIS_CR3_URL",
-        "opvault": VAULT_ID,
-    },
-    "AWS_CRIS_CR3_BUCKET_NAME": {
-        "opitem": "Vision Zero CRIS CR3 Download",
-        "opfield": "production.AWS_CRIS_CR3_BUCKET_NAME",
-        "opvault": VAULT_ID,
-    },
-    "AWS_CRIS_CR3_BUCKET_PATH": {
-        "opitem": "Vision Zero CRIS CR3 Download",
-        "opfield": "production.AWS_CRIS_CR3_BUCKET_PATH",
-        "opvault": VAULT_ID,
-    },
-}
-
-env_vars = onepasswordconnectsdk.load_dict(one_password_client, REQUIRED_SECRETS)
-
-# Set secrets from 1Password in environment
-for key, value in env_vars.items():
-    os.environ[key] = value
-
-#
-# We now need to request a list of N number of records
-# that do not have a CR3. For each record we must download
-# the CR3 pdf, upload to S3
-#
-
-# # ask user for a set of valid cookies for requests to the CRIS website
-CRIS_BROWSER_COOKIES = input(
-    "Please login to CRIS and extract the contents of the Cookie: header and please paste it here:"
-)
-
-print("Preparing download loop.")
-
-print("Gathering list of crashes.")
-# Track crash IDs that we don't successfully retrieve a pdf file for
-skipped_uploads_and_updates = []
-
-# Some crash IDs were manually added at the request of the VZ team so
-# CR3s for these crash IDs are not available in the CRIS database.
-# We can skip requesting them.
-# See https://github.com/cityofaustin/atd-data-tech/issues/9786
-known_skips = [180290542, 144720068]
-
-crashes_list_without_skips = []
-
-try:
-    print("Hasura endpoint: '%s' " % os.getenv("HASURA_ENDPOINT"))
-
-    response = get_crash_id_list()
-    # print("\nResponse from Hasura: %s" % json.dumps(response))
-
-    crashes_list = response["data"]["atd_txdot_crashes"]
-
-    crashes_list_without_skips = [
-        x for x in crashes_list if x["crash_id"] not in known_skips
-    ]
-
-
-except Exception as e:
-    crashes_list_without_skips = []
-    print("Error, could not run CR3 processing: " + str(e))
-
-
-print(f"Length of queue: {len(crashes_list_without_skips)}")
-
-print("\nStarting CR3 downloads:")
-
-
-def process_crash_cr3_threaded(crash_record):
+def process_crash_cr3_threaded(
+    crash_record, cris_browser_cookies, skipped_uploads_and_updates, verbose
+):
+    """Process a crash record in a separate thread."""
     try:
         process_crash_cr3(
-            crash_record,
-            CRIS_BROWSER_COOKIES,
-            skipped_uploads_and_updates,
+            crash_record, cris_browser_cookies, skipped_uploads_and_updates, verbose
         )
-        print(f"Processed crash ID: {crash_record['crash_id']}")
+        if verbose:
+            print(f"Processed crash ID: {crash_record['crash_id']}")
     except Exception as e:
         print(f"Error processing crash ID {crash_record['crash_id']}: {str(e)}")
         skipped_uploads_and_updates.append(str(crash_record["crash_id"]))
 
 
-max_workers = 4  # Specify the number of concurrent downloaders
+def main():
+    # Parse command-line arguments
+    parser = argparse.ArgumentParser(description="CRIS - CR3 Downloader")
+    parser.add_argument(
+        "-t",
+        "--threads",
+        type=int,
+        default=1,
+        help="Number of concurrent downloaders (default: 1)",
+    )
+    parser.add_argument(
+        "-v", "--verbose", action="store_true", help="Enable verbose logging"
+    )
+    args = parser.parse_args()
 
-with ThreadPoolExecutor(max_workers=max_workers) as executor:
-    futures = []
-    for crash_record in crashes_list_without_skips:
-        future = executor.submit(process_crash_cr3_threaded, crash_record)
-        futures.append(future)
+    # Start timer
+    start = time.time()
 
-    for future in futures:
-        future.result()
+    # Get 1Password secrets from environment
+    ONEPASSWORD_CONNECT_HOST = os.getenv("OP_CONNECT")
+    ONEPASSWORD_CONNECT_TOKEN = os.getenv("OP_API_TOKEN")
+    VAULT_ID = os.getenv("OP_VAULT_ID")
 
-print("\nProcess done.")
+    # Setup 1Password server connection
+    one_password_client = new_client(
+        ONEPASSWORD_CONNECT_HOST, ONEPASSWORD_CONNECT_TOKEN
+    )
 
-if skipped_uploads_and_updates:
-    skipped_downloads = ", ".join(skipped_uploads_and_updates)
-    print(f"\nUnable to download pdfs for crash IDs: {skipped_downloads}")
+    # Load secrets from 1Password and set them in the environment
+    env_vars = load_secrets(one_password_client, VAULT_ID)
+    for key, value in env_vars.items():
+        os.environ[key] = value
 
-end = time.time()
-hours, rem = divmod(end - start, 3600)
-minutes, seconds = divmod(rem, 60)
-print("\nFinished in: {:0>2}:{:0>2}:{:05.2f}".format(int(hours), int(minutes), seconds))
+    # Ask user for a set of valid cookies for requests to the CRIS website
+    CRIS_BROWSER_COOKIES = input(
+        "Please login to CRIS and extract the contents of the Cookie: header and please paste it here: "
+    )
+
+    if args.verbose:
+        print("Preparing download loop.")
+        print("Gathering list of crashes.")
+
+    # Track crash IDs that we don't successfully retrieve a pdf file for
+    skipped_uploads_and_updates = []
+
+    # Some crash IDs were manually added at the request of the VZ team so
+    # CR3s for these crash IDs are not available in the CRIS database.
+    # We can skip requesting them.
+    # See https://github.com/cityofaustin/atd-data-tech/issues/9786
+    known_skips = [180290542, 144720068]
+
+    crashes_list_without_skips = []
+
+    try:
+        if args.verbose:
+            print(f"Hasura endpoint: '{os.getenv('HASURA_ENDPOINT')}'")
+
+        response = get_crash_id_list()
+
+        crashes_list = response["data"]["atd_txdot_crashes"]
+        crashes_list_without_skips = [
+            x for x in crashes_list if x["crash_id"] not in known_skips
+        ]
+
+    except Exception as e:
+        crashes_list_without_skips = []
+        print(f"Error, could not run CR3 processing: {str(e)}")
+
+    if args.verbose:
+        print(f"Length of queue: {len(crashes_list_without_skips)}")
+        print("Starting CR3 downloads:")
+
+    max_workers = args.threads
+    with ThreadPoolExecutor(max_workers=max_workers) as executor:
+        futures = []
+        for crash_record in crashes_list_without_skips:
+            future = executor.submit(
+                process_crash_cr3_threaded,
+                crash_record,
+                CRIS_BROWSER_COOKIES,
+                skipped_uploads_and_updates,
+                args.verbose,
+            )
+            futures.append(future)
+
+        for future in futures:
+            future.result()
+
+    print("Process done.")
+
+    if skipped_uploads_and_updates:
+        skipped_downloads = ", ".join(skipped_uploads_and_updates)
+        print(f"\nUnable to download PDFs for crash IDs: {skipped_downloads}")
+
+    end = time.time()
+    hours, rem = divmod(end - start, 3600)
+    minutes, seconds = divmod(rem, 60)
+    print(
+        "\nFinished in: {:0>2}:{:0>2}:{:05.2f}".format(
+            int(hours), int(minutes), seconds
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/atd-etl/cr3_download/cr3_download.py
+++ b/atd-etl/cr3_download/cr3_download.py
@@ -5,18 +5,20 @@ Author: Austin Transportation Department, Data and Technology Services
 
 Description: This script allows the user to log in to the CRIS website
 and download CR3 pdf files as needed. The list of CR3 files to be downloaded
-is obtained from Hasura, and it is contingent to records that do not have
+is obtained from Hasura, and it is made up of the records that do not have
 any CR3 files associated.
 """
 
 import os
 import time
 import json
+from concurrent.futures import ThreadPoolExecutor
 
 from process.helpers_cr3 import *
 
 from onepasswordconnectsdk.client import Client, new_client
 import onepasswordconnectsdk
+
 
 # Start timer
 start = time.time()
@@ -86,7 +88,7 @@ for key, value in env_vars.items():
 # the CR3 pdf, upload to S3
 #
 
-# ask user for a set of valid cookies for requests to the CRIS website
+# # ask user for a set of valid cookies for requests to the CRIS website
 CRIS_BROWSER_COOKIES = input(
     "Please login to CRIS and extract the contents of the Cookie: header and please paste it here:"
 )
@@ -107,35 +109,58 @@ crashes_list_without_skips = []
 
 try:
     print("Hasura endpoint: '%s' " % os.getenv("HASURA_ENDPOINT"))
-    downloads_per_run = os.getenv("ATD_CRIS_CR3_DOWNLOADS_PER_RUN")
-    downloads_per_run = 2000
-    print("Downloads Per This Run: %s" % str(downloads_per_run))
 
-    response = get_crash_id_list(downloads_per_run=downloads_per_run)
-    print("\nResponse from Hasura: %s" % json.dumps(response))
+    response = get_crash_id_list()
+    # print("\nResponse from Hasura: %s" % json.dumps(response))
 
     crashes_list = response["data"]["atd_txdot_crashes"]
 
     crashes_list_without_skips = [
         x for x in crashes_list if x["crash_id"] not in known_skips
     ]
-    print(
-        f"\nList of {len(crashes_list_without_skips)} crashes needing CR3 download: %s"
-        % json.dumps(crashes_list_without_skips)
-    )
 
-    print("\nStarting CR3 downloads:")
+
 except Exception as e:
     crashes_list_without_skips = []
     print("Error, could not run CR3 processing: " + str(e))
 
 
-for crash_record in crashes_list_without_skips:
-    process_crash_cr3(
-        crash_record,
-        CRIS_BROWSER_COOKIES,
-        skipped_uploads_and_updates,
-    )
+print(f"Length of queue: {len(crashes_list_without_skips)}")
+
+print("\nStarting CR3 downloads:")
+
+
+def process_crash_cr3_threaded(crash_record):
+    try:
+        process_crash_cr3(
+            crash_record,
+            CRIS_BROWSER_COOKIES,
+            skipped_uploads_and_updates,
+        )
+        print(f"Processed crash ID: {crash_record['crash_id']}")
+    except Exception as e:
+        print(f"Error processing crash ID {crash_record['crash_id']}: {str(e)}")
+        skipped_uploads_and_updates.append(str(crash_record["crash_id"]))
+
+
+max_workers = 4  # Specify the number of concurrent downloaders
+
+with ThreadPoolExecutor(max_workers=max_workers) as executor:
+    futures = []
+    for crash_record in crashes_list_without_skips:
+        future = executor.submit(process_crash_cr3_threaded, crash_record)
+        futures.append(future)
+
+    for future in futures:
+        future.result()
+
+
+# for crash_record in crashes_list_without_skips:
+#     process_crash_cr3(
+#         crash_record,
+#         CRIS_BROWSER_COOKIES,
+#         skipped_uploads_and_updates,
+#     )
 
 print("\nProcess done.")
 

--- a/atd-etl/cr3_download/cr3_download.py
+++ b/atd-etl/cr3_download/cr3_download.py
@@ -150,8 +150,8 @@ def main():
         crashes_list_without_skips = []
         print(f"Error, could not run CR3 processing: {str(e)}")
 
+    print(f"Length of queue: {len(crashes_list_without_skips)}")
     if args.verbose:
-        print(f"Length of queue: {len(crashes_list_without_skips)}")
         print("Starting CR3 downloads:")
 
     max_workers = args.threads

--- a/atd-etl/cr3_download/docker-compose.yml
+++ b/atd-etl/cr3_download/docker-compose.yml
@@ -5,5 +5,14 @@ services:
       - .:/app
     env_file:
       - ./.env
-    # entrypoint: /bin/bash #enables a shell
+
+    # For normal operation, the entry point is defined to simply run the script
+    # and then exit.
     entrypoint: /app/cr3_download.py -t 5
+
+    # During development or during CRIS reprocessing, it can be helpful to run
+    # the container interactively, so the the following entrypoint can be used
+    # to drop the user into a shell where they can run the script manually.
+    # This can also be done via the --entrypoint=/bin/bash flag when running.
+
+    # entrypoint: /bin/bash

--- a/atd-etl/cr3_download/docker-compose.yml
+++ b/atd-etl/cr3_download/docker-compose.yml
@@ -6,4 +6,4 @@ services:
     env_file:
       - ./.env
     # entrypoint: /bin/bash
-    entrypoint: /app/cr3_download.py
+    entrypoint: /app/cr3_download.py -t 5

--- a/atd-etl/cr3_download/docker-compose.yml
+++ b/atd-etl/cr3_download/docker-compose.yml
@@ -5,4 +5,5 @@ services:
       - .:/app
     env_file:
       - ./.env
-    #entrypoint: /bin/bash
+    # entrypoint: /bin/bash
+    entrypoint: /app/cr3_download.py

--- a/atd-etl/cr3_download/docker-compose.yml
+++ b/atd-etl/cr3_download/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   cr3_download:
     build: .
@@ -7,3 +5,4 @@ services:
       - .:/app
     env_file:
       - ./.env
+    #entrypoint: /bin/bash

--- a/atd-etl/cr3_download/process/helpers_cr3.py
+++ b/atd-etl/cr3_download/process/helpers_cr3.py
@@ -28,6 +28,7 @@ def run_command(command, verbose, log):
     Runs a command
     :param command: array of strings containing the command and flags
     :param verbose: boolean, handles level of logging
+    :param log: logger - The logger object
     """
     if verbose:
         log.info(command)
@@ -42,6 +43,7 @@ def download_cr3(crash_id, cookies, verbose, log):
     :param crash_id: string - The crash id
     :param cookies: dict - A dictionary containing key=value pairs with cookie name and values.
     :param verbose: boolean, handles level of logging
+    :param log: logger - The logger object
     """
 
     cookie = SimpleCookie()
@@ -125,7 +127,7 @@ def update_crash_id(crash_id, log):
     """
     Updates the status of a crash to having an available CR3 pdf in the S3 bucket.
     :param crash_id: string - The Crash ID that needs to be updated
-    :param verbose: boolean, handles level of logging
+    :param log: logger - The logger object
     :return: dict - Response from request.post
     """
 
@@ -161,6 +163,7 @@ def process_crash_cr3(crash_record, cookies, skipped_uploads_and_updates, verbos
     :param cookies: dict - The cookies taken from the browser object
     :param skipped_uploads_and_updates: list - Crash IDs of unsuccessful pdf downloads
     :param verbose: boolean, handles level of logging
+    :param log: logger - The logger object
     """
     try:
         crash_id = str(crash_record["crash_id"])

--- a/atd-etl/cr3_download/process/helpers_cr3.py
+++ b/atd-etl/cr3_download/process/helpers_cr3.py
@@ -31,6 +31,8 @@ def run_command(command, verbose):
     if verbose:
         print(command)
         print(subprocess.check_output(command, shell=True).decode("utf-8"))
+    else:
+        subprocess.check_output(command, shell=True).decode("utf-8")
 
 
 # Now we need to implement our methods.

--- a/atd-etl/cr3_download/process/helpers_cr3.py
+++ b/atd-etl/cr3_download/process/helpers_cr3.py
@@ -83,7 +83,7 @@ def delete_cr3s(crash_id):
     run_command("rm %s" % file)
 
 
-def get_crash_id_list(downloads_per_run="25"):
+def get_crash_id_list():
     """
     Downloads a list of crashes that do not have a CR3 associated.
     :return: dict - Response from request.post
@@ -91,7 +91,6 @@ def get_crash_id_list(downloads_per_run="25"):
     query_crashes_cr3 = """
         query CrashesWithoutCR3 {
           atd_txdot_crashes(
-            limit: %s,
             where: {
                 cr3_stored_flag: {_eq: "N"}
                 temp_record: {_eq: false}
@@ -101,9 +100,7 @@ def get_crash_id_list(downloads_per_run="25"):
             crash_id
           }
         }
-    """ % (
-        str(downloads_per_run)
-    )
+    """
 
     return run_query(query_crashes_cr3)
 
@@ -157,6 +154,9 @@ def process_crash_cr3(crash_record, cookies, skipped_uploads_and_updates):
 
         if not is_file_pdf:
             print(f"\nFile {download_path} is not a pdf - skipping upload and update")
+            with open(download_path, "r") as file:
+                print(file.read())
+            time.sleep(10)
             skipped_uploads_and_updates.append(crash_id)
         else:
             upload_cr3(crash_id)


### PR DESCRIPTION
## Associated issues

This PR intends to close: https://github.com/cityofaustin/atd-data-tech/issues/16556

## Testing 🤔 

🎗️ First, please rebuild with `docker compose build`, both when you start to test and when you switch back to `master`.

I guess, maybe we should just test it for a few weeks while we download CR3s? 
Maybe trade days? 

We can decide on this in a dev sync. I'm not positive what is best and easiest. 

---
#### Ship list
- [x] Check migrations for any conflicts with latest migrations in master branch
- [x] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved