### PR TITLE
Check for CR3 metadata when showing the download CR3 button

### DIFF
--- a/atd-vze/src/views/Crashes/Crash.js
+++ b/atd-vze/src/views/Crashes/Crash.js
@@ -278,7 +278,7 @@ function Crash(props) {
         <Col xs="12" md="6" className="mb-4">
           <CrashDiagram
             crashId={crashId}
-            isCr3Stored={cr3StoredFlag === "Y"}
+            isCr3Stored={cr3StoredFlag === "Y" && !!cr3FileMetadata}
             isTempRecord={tempRecord}
             cr3FileMetadata={cr3FileMetadata}
           />


### PR DESCRIPTION
## Associated issues
- https://github.com/cityofaustin/atd-data-tech/issues/16759

## Testing
**URL to test:** Local

I believe you'll need to test locally because I was not able to locate a record in staging that is missing CR3 file metadata.

**Steps to test:**
1. Find a crash that has a stored CR3 but no file metadata: 
```sql
select crash_id from atd_txdot_crashes
  where cr3_stored_flag = 'Y'
  and cr3_file_metadata is null limit 1;```

2. Visit the crash details page for this crash and verify that the **DOWNLOAD CR3 PDF** button is not visible

---
#### Ship list
- [ ] Check migrations for any conflicts with latest migrations in master branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved