### PR TITLE
Update description of 'Other' modes in by travel mode modal

### DIFF
--- a/atd-vzv/src/Components/Popover/popoverConfig.js
+++ b/atd-vzv/src/Components/Popover/popoverConfig.js
@@ -223,9 +223,8 @@ export const popoverConfig = {
                 motorized scooter
               </li>
               <li>
-                <strong>Other</strong>: Any modality other than motorist,
-                pedestrian, motorcyclist, bicyclist, or e-scooter rider, such as
-                a pedicab
+                <strong>Other</strong>: Any other modality, such as
+                a pedicab, or the modality may be unreported or unknown
               </li>
             </ul>
           </div>

--- a/atd-vzv/src/Components/Popover/popoverConfig.js
+++ b/atd-vzv/src/Components/Popover/popoverConfig.js
@@ -224,7 +224,7 @@ export const popoverConfig = {
               </li>
               <li>
                 <strong>Other</strong>: Any other modality, such as
-                a pedicab, or the modality may be unreported or unknown
+                a pedicab, or when the modality is unreported or unknown
               </li>
             </ul>
           </div>


### PR DESCRIPTION
## Associated issues
- https://github.com/cityofaustin/atd-data-tech/issues/17102

## Testing
- Netlify

Check out the text in the By Travel Mode popup:
<img width="553" alt="Screenshot 2024-05-02 at 12 09 13 PM" src="https://github.com/cityofaustin/atd-vz-data/assets/14793120/e430ee6f-5faf-4aa7-8833-cf08560e55c0">



---
#### Ship list
- [ ] Check migrations for any conflicts with latest migrations in master branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved