### PR TITLE
Make the VZV metric cards be the same height

### DIFF
--- a/atd-vzv/package-lock.json
+++ b/atd-vzv/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "atd-vzv",
-  "version": "1.40.0",
+  "version": "1.44.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "atd-vzv",
-      "version": "1.40.0",
+      "version": "1.44.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/atd-vzv/src/views/summary/SummaryCard.js
+++ b/atd-vzv/src/views/summary/SummaryCard.js
@@ -13,8 +13,8 @@ const SummaryCard = ({ child }) => {
   return (
     <Col className="summary-child" xl="6" md="12">
       {/* Set height to fill parent column */}
-      <Card>
-        <CardBody className="h-100 py-0">
+      <Card className="h-100">
+        <CardBody className="py-0">
           <StyledCardTitle>{child.title}</StyledCardTitle>
           {child.component}
         </CardBody>


### PR DESCRIPTION
## Associated issues
Closes https://github.com/cityofaustin/atd-data-tech/issues/15888

## Testing
**URL to test:** <!-- VZ URL or Netlify -->

**Steps to test:**
1. See that the metrics cards in the VZV are all the same height!


---
#### Ship list
- [ ] Check migrations for any conflicts with latest migrations in master branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved