### PR TITLE
Add loading spinners to cards

### DIFF
--- a/atd-vzv/src/views/summary/CrashesByMode.js
+++ b/atd-vzv/src/views/summary/CrashesByMode.js
@@ -1,7 +1,7 @@
 import React, { useEffect, useState, useRef, useMemo } from "react";
 import axios from "axios";
 import { Bar } from "react-chartjs-2";
-import { Container, Row, Col } from "reactstrap";
+import { Container, Row, Col, Spinner } from "reactstrap";
 import styled from "styled-components";
 import { format } from "date-fns";
 
@@ -224,8 +224,8 @@ const CrashesByMode = () => {
     <Container className="m-0 p-0">
       <Row>
         <Col>
-          <h2 className="text-left font-weight-bold">By Travel Mode{" "}
-            <InfoPopover config={popoverConfig.summary.byMode} />
+          <h2 className="text-left font-weight-bold">
+            By Travel Mode <InfoPopover config={popoverConfig.summary.byMode} />
           </h2>
         </Col>
       </Row>
@@ -242,157 +242,165 @@ const CrashesByMode = () => {
           <hr className="mb-2" />
         </Col>
       </Row>
-      <Row className="mt-1">
-        <Col>
-          {chartLegend}
-          {
-            <Container>
-              <Bar
-                ref={(ref) => (chartRef.current = ref)}
-                data={data}
-                height={null}
-                width={null}
-                options={{
-                  responsive: true,
-                  aspectRatio: 1.37,
-                  maintainAspectRatio: false,
-                  scales: {
-                    xAxes: [
-                      {
-                        stacked: true,
-                      },
-                    ],
-                    yAxes: [
-                      {
-                        stacked: true,
-                      },
-                    ],
-                  },
-                  legend: {
-                    display: false,
-                  },
-                  legendCallback: function (chart) {
-                    return (
-                      <Row className="pb-2">
-                        <Col className="pr-1 col-sm-4">
-                          <StyledDiv>
-                            <div>
-                              <p
-                                className="h6 text-center my-1 pt-2"
-                                style={{ height: "27px" }}
-                              ></p>
-                            </div>
-                            {chart.data.datasets.map((dataset, i) => {
-                              const updateLegendColors = () => {
-                                const legendColorsClone = [...legendColors];
-                                legendColors[i] !== "dimgray"
-                                  ? legendColorsClone.splice(i, 1, "dimgray")
-                                  : legendColorsClone.splice(
-                                      i,
-                                      1,
-                                      chartColors[i]
-                                    );
-                                setLegendColors(legendColorsClone);
-                              };
+      {!!data.datasets ? (
+        <Row className="mt-1">
+          <Col>
+            {chartLegend}
+            {
+              <Container>
+                <Bar
+                  ref={(ref) => (chartRef.current = ref)}
+                  data={data}
+                  height={null}
+                  width={null}
+                  options={{
+                    responsive: true,
+                    aspectRatio: 1.37,
+                    maintainAspectRatio: false,
+                    scales: {
+                      xAxes: [
+                        {
+                          stacked: true,
+                        },
+                      ],
+                      yAxes: [
+                        {
+                          stacked: true,
+                        },
+                      ],
+                    },
+                    legend: {
+                      display: false,
+                    },
+                    legendCallback: function (chart) {
+                      return (
+                        <Row className="pb-2">
+                          <Col className="pr-1 col-sm-4">
+                            <StyledDiv>
+                              <div>
+                                <p
+                                  className="h6 text-center my-1 pt-2"
+                                  style={{ height: "27px" }}
+                                ></p>
+                              </div>
+                              {chart.data.datasets.map((dataset, i) => {
+                                const updateLegendColors = () => {
+                                  const legendColorsClone = [...legendColors];
+                                  legendColors[i] !== "dimgray"
+                                    ? legendColorsClone.splice(i, 1, "dimgray")
+                                    : legendColorsClone.splice(
+                                        i,
+                                        1,
+                                        chartColors[i]
+                                      );
+                                  setLegendColors(legendColorsClone);
+                                };
 
-                              const customLegendClickHandler = () => {
-                                const legendItem = chart.legend.legendItems[i];
-                                const index = legendItem.datasetIndex;
-                                const ci = chartRef.current.chartInstance.chart;
-                                const meta = ci.getDatasetMeta(index);
+                                const customLegendClickHandler = () => {
+                                  const legendItem =
+                                    chart.legend.legendItems[i];
+                                  const index = legendItem.datasetIndex;
+                                  const ci =
+                                    chartRef.current.chartInstance.chart;
+                                  const meta = ci.getDatasetMeta(index);
 
-                                // See controller.isDatasetVisible comment
-                                meta.hidden =
-                                  meta.hidden === null
-                                    ? !ci.data.datasets[index].hidden
-                                    : null;
+                                  // See controller.isDatasetVisible comment
+                                  meta.hidden =
+                                    meta.hidden === null
+                                      ? !ci.data.datasets[index].hidden
+                                      : null;
 
-                                // We hid a dataset ... rerender the chart,
-                                // then update the legend colors
-                                updateLegendColors(ci.update());
-                              };
+                                  // We hid a dataset ... rerender the chart,
+                                  // then update the legend colors
+                                  updateLegendColors(ci.update());
+                                };
 
-                              return (
-                                <div
-                                  key={i}
-                                  className="mode-label-div"
-                                  title={dataset.label}
-                                  onClick={customLegendClickHandler}
-                                >
-                                  <hr className="my-0"></hr>
-                                  <p className="h6 text-center my-0 py-1">
-                                    <FontAwesomeIcon
-                                      aria-hidden="true"
-                                      className="block-icon"
-                                      icon={dataset.icon}
-                                      color={legendColors[i]}
-                                    />
-                                    <span className="sr-only">
-                                      {dataset.label}
-                                    </span>
-                                    <span className="mode-label-text">
-                                      {" "}
-                                      {dataset.label}
-                                    </span>
-                                  </p>
-                                </div>
-                              );
-                            })}
-                            <div>
-                              <hr className="my-0"></hr>
-                              <p className="h6 text-center my-0 py-1">
-                                <span className="sr-only">Total</span>
-                                <span className="mode-label-text">Total</span>
-                              </p>
-                            </div>
-                          </StyledDiv>
-                        </Col>
-                        {chart.data.labels.map((year, yearIterator) => {
-                          let paddingRight =
-                            yearIterator === 4 ? "null" : "pr-1";
-                          return (
-                            <Col
-                              key={yearIterator}
-                              className={`pl-0 ${paddingRight}`}
-                            >
-                              <StyledDiv>
-                                <div className="year-total-div">
-                                  <div>
-                                    <p className="h6 text-center my-1 pt-2">
-                                      <strong>{year}</strong>
+                                return (
+                                  <div
+                                    key={i}
+                                    className="mode-label-div"
+                                    title={dataset.label}
+                                    onClick={customLegendClickHandler}
+                                  >
+                                    <hr className="my-0"></hr>
+                                    <p className="h6 text-center my-0 py-1">
+                                      <FontAwesomeIcon
+                                        aria-hidden="true"
+                                        className="block-icon"
+                                        icon={dataset.icon}
+                                        color={legendColors[i]}
+                                      />
+                                      <span className="sr-only">
+                                        {dataset.label}
+                                      </span>
+                                      <span className="mode-label-text">
+                                        {" "}
+                                        {dataset.label}
+                                      </span>
                                     </p>
                                   </div>
-                                  {chart.data.datasets.map(
-                                    (mode, modeIterator) => {
-                                      return (
-                                        <div key={modeIterator}>
-                                          <hr className="my-0"></hr>
-                                          <p className={`h6 text-center my-1`}>
-                                            {mode.data[yearIterator]}
-                                          </p>
-                                        </div>
-                                      );
-                                    }
-                                  )}
-                                  <hr className="my-0"></hr>
-                                  <p className={`h6 text-center my-1 pb-1`}>
-                                    {data.datasets &&
-                                      yearTotalsArray[yearIterator]}
-                                  </p>
-                                </div>
-                              </StyledDiv>
-                            </Col>
-                          );
-                        })}
-                      </Row>
-                    );
-                  },
-                }}
-              />
-            </Container>
-          }
-        </Col>
-      </Row>
+                                );
+                              })}
+                              <div>
+                                <hr className="my-0"></hr>
+                                <p className="h6 text-center my-0 py-1">
+                                  <span className="sr-only">Total</span>
+                                  <span className="mode-label-text">Total</span>
+                                </p>
+                              </div>
+                            </StyledDiv>
+                          </Col>
+                          {chart.data.labels.map((year, yearIterator) => {
+                            let paddingRight =
+                              yearIterator === 4 ? "null" : "pr-1";
+                            return (
+                              <Col
+                                key={yearIterator}
+                                className={`pl-0 ${paddingRight}`}
+                              >
+                                <StyledDiv>
+                                  <div className="year-total-div">
+                                    <div>
+                                      <p className="h6 text-center my-1 pt-2">
+                                        <strong>{year}</strong>
+                                      </p>
+                                    </div>
+                                    {chart.data.datasets.map(
+                                      (mode, modeIterator) => {
+                                        return (
+                                          <div key={modeIterator}>
+                                            <hr className="my-0"></hr>
+                                            <p
+                                              className={`h6 text-center my-1`}
+                                            >
+                                              {mode.data[yearIterator]}
+                                            </p>
+                                          </div>
+                                        );
+                                      }
+                                    )}
+                                    <hr className="my-0"></hr>
+                                    <p className={`h6 text-center my-1 pb-1`}>
+                                      {data.datasets &&
+                                        yearTotalsArray[yearIterator]}
+                                    </p>
+                                  </div>
+                                </StyledDiv>
+                              </Col>
+                            );
+                          })}
+                        </Row>
+                      );
+                    },
+                  }}
+                />
+              </Container>
+            }
+          </Col>
+        </Row>
+      ) : (
+        <Spinner />
+      )}
     </Container>
   );
 };

--- a/atd-vzv/src/views/summary/CrashesByMode.js
+++ b/atd-vzv/src/views/summary/CrashesByMode.js
@@ -1,7 +1,7 @@
 import React, { useEffect, useState, useRef, useMemo } from "react";
 import axios from "axios";
 import { Bar } from "react-chartjs-2";
-import { Container, Row, Col, Spinner } from "reactstrap";
+import { Container, Row, Col } from "reactstrap";
 import styled from "styled-components";
 import { format } from "date-fns";
 

--- a/atd-vzv/src/views/summary/CrashesByMode.js
+++ b/atd-vzv/src/views/summary/CrashesByMode.js
@@ -239,7 +239,7 @@ const CrashesByMode = () => {
       </Row>
       <Row>
         <Col>
-          <hr className="mb-2" />
+          <hr />
         </Col>
       </Row>
       {!!data.datasets ? (

--- a/atd-vzv/src/views/summary/CrashesByMode.js
+++ b/atd-vzv/src/views/summary/CrashesByMode.js
@@ -24,6 +24,7 @@ import {
   summaryCurrentYearEndDate,
 } from "../../constants/time";
 import { crashEndpointUrl } from "./queries/socrataQueries";
+import ColorSpinner from "../../Components/Spinner/ColorSpinner";
 
 const CrashesByMode = () => {
   const chartColors = [
@@ -399,7 +400,9 @@ const CrashesByMode = () => {
           </Col>
         </Row>
       ) : (
-        <Spinner />
+        <h1>
+          <ColorSpinner />
+        </h1>
       )}
     </Container>
   );

--- a/atd-vzv/src/views/summary/CrashesByPopulation.js
+++ b/atd-vzv/src/views/summary/CrashesByPopulation.js
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from "react";
 import axios from "axios";
 import styled from "styled-components";
 import { Bar } from "react-chartjs-2";
-import { Container, Row, Col } from "reactstrap";
+import { Container, Row, Col, Spinner } from "reactstrap";
 import { format } from "date-fns";
 
 import CrashTypeSelector from "./Components/CrashTypeSelector";
@@ -108,68 +108,73 @@ const CrashesByPopulation = () => {
           <hr />
         </Col>
       </Row>
-      <Row className="pb-2">
-        <Col xs={4} s={2} m={2} l={2} xl={2}>
-          <div>
-            <p className="h6 text-center pt-2 my-1">
-              <strong>Year</strong>
-            </p>
-            <hr className="my-1"></hr>
-            <p className="h6 text-center py-1">Ratio</p>
-          </div>
-        </Col>
-        {!!chartData &&
-          chartData.labels &&
-          chartData.labels.map((year, i) => {
-            const yearRatio = chartData.datasets?.[0]?.data?.[i];
+      {!!chartData.datasets ? (
+        <div>
+          <Row className="pb-2">
+            <Col xs={4} s={2} m={2} l={2} xl={2}>
+              <div>
+                <p className="h6 text-center pt-2 my-1">
+                  <strong>Year</strong>
+                </p>
+                <hr className="my-1"></hr>
+                <p className="h6 text-center py-1">Ratio</p>
+              </div>
+            </Col>
+            {chartData.labels &&
+              chartData.labels.map((year, i) => {
+                const yearRatio = chartData.datasets?.[0]?.data?.[i];
 
-            return (
-              <Col xs={4} s={2} m={2} l={2} xl={2} key={i}>
-                <StyledDiv>
-                  <div className="year-total-div">
-                    <p className="text-center pt-2 my-1">
-                      <strong>{year}</strong>
-                    </p>
-                    <hr className="my-1"></hr>
-                    <p className="text-center py-1">
-                      {/* Fallback if we haven't added the population for the year yet in popEsts.js */}
-                      {yearRatio ? yearRatio : "-"}
-                    </p>
-                  </div>
-                </StyledDiv>
-              </Col>
-            );
-          })}
-      </Row>
-      <Row className="mt-1">
-        <Col>
-          <Bar
-            data={chartData}
-            width={null}
-            height={null}
-            options={{
-              responsive: true,
-              aspectRatio: 0.849,
-              maintainAspectRatio: false,
-              tooltips: {
-                mode: "index",
-              },
-              scales: {
-                yAxes: [
-                  {
-                    ticks: {
-                      beginAtZero: true,
-                    },
+                return (
+                  <Col xs={4} s={2} m={2} l={2} xl={2} key={i}>
+                    <StyledDiv>
+                      <div className="year-total-div">
+                        <p className="text-center pt-2 my-1">
+                          <strong>{year}</strong>
+                        </p>
+                        <hr className="my-1"></hr>
+                        <p className="text-center py-1">
+                          {/* Fallback if we haven't added the population for the year yet in popEsts.js */}
+                          {yearRatio ? yearRatio : "-"}
+                        </p>
+                      </div>
+                    </StyledDiv>
+                  </Col>
+                );
+              })}
+          </Row>
+          <Row className="mt-1">
+            <Col>
+              <Bar
+                data={chartData}
+                width={null}
+                height={null}
+                options={{
+                  responsive: true,
+                  aspectRatio: 0.849,
+                  maintainAspectRatio: false,
+                  tooltips: {
+                    mode: "index",
                   },
-                ],
-              },
-              legend: {
-                display: false,
-              },
-            }}
-          />
-        </Col>
-      </Row>
+                  scales: {
+                    yAxes: [
+                      {
+                        ticks: {
+                          beginAtZero: true,
+                        },
+                      },
+                    ],
+                  },
+                  legend: {
+                    display: false,
+                  },
+                }}
+              />
+            </Col>
+          </Row>
+        </div>
+      ) : (
+        <Spinner />
+      )}
     </Container>
   );
 };

--- a/atd-vzv/src/views/summary/CrashesByPopulation.js
+++ b/atd-vzv/src/views/summary/CrashesByPopulation.js
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from "react";
 import axios from "axios";
 import styled from "styled-components";
 import { Bar } from "react-chartjs-2";
-import { Container, Row, Col, Spinner } from "reactstrap";
+import { Container, Row, Col } from "reactstrap";
 import { format } from "date-fns";
 
 import CrashTypeSelector from "./Components/CrashTypeSelector";

--- a/atd-vzv/src/views/summary/CrashesByPopulation.js
+++ b/atd-vzv/src/views/summary/CrashesByPopulation.js
@@ -12,6 +12,7 @@ import { crashEndpointUrl } from "./queries/socrataQueries";
 import { dataStartDate, fiveYearAvgEndDateByPop } from "../../constants/time";
 import { popEsts } from "../../constants/popEsts";
 import { colors } from "../../constants/colors";
+import ColorSpinner from "../../Components/Spinner/ColorSpinner";
 
 const CrashesByPopulation = () => {
   const [crashType, setCrashType] = useState(null);
@@ -173,7 +174,9 @@ const CrashesByPopulation = () => {
           </Row>
         </div>
       ) : (
-        <Spinner />
+        <h1>
+          <ColorSpinner />
+        </h1>
       )}
     </Container>
   );

--- a/atd-vzv/src/views/summary/CrashesByTimeOfDay.js
+++ b/atd-vzv/src/views/summary/CrashesByTimeOfDay.js
@@ -27,6 +27,7 @@ import {
 import { crashEndpointUrl } from "./queries/socrataQueries";
 import { getYearsAgoLabel } from "./helpers/helpers";
 import { colors } from "../../constants/colors";
+import ColorSpinner from "../../Components/Spinner/ColorSpinner";
 
 const dayOfWeekArray = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
 
@@ -318,7 +319,9 @@ const CrashesByTimeOfDay = () => {
           </Row>
         </div>
       ) : (
-        <Spinner />
+        <h1>
+          <ColorSpinner />
+        </h1>
       )}
     </Container>
   );

--- a/atd-vzv/src/views/summary/CrashesByTimeOfDay.js
+++ b/atd-vzv/src/views/summary/CrashesByTimeOfDay.js
@@ -4,7 +4,7 @@ import { format, parseISO, sub } from "date-fns";
 import clonedeep from "lodash.clonedeep";
 
 import CrashTypeSelector from "./Components/CrashTypeSelector";
-import { Row, Col, Container, Button } from "reactstrap";
+import { Row, Col, Container, Button, Spinner } from "reactstrap";
 import styled from "styled-components";
 import classnames from "classnames";
 import {
@@ -221,99 +221,105 @@ const CrashesByTimeOfDay = () => {
           <hr />
         </Col>
       </Row>
-      <Row className="text-center">
-        <Col className="pb-2">
-          <StyledButton>
-            {yearsArray() // Calculate years ago for each year in data window
-              .map((year) => {
-                const currentYear = parseInt(format(dataEndDate, "yyyy"));
-                return currentYear - year;
-              })
-              .map((yearsAgo) => (
-                <Button
-                  key={yearsAgo}
-                  className={classnames(
-                    { active: activeTab === yearsAgo },
-                    "year-selector"
-                  )}
-                  onClick={() => {
-                    toggle(yearsAgo);
-                  }}
-                >
-                  {getYearsAgoLabel(yearsAgo)}
-                </Button>
-              ))}
-          </StyledButton>
-        </Col>
-      </Row>
-      <Row className="h-auto">
-        <Col id="demographics-heatmap" className="pl-4">
-          <Heatmap
-            height={267}
-            data={heatmapDataWithPlaceholder}
-            series={
-              <HeatmapSeries
-                colorScheme={[
-                  colors.intensity2Of5,
-                  colors.intensity3Of5,
-                  colors.intensity4Of5,
-                  colors.viridis1Of6Highest,
-                ]}
-                emptyColor={colors.intensity1Of5Lowest}
-                cell={
-                  <HeatmapCell
-                    // This ref is needed to hide placeholder cells
-                    ref={heatmapCellRef}
-                    tooltip={
-                      <ChartTooltip
-                        content={(d) =>
-                          `${d.x} ∙
+      {!!heatmapDataWithPlaceholder ? (
+        <div>
+          <Row className="text-center">
+            <Col className="pb-2">
+              <StyledButton>
+                {yearsArray() // Calculate years ago for each year in data window
+                  .map((year) => {
+                    const currentYear = parseInt(format(dataEndDate, "yyyy"));
+                    return currentYear - year;
+                  })
+                  .map((yearsAgo) => (
+                    <Button
+                      key={yearsAgo}
+                      className={classnames(
+                        { active: activeTab === yearsAgo },
+                        "year-selector"
+                      )}
+                      onClick={() => {
+                        toggle(yearsAgo);
+                      }}
+                    >
+                      {getYearsAgoLabel(yearsAgo)}
+                    </Button>
+                  ))}
+              </StyledButton>
+            </Col>
+          </Row>
+          <Row className="h-auto">
+            <Col id="demographics-heatmap" className="pl-4">
+              <Heatmap
+                height={267}
+                data={heatmapDataWithPlaceholder}
+                series={
+                  <HeatmapSeries
+                    colorScheme={[
+                      colors.intensity2Of5,
+                      colors.intensity3Of5,
+                      colors.intensity4Of5,
+                      colors.viridis1Of6Highest,
+                    ]}
+                    emptyColor={colors.intensity1Of5Lowest}
+                    cell={
+                      <HeatmapCell
+                        // This ref is needed to hide placeholder cells
+                        ref={heatmapCellRef}
+                        tooltip={
+                          <ChartTooltip
+                            content={(d) =>
+                              `${d.x} ∙
                           ${formatValue(d)}`
+                            }
+                          />
+                        }
+                      />
+                    }
+                  />
+                }
+                xAxis={
+                  <LinearXAxis
+                    type="category"
+                    axisLine={null}
+                    tickSeries={
+                      <LinearXAxisTickSeries
+                        line={null}
+                        label={
+                          <LinearXAxisTickLabel
+                            padding={
+                              navigator.userAgent.includes("Firefox") ? 15 : 5
+                            }
+                          />
                         }
                       />
                     }
                   />
                 }
               />
-            }
-            xAxis={
-              <LinearXAxis
-                type="category"
-                axisLine={null}
-                tickSeries={
-                  <LinearXAxisTickSeries
-                    line={null}
-                    label={
-                      <LinearXAxisTickLabel
-                        padding={
-                          navigator.userAgent.includes("Firefox") ? 15 : 5
-                        }
-                      />
-                    }
-                  />
-                }
-              />
-            }
-          />
-        </Col>
-      </Row>
-      <Row>
-        <Col className="py-2">
-          {!!maxForLegend && (
-            <SequentialLegend
-              data={[
-                { key: "Max", data: maxForLegend[crashType.name] },
-                { key: "Min", data: 0 },
-              ]}
-              orientation="horizontal"
-              colorScheme={[
-                colors.intensity1Of5Lowest,
-                colors.viridis1Of6Highest,
-              ]}
-            />
-          )}
-        </Col>
-      </Row>
+            </Col>
+          </Row>
+          <Row>
+            <Col className="py-2">
+              {!!maxForLegend && (
+                <SequentialLegend
+                  data={[
+                    { key: "Max", data: maxForLegend[crashType.name] },
+                    { key: "Min", data: 0 },
+                  ]}
+                  orientation="horizontal"
+                  colorScheme={[
+                    colors.intensity1Of5Lowest,
+                    colors.viridis1Of6Highest,
+                  ]}
+                />
+              )}
+            </Col>
+          </Row>
+        </div>
+      ) : (
+        <Spinner />
+      )}
     </Container>
   );
 };

--- a/atd-vzv/src/views/summary/CrashesByTimeOfDay.js
+++ b/atd-vzv/src/views/summary/CrashesByTimeOfDay.js
@@ -221,7 +221,7 @@ const CrashesByTimeOfDay = () => {
           <hr />
         </Col>
       </Row>
-      {!!heatmapDataWithPlaceholder ? (
+      {!!heatmapDataWithPlaceholder.length > 0 ? (
         <div>
           <Row className="text-center">
             <Col className="pb-2">

--- a/atd-vzv/src/views/summary/CrashesByTimeOfDay.js
+++ b/atd-vzv/src/views/summary/CrashesByTimeOfDay.js
@@ -4,7 +4,7 @@ import { format, parseISO, sub } from "date-fns";
 import clonedeep from "lodash.clonedeep";
 
 import CrashTypeSelector from "./Components/CrashTypeSelector";
-import { Row, Col, Container, Button, Spinner } from "reactstrap";
+import { Row, Col, Container, Button } from "reactstrap";
 import styled from "styled-components";
 import classnames from "classnames";
 import {

--- a/atd-vzv/src/views/summary/CrashesByYear.js
+++ b/atd-vzv/src/views/summary/CrashesByYear.js
@@ -15,6 +15,7 @@ import {
   summaryCurrentYearEndDate,
   summaryCurrentYearStartDate,
 } from "../../constants/time";
+import ColorSpinner from "../../Components/Spinner/ColorSpinner";
 
 const CrashesByYear = () => {
   const chartTypes = ["Monthly", "Cumulative"];
@@ -124,7 +125,9 @@ const CrashesByYear = () => {
           </Row>
         </div>
       ) : (
-        <Spinner />
+        <h1>
+          <ColorSpinner />
+        </h1>
       )}
     </Container>
   );

--- a/atd-vzv/src/views/summary/CrashesByYear.js
+++ b/atd-vzv/src/views/summary/CrashesByYear.js
@@ -3,7 +3,7 @@ import axios from "axios";
 import CrashesByYearCumulative from "./CrashesByYearCumulative";
 import CrashesByYearAverage from "./CrashesByYearAverage";
 import ChartTypeSelector from "./Components/ChartTypeSelector";
-import { Container, Row, Col, Spinner } from "reactstrap";
+import { Container, Row, Col } from "reactstrap";
 
 import CrashTypeSelector from "./Components/CrashTypeSelector";
 import InfoPopover from "../../Components/Popover/InfoPopover";

--- a/atd-vzv/src/views/summary/CrashesByYear.js
+++ b/atd-vzv/src/views/summary/CrashesByYear.js
@@ -3,7 +3,7 @@ import axios from "axios";
 import CrashesByYearCumulative from "./CrashesByYearCumulative";
 import CrashesByYearAverage from "./CrashesByYearAverage";
 import ChartTypeSelector from "./Components/ChartTypeSelector";
-import { Container, Row, Col } from "reactstrap";
+import { Container, Row, Col, Spinner } from "reactstrap";
 
 import CrashTypeSelector from "./Components/CrashTypeSelector";
 import InfoPopover from "../../Components/Popover/InfoPopover";
@@ -101,7 +101,10 @@ const CrashesByYear = () => {
       </Row>
       <Row>
         <Col>
-          <CrashTypeSelector setCrashType={setCrashType} componentName="CrashesByYear"/>
+          <CrashTypeSelector
+            setCrashType={setCrashType}
+            componentName="CrashesByYear"
+          />
         </Col>
       </Row>
       <Row>
@@ -114,9 +117,13 @@ const CrashesByYear = () => {
         chartType={chartType}
         setChartType={setChartType}
       />
-      <Row className="mt-1">
-        <Col>{renderChartByType(chartType)}</Col>
-      </Row>
+      {avgData.length > 0 && currentYearData.length > 0 ? (
+        <Row className="mt-1">
+          <Col>{renderChartByType(chartType)}</Col>
+        </Row>
+      ) : (
+        <Spinner />
+      )}
     </Container>
   );
 };

--- a/atd-vzv/src/views/summary/CrashesByYear.js
+++ b/atd-vzv/src/views/summary/CrashesByYear.js
@@ -112,15 +112,17 @@ const CrashesByYear = () => {
           <hr />
         </Col>
       </Row>
-      <ChartTypeSelector
-        chartTypes={chartTypes}
-        chartType={chartType}
-        setChartType={setChartType}
-      />
       {avgData.length > 0 && currentYearData.length > 0 ? (
-        <Row className="mt-1">
-          <Col>{renderChartByType(chartType)}</Col>
-        </Row>
+        <div>
+          <ChartTypeSelector
+            chartTypes={chartTypes}
+            chartType={chartType}
+            setChartType={setChartType}
+          />
+          <Row className="mt-1">
+            <Col>{renderChartByType(chartType)}</Col>
+          </Row>
+        </div>
       ) : (
         <Spinner />
       )}

--- a/atd-vzv/src/views/summary/PeopleByDemographics.js
+++ b/atd-vzv/src/views/summary/PeopleByDemographics.js
@@ -3,7 +3,7 @@ import axios from "axios";
 import { HorizontalBar } from "react-chartjs-2";
 import "chartjs-plugin-stacked100";
 import ChartTypeSelector from "./Components/ChartTypeSelector";
-import { Container, Row, Col, Spinner } from "reactstrap";
+import { Container, Row, Col } from "reactstrap";
 import { format } from "date-fns";
 
 import CrashTypeSelector from "./Components/CrashTypeSelector";

--- a/atd-vzv/src/views/summary/PeopleByDemographics.js
+++ b/atd-vzv/src/views/summary/PeopleByDemographics.js
@@ -299,44 +299,46 @@ const PeopleByDemographics = () => {
           <hr />
         </Col>
       </Row>
-      <ChartTypeSelector
-        chartTypes={Object.values(chartConfigs).map((value) => value.label)}
-        chartType={chartType}
-        setChartType={setChartType}
-      />
       {!!chartData.datasets ? (
-        <Row>
-          <Col>
-            <HorizontalBar
-              redraw
-              data={chartData}
-              height={null}
-              width={null}
-              options={{
-                responsive: true,
-                aspectRatio: 1,
-                maintainAspectRatio: false,
-                plugins: {
-                  // Imported to display percentages without calculating them from data
-                  stacked100: { enable: true, replaceTooltipLabel: false },
-                },
-                tooltips: {
-                  callbacks: {
-                    label: (tooltipItem, data) => {
-                      const datasetIndex = tooltipItem.datasetIndex;
-                      const datasetLabel = data.datasets[datasetIndex].label;
-                      const originalValue =
-                        data.originalData[datasetIndex][tooltipItem.index];
-                      const rateValue =
-                        data.calculatedData[datasetIndex][tooltipItem.index];
-                      return `${datasetLabel}: ${originalValue} (${rateValue}%)`;
+        <div>
+          <ChartTypeSelector
+            chartTypes={Object.values(chartConfigs).map((value) => value.label)}
+            chartType={chartType}
+            setChartType={setChartType}
+          />
+          <Row>
+            <Col>
+              <HorizontalBar
+                redraw
+                data={chartData}
+                height={null}
+                width={null}
+                options={{
+                  responsive: true,
+                  aspectRatio: 1,
+                  maintainAspectRatio: false,
+                  plugins: {
+                    // Imported to display percentages without calculating them from data
+                    stacked100: { enable: true, replaceTooltipLabel: false },
+                  },
+                  tooltips: {
+                    callbacks: {
+                      label: (tooltipItem, data) => {
+                        const datasetIndex = tooltipItem.datasetIndex;
+                        const datasetLabel = data.datasets[datasetIndex].label;
+                        const originalValue =
+                          data.originalData[datasetIndex][tooltipItem.index];
+                        const rateValue =
+                          data.calculatedData[datasetIndex][tooltipItem.index];
+                        return `${datasetLabel}: ${originalValue} (${rateValue}%)`;
+                      },
                     },
                   },
-                },
-              }}
-            />
-          </Col>
-        </Row>
+                }}
+              />
+            </Col>
+          </Row>
+        </div>
       ) : (
         <Spinner />
       )}

--- a/atd-vzv/src/views/summary/PeopleByDemographics.js
+++ b/atd-vzv/src/views/summary/PeopleByDemographics.js
@@ -3,7 +3,7 @@ import axios from "axios";
 import { HorizontalBar } from "react-chartjs-2";
 import "chartjs-plugin-stacked100";
 import ChartTypeSelector from "./Components/ChartTypeSelector";
-import { Container, Row, Col } from "reactstrap";
+import { Container, Row, Col, Spinner } from "reactstrap";
 import { format } from "date-fns";
 
 import CrashTypeSelector from "./Components/CrashTypeSelector";
@@ -304,38 +304,42 @@ const PeopleByDemographics = () => {
         chartType={chartType}
         setChartType={setChartType}
       />
-      <Row>
-        <Col>
-          <HorizontalBar
-            redraw
-            data={chartData}
-            height={null}
-            width={null}
-            options={{
-              responsive: true,
-              aspectRatio: 1,
-              maintainAspectRatio: false,
-              plugins: {
-                // Imported to display percentages without calculating them from data
-                stacked100: { enable: true, replaceTooltipLabel: false },
-              },
-              tooltips: {
-                callbacks: {
-                  label: (tooltipItem, data) => {
-                    const datasetIndex = tooltipItem.datasetIndex;
-                    const datasetLabel = data.datasets[datasetIndex].label;
-                    const originalValue =
-                      data.originalData[datasetIndex][tooltipItem.index];
-                    const rateValue =
-                      data.calculatedData[datasetIndex][tooltipItem.index];
-                    return `${datasetLabel}: ${originalValue} (${rateValue}%)`;
+      {!!chartData.datasets ? (
+        <Row>
+          <Col>
+            <HorizontalBar
+              redraw
+              data={chartData}
+              height={null}
+              width={null}
+              options={{
+                responsive: true,
+                aspectRatio: 1,
+                maintainAspectRatio: false,
+                plugins: {
+                  // Imported to display percentages without calculating them from data
+                  stacked100: { enable: true, replaceTooltipLabel: false },
+                },
+                tooltips: {
+                  callbacks: {
+                    label: (tooltipItem, data) => {
+                      const datasetIndex = tooltipItem.datasetIndex;
+                      const datasetLabel = data.datasets[datasetIndex].label;
+                      const originalValue =
+                        data.originalData[datasetIndex][tooltipItem.index];
+                      const rateValue =
+                        data.calculatedData[datasetIndex][tooltipItem.index];
+                      return `${datasetLabel}: ${originalValue} (${rateValue}%)`;
+                    },
                   },
                 },
-              },
-            }}
-          />
-        </Col>
-      </Row>
+              }}
+            />
+          </Col>
+        </Row>
+      ) : (
+        <Spinner />
+      )}
     </Container>
   );
 };

--- a/atd-vzv/src/views/summary/PeopleByDemographics.js
+++ b/atd-vzv/src/views/summary/PeopleByDemographics.js
@@ -12,6 +12,7 @@ import { dataEndDate, yearsArray, dataStartDate } from "../../constants/time";
 import { personEndpointUrl } from "./queries/socrataQueries";
 import InfoPopover from "../../Components/Popover/InfoPopover";
 import { popoverConfig } from "../../Components/Popover/popoverConfig";
+import ColorSpinner from "../../Components/Spinner/ColorSpinner";
 
 const url = `${personEndpointUrl}?$query=`;
 
@@ -340,7 +341,9 @@ const PeopleByDemographics = () => {
           </Row>
         </div>
       ) : (
-        <Spinner />
+        <h1>
+          <ColorSpinner />
+        </h1>
       )}
     </Container>
   );

--- a/atd-vzv/src/views/summary/SummaryCard.js
+++ b/atd-vzv/src/views/summary/SummaryCard.js
@@ -14,7 +14,7 @@ const SummaryCard = ({ child }) => {
     <Col className="summary-child" xl="6" md="12">
       {/* Set height to fill parent column */}
       <Card>
-        <CardBody className="h-100 py-0">
+        <CardBody className="h-100 py-0 mb-2">
           <StyledCardTitle>{child.title}</StyledCardTitle>
           {child.component}
         </CardBody>


### PR DESCRIPTION
## Associated issues
Closes https://github.com/cityofaustin/atd-data-tech/issues/16100

## Testing
**URL to test:** <!-- VZ URL or Netlify -->
https://deploy-preview-1428--atd-vzv-staging.netlify.app/

**Steps to test:**
1. The spinners happen super fast sometimes so you may need to throttle your network to actually see anything. But just go to the summary page of the VZV and look for the new spinners while the summary cards are loading

Looking for design feedback so lmk what yall think. Heres a screenshot I took of when all the spinners are going so yall can see it easier:

![image](https://github.com/cityofaustin/atd-vz-data/assets/67130963/cb325d85-56b7-4d2e-97dc-205a3277d51c)

---
#### Ship list
- [x] Check migrations for any conflicts with latest migrations in master branch
- [x] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved