### PR TITLE
Preserve old CR3 metadata when CRIS updates a crash

### DIFF
--- a/atd-etl/cris_import/lib/sql.py
+++ b/atd-etl/cris_import/lib/sql.py
@@ -25,7 +25,7 @@ def get_pgfutter_path():
 
 def invalidate_cr3(pg, crash_id):
     invalidate_cr3_sql = f"""UPDATE public.atd_txdot_crashes 
-    SET cr3_stored_flag = 'N', cr3_file_metadata = null, cr3_ocr_extraction_date = null
+    SET cr3_stored_flag = 'N'
     WHERE crash_id = {crash_id}"""
     cursor = pg.cursor(cursor_factory=psycopg2.extras.RealDictCursor)
     cursor.execute(invalidate_cr3_sql)


### PR DESCRIPTION
## Associated issues
- https://github.com/cityofaustin/atd-data-tech/issues/16684

## Testing

I'm not sure what the best way is to test the CRIS import ETL. Looking for guidance here :) 

---
#### Ship list
- [ ] Check migrations for any conflicts with latest migrations in master branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved