### PR TITLE
[Enhancement] Persist sidebar visibility between sessions

### DIFF
--- a/atd-vze/public/index.html
+++ b/atd-vze/public/index.html
@@ -64,7 +64,7 @@
 
   -->
 
-  <body>
+  <body id="body-outside-app">
     <noscript>
       You need to enable JavaScript to run this app.
     </noscript>

--- a/atd-vze/src/containers/DefaultLayout/DefaultLayout.js
+++ b/atd-vze/src/containers/DefaultLayout/DefaultLayout.js
@@ -25,29 +25,38 @@ const DefaultAside = React.lazy(() => import("./DefaultAside"));
 const DefaultFooter = React.lazy(() => import("./DefaultFooter"));
 const DefaultHeader = React.lazy(() => import("./DefaultHeader"));
 
+/**
+ * Custom hook to observe the body element for changes in the class attribute and update the state.
+ * See /public/index.html for the ID added to the body element that is used in this hook.
+ * See https://github.com/coreui/coreui-react/blob/2dc4521d7e43dd5cc48d0ed184dfb03ca765207a/src/SidebarToggler.js#L34-L41
+ */
 const useIsAppSideBarOpen = () => {
-  const localStorageIsAppSideBarOpen = localStorage.getItem("isAppSideBarOpen");
-  const doesLocalStorageExist = localStorageIsAppSideBarOpen !== null;
+  const openSideBarClassName = "sidebar-lg-show";
+  const sideBarLocalStorageKey = "isAppSideBarOpen";
+  const appBodyId = "body-outside-app";
+
+  const initialIsAppSideBarOpen = localStorage.getItem(sideBarLocalStorageKey);
+  const doesLocalStorageExist = initialIsAppSideBarOpen !== null;
 
   const [isAppSideBarOpen, setIsAppSideBarOpen] = React.useState(
-    doesLocalStorageExist ? JSON.parse(localStorageIsAppSideBarOpen) : true
+    doesLocalStorageExist ? JSON.parse(initialIsAppSideBarOpen) : true
   );
 
-  // On mount, observe the body element for changes in the class attribute and update the state
-  // and local storage when CoreUI toggles the sidebar
+  // On mount, set an observer that watches the body element for changes in the class attribute
+  // and updates the state and local storage to match the classes used by CoreUI to show/hide the sidebar
   React.useEffect(() => {
-    const elemToObserve = document.getElementById("body-outside-app");
+    const elemToObserve = document.getElementById(appBodyId);
 
     const observer = new MutationObserver(function(mutations) {
       mutations.forEach(function(mutation) {
         if (mutation.attributeName === "class") {
           const isAppSideBarOpenClassPresent = mutation.target.classList.contains(
-            "sidebar-lg-show"
+            openSideBarClassName
           );
 
           setIsAppSideBarOpen(isAppSideBarOpenClassPresent);
           localStorage.setItem(
-            "isAppSideBarOpen",
+            sideBarLocalStorageKey,
             isAppSideBarOpenClassPresent
           );
         }
@@ -60,16 +69,15 @@ const useIsAppSideBarOpen = () => {
 
   // Sync the body class with the state of the sidebar
   React.useEffect(() => {
-    const elemToUpdate = document.getElementById("body-outside-app");
-
+    const elemToUpdate = document.getElementById(appBodyId);
     const isOpenClassPresent = elemToUpdate.classList.contains(
-      "sidebar-lg-show"
+      openSideBarClassName
     );
 
     if (isAppSideBarOpen && !isOpenClassPresent) {
-      elemToUpdate.classList.add("sidebar-lg-show");
+      elemToUpdate.classList.add(openSideBarClassName);
     } else if (!isAppSideBarOpen && isOpenClassPresent) {
-      elemToUpdate.classList.remove("sidebar-lg-show");
+      elemToUpdate.classList.remove(openSideBarClassName);
     }
   }, [isAppSideBarOpen]);
 };

--- a/atd-vze/src/containers/DefaultLayout/DefaultLayout.js
+++ b/atd-vze/src/containers/DefaultLayout/DefaultLayout.js
@@ -29,6 +29,10 @@ const DefaultLayout = props => {
   const { getRoles } = useAuth0();
   const roles = getRoles();
 
+  // get initial state from local storage
+  const [isAppSideBarOpen, setIsAppSideBarOpen] = React.useState(true);
+  console.log("isAppSideBarOpen", isAppSideBarOpen);
+
   const loading = () => (
     <div className="animated fadeIn pt-1 text-center">Loading...</div>
   );
@@ -37,6 +41,34 @@ const DefaultLayout = props => {
     e.preventDefault();
     props.history.push("/login");
   };
+
+  React.useEffect(() => {
+    const elemToObserve = document.getElementById("body-outside-app");
+
+    let prevClassState = elemToObserve.classList.contains("sidebar-lg-show");
+
+    const observer = new MutationObserver(function(mutations) {
+      mutations.forEach(function(mutation) {
+        if (mutation.attributeName == "class") {
+          const currentClassState = mutation.target.classList.contains(
+            "sidebar-lg-show"
+          );
+          if (prevClassState !== currentClassState) {
+            prevClassState = currentClassState;
+
+            if (currentClassState) {
+              setIsAppSideBarOpen(true);
+            } else {
+              setIsAppSideBarOpen(false);
+            }
+          }
+        }
+      });
+    });
+    observer.observe(elemToObserve, { attributes: true });
+
+    return () => observer.disconnect();
+  }, []);
 
   return (
     <div className="app">

--- a/atd-vze/src/containers/DefaultLayout/DefaultLayout.js
+++ b/atd-vze/src/containers/DefaultLayout/DefaultLayout.js
@@ -26,33 +26,17 @@ const DefaultFooter = React.lazy(() => import("./DefaultFooter"));
 const DefaultHeader = React.lazy(() => import("./DefaultHeader"));
 
 const useIsAppSideBarOpen = () => {
-  // TODO: Load isAppSideBarOpen from local storage
+  const [isAppSideBarOpen, setIsAppSideBarOpen] = React.useState(null);
 
-  const elemToObserve = document.getElementById("body-outside-app");
-  const isAppSideBarOpenSetting = localStorage.getItem("isAppSideBarOpen");
+  console.log(isAppSideBarOpen);
 
-  const [isAppSideBarOpen, setIsAppSideBarOpen] = React.useState(
-    isAppSideBarOpenSetting || true
-  );
-
-  console.log(isAppSideBarOpenSetting);
-  // sync state with local storage
+  // Sync state with classes on body-outside-app
   React.useEffect(() => {
-    console.log("this ran", isAppSideBarOpen);
-    if (isAppSideBarOpen === null || isAppSideBarOpen === true) {
-      localStorage.setItem("isAppSideBarOpen", true);
-    } else {
-      localStorage.setItem("isAppSideBarOpen", false);
-    }
-  }, [isAppSideBarOpen]);
-
-  // sync state with classes on body-outside-app
-  React.useEffect(() => {
-    let prevClassState = elemToObserve.classList.contains("sidebar-lg-show");
+    const elemToObserve = document.getElementById("body-outside-app");
 
     const observer = new MutationObserver(function(mutations) {
       mutations.forEach(function(mutation) {
-        if (mutation.attributeName == "class") {
+        if (mutation.attributeName === "class") {
           const currentClassState = mutation.target.classList.contains(
             "sidebar-lg-show"
           );
@@ -66,17 +50,30 @@ const useIsAppSideBarOpen = () => {
     return () => observer.disconnect();
   }, []);
 
-  // sync classes with state
+  // Sync local storage with state
   React.useEffect(() => {
-    if (isAppSideBarOpen) {
-      const isClassAlreadyAdded = elemToObserve.classList.contains(
-        "sidebar-lg-show"
-      );
-      !isClassAlreadyAdded && elemToObserve.classList.add("sidebar-lg-show");
+    const isAppSideBarOpenSetting = localStorage.getItem("isAppSideBarOpen");
+
+    if (isAppSideBarOpenSetting === isAppSideBarOpen) {
+      return;
     } else {
-      elemToObserve.classList.remove("sidebar-lg-show");
+      localStorage.setItem("isAppSideBarOpen", isAppSideBarOpen);
     }
   }, [isAppSideBarOpen]);
+
+  // TODO: Consume isAppSideBarOpen from local storage and add/remove class from body-outside-app
+  // React.useEffect(() => {
+  //   const elemToObserve = document.getElementById("body-outside-app");
+
+  //   if (isAppSideBarOpen) {
+  //     const isClassAlreadyAdded = elemToObserve.classList.contains(
+  //       "sidebar-lg-show"
+  //     );
+  //     !isClassAlreadyAdded && elemToObserve.classList.add("sidebar-lg-show");
+  //   } else {
+  //     elemToObserve.classList.remove("sidebar-lg-show");
+  //   }
+  // }, [isAppSideBarOpen]);
 };
 
 const DefaultLayout = props => {


### PR DESCRIPTION
## Associated issues
https://github.com/cityofaustin/atd-data-tech/issues/16006

This PR adds a local storage a setting for whether the app side bar is open or closed and uses it to update the app to reflect that value. CoreUI controls the side bar with a class added to or removed from the `body` tag of `index.html`. This falls outside of the DOM node that the React app is appended to so we can't use [React refs](https://react.dev/reference/react/useRef#manipulating-the-dom-with-a-ref) here. But, we can use the [MutationObserver API](https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver) and query selectors to reach outside the app and watch the class changes.

## Testing
**URL to test:** <!-- VZ URL or Netlify -->
https://deploy-preview-1424--atd-vze-staging.netlify.app/

**Steps to test:**
1. Go to any view of the app
2. Check your local storage for a key called `isAppSideBarOpen`. On the first time this key is initialized, it should have a value of `true` and the sidebar should be open.
3. Refresh the page, the local storage value should remain `true`.
4. Now click on the hamburger icon on the side bar header to close the side bar. The local storage value should now be `false`.
5. Refresh the page or close the app and come back. When the app loads, it should load with the side bar closed.
6. Try updating the value of `isAppSideBarOpen` in your browser settings manually to either `true` or `false` and refresh. The app will use this value to either hide or show the side bar on load.
7. Try out different combinations, and your local storage value should always match the status of the side bar.

---
#### Ship list
- [x] Check migrations for any conflicts with latest migrations in master branch
- [x] Confirm Hasura role permissions for necessary access
- [x] Code reviewed
- [x] Product manager approved