### PR TITLE
Ensure that temporary records are not removed by the import script

### DIFF
--- a/atd-etl/cris_import/cris_import.py
+++ b/atd-etl/cris_import/cris_import.py
@@ -712,7 +712,7 @@ def group_csvs_into_logical_groups(extracted_archives, dry_run):
     files = os.listdir(str(extracted_archives))
     logical_groups = []
     for file in files:
-        if file.endswith(".xml"):
+        if file.endswith(".xml") or file == "crashReports":
             continue
         match = re.search("^extract_(\d+_\d+)_", file)
         group_id = match.group(1)

--- a/atd-etl/cris_import/cris_import.py
+++ b/atd-etl/cris_import/cris_import.py
@@ -669,21 +669,6 @@ def align_records(map_state):
                         print("Changed column count: " + str(len(changed_columns['changed_columns'])))
                         print("Changed Columns:" + str(changed_columns["changed_columns"]))
                         
-                        try:
-                            # this seemingly violates the principal of treating each record source equally, however, this is 
-                            # really only a reflection that we create incomplete temporary records consisting only of a crash record
-                            # and not holding place entities for units, persons, etc.
-                            if table == "crash" and util.has_existing_temporary_record(pg, source["case_id"]):
-                                print("\b🛎: " + str(source["crash_id"]) + " has existing temporary record")
-                                time.sleep(5)
-                                util.remove_existing_temporary_record(pg, source["case_id"])
-                        except:
-                            # Trap the case of a missing case_id key error in the RealDictRow object.
-                            # A RealDictRow, returned by the psycopg2 cursor, is a dictionary-like object,
-                            # but lacks has_key() and other methods.
-                            print("Skipping checking on existing temporary record for " + str(source["crash_id"]))
-                            pass
-                        
                         # build an comma delimited list of changed columns
                         all_changed_columns = ", ".join(important_changed_columns["changed_columns"] + changed_columns["changed_columns"])
 

--- a/atd-etl/cris_import/lib/sql.py
+++ b/atd-etl/cris_import/lib/sql.py
@@ -226,33 +226,6 @@ def is_change_existing(pg, record_type, record_id):
         return False
 
 
-def has_existing_temporary_record(pg, case_id):
-    sql = f"""
-    select count(*) as exists
-    from atd_txdot_crashes
-    where crash_id < 10000
-    and case_id = '{case_id}'
-    """
-    cursor = pg.cursor(cursor_factory=psycopg2.extras.RealDictCursor)
-    cursor.execute(sql)
-    change_request_exists = cursor.fetchone()
-    if change_request_exists["exists"] > 0:
-        return True
-    else:
-        return False
-
-
-def remove_existing_temporary_record(pg, case_id):
-    sql = f"""
-    delete from atd_txdot_crashes
-    where crash_id < 10000
-    and case_id = '{case_id}'
-    """
-    cursor = pg.cursor(cursor_factory=psycopg2.extras.RealDictCursor)
-    cursor.execute(sql)
-    return True
-
-
 def try_statement(pg, output_map, table, public_key_sql, sql, dry_run):
     if dry_run:
         print("Dry run; skipping")


### PR DESCRIPTION
## Associated issues

This PR aims to close https://github.com/cityofaustin/atd-data-tech/issues/17143.

## Testing

Test this one locally by:

* Fire up your local stack, at least so that you have a DB & `graphql-engine` endpoint running.
* Drop a export from CRIS you want to test with into the `development_extracts` folder inside the CRIS import folder.
```
cd atd-etl/cris_import;
docker compose build;
docker compose run cris-import;
```
* Did it run?


---
#### Ship list
- [x] Check migrations for any conflicts with latest migrations in master branch
- [x] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved