### PR TITLE
[BUG] Crash coordinates render as NaN when they should be blank

### DIFF
--- a/atd-vze/src/views/Crashes/Crash.js
+++ b/atd-vze/src/views/Crashes/Crash.js
@@ -168,7 +168,8 @@ function Crash(props) {
     data &&
     data?.atd_txdot_crashes.length > 0 &&
     data?.atd_txdot_crashes[0]["location_id"];
-  const notEditingCoords = !isEditingCoords && latitude && longitude;
+  const hasCoordinates = Boolean(latitude) && Boolean(longitude);
+  const notEditingCoords = !isEditingCoords && hasCoordinates;
 
   return !data?.atd_txdot_crashes?.length ? (
     <Page404 />
@@ -237,7 +238,7 @@ function Crash(props) {
                   )
                   <br />
                   Geocode Provider:{" "}
-                  {latitude && longitude
+                  {hasCoordinates
                     ? geocodeMethod.name
                     : "No Primary Coordinates"}
                 </Col>
@@ -255,7 +256,7 @@ function Crash(props) {
               </Row>
             </CardHeader>
             <CardBody style={{ minHeight: "350px" }}>
-              {(!latitude || !longitude) && (
+              {!hasCoordinates && (
                 <Alert color="danger">
                   Crash record is missing latitude and longitude values required
                   for map display.

--- a/atd-vze/src/views/Crashes/Crash.js
+++ b/atd-vze/src/views/Crashes/Crash.js
@@ -168,7 +168,7 @@ function Crash(props) {
     data &&
     data?.atd_txdot_crashes.length > 0 &&
     data?.atd_txdot_crashes[0]["location_id"];
-  const hasCoordinates = Boolean(latitude) && Boolean(longitude);
+  const hasCoordinates = !!latitude && !!longitude;
 
   return !data?.atd_txdot_crashes?.length ? (
     <Page404 />

--- a/atd-vze/src/views/Crashes/Crash.js
+++ b/atd-vze/src/views/Crashes/Crash.js
@@ -254,7 +254,10 @@ function Crash(props) {
                 </Col>
               </Row>
             </CardHeader>
-            <CardBody className="d-flex flex-column">
+            <CardBody
+              className="d-flex flex-column"
+              style={{ minHeight: "400px" }}
+            >
               {!hasCoordinates && (
                 <Alert color="danger">
                   Crash record is missing latitude and longitude values required

--- a/atd-vze/src/views/Crashes/Crash.js
+++ b/atd-vze/src/views/Crashes/Crash.js
@@ -169,7 +169,6 @@ function Crash(props) {
     data?.atd_txdot_crashes.length > 0 &&
     data?.atd_txdot_crashes[0]["location_id"];
   const hasCoordinates = Boolean(latitude) && Boolean(longitude);
-  const notEditingCoords = !isEditingCoords && hasCoordinates;
 
   return !data?.atd_txdot_crashes?.length ? (
     <Page404 />
@@ -255,14 +254,14 @@ function Crash(props) {
                 </Col>
               </Row>
             </CardHeader>
-            <CardBody style={{ minHeight: "350px" }}>
+            <CardBody className="d-flex flex-column">
               {!hasCoordinates && (
                 <Alert color="danger">
                   Crash record is missing latitude and longitude values required
                   for map display.
                 </Alert>
               )}
-              {notEditingCoords ? (
+              {!isEditingCoords ? (
                 <CrashMap data={data.atd_txdot_crashes[0]} />
               ) : (
                 <CrashEditCoordsMap

--- a/atd-vze/src/views/Crashes/Maps/CrashEditCoordsMap.js
+++ b/atd-vze/src/views/Crashes/Maps/CrashEditCoordsMap.js
@@ -31,8 +31,8 @@ const CrashEditCoordsMap = ({
   const mapRef = React.useRef();
   const [isDragging, setIsDragging] = React.useState(false);
   const [markerCoordinates, setMarkerCoordinates] = React.useState({
-    latitude: latitude_primary,
-    longitude: longitude_primary,
+    latitude: latitude_primary || defaultInitialState.latitude,
+    longitude: longitude_primary || defaultInitialState.longitude,
   });
   const [isSubmitting, setIsSubmitting] = React.useState(false);
 

--- a/atd-vze/src/views/Crashes/Maps/CrashEditCoordsMap.js
+++ b/atd-vze/src/views/Crashes/Maps/CrashEditCoordsMap.js
@@ -31,8 +31,8 @@ const CrashEditCoordsMap = ({
   const mapRef = React.useRef();
   const [isDragging, setIsDragging] = React.useState(false);
   const [markerCoordinates, setMarkerCoordinates] = React.useState({
-    latitude: latitude_primary || defaultInitialState.latitude,
-    longitude: longitude_primary || defaultInitialState.longitude,
+    latitude: latitude_primary,
+    longitude: longitude_primary,
   });
   const [isSubmitting, setIsSubmitting] = React.useState(false);
 
@@ -108,7 +108,12 @@ const CrashEditCoordsMap = ({
       >
         <FullscreenControl position="top-left" />
         <NavigationControl position="top-left" showCompass={false} />
-        <Marker {...markerCoordinates}>
+        <Marker
+          latitude={markerCoordinates.latitude || defaultInitialState.latitude}
+          longitude={
+            markerCoordinates.longitude || defaultInitialState.longitude
+          }
+        >
           <Pin size={40} color={"warning"} isDragging={isDragging} animated />
         </Marker>
         {/* add nearmap raster source and style */}

--- a/atd-vze/src/views/Crashes/Maps/CrashEditCoordsMap.js
+++ b/atd-vze/src/views/Crashes/Maps/CrashEditCoordsMap.js
@@ -72,7 +72,7 @@ const CrashEditCoordsMap = ({
     // Reset marker to original coordinates or default fallback
     const originalMarkerCoordinates = {
       latitude: latitude_primary || defaultInitialState.latitude,
-      longitude: longitude_primary || defaultInitialState.latitude,
+      longitude: longitude_primary || defaultInitialState.longitude,
     };
 
     // Move map center and marks to original coordinates or default fallback

--- a/atd-vze/src/views/Crashes/Maps/CrashEditLatLonForm.js
+++ b/atd-vze/src/views/Crashes/Maps/CrashEditLatLonForm.js
@@ -21,7 +21,7 @@ export const CrashEditLatLonForm = ({
           id="qa-latitude"
           name="qa-latitude"
           placeholder=""
-          value={truncateCoordinate(latitude)}
+          value={!!latitude ? truncateCoordinate(latitude) : "None"}
           readOnly
         />
       </Col>
@@ -36,7 +36,7 @@ export const CrashEditLatLonForm = ({
           id="qa-longitude"
           name="qa-longitude"
           placeholder=""
-          value={truncateCoordinate(longitude)}
+          value={!!longitude ? truncateCoordinate(longitude) : "None"}
           readOnly
         />
       </Col>


### PR DESCRIPTION
## Associated issues
Closes https://github.com/cityofaustin/atd-data-tech/issues/17104

This makes a few small bug fixes to the crash coordinates edit map. It:
- makes the form show **None** when there are no crash coordinates
- gives the marker default coordinates so it always show on the map when it opens
- fixes an issue where the alert message about a crash not having coordinates pushes the crash map out of the card it should stay inside

Side note - i found an interesting gist about `!!` vs `Boolean()` [here](https://gist.github.com/arthurvi/66cb1e2bcfc92f99f465e0db04264367). 

## Testing
**URL to test:** <!-- VZ URL or Netlify -->
https://deploy-preview-1448--atd-vze-staging.netlify.app/

**Steps to test:**
1. Go to https://deploy-preview-1448--atd-vze-staging.netlify.app/#/crashes/11157589 to a crash without coordinates and no crash diagram
2. See that the map card shows an alert and that the map is contained in the card body
3. Also see that the map has height even though there is no crash diagram
4. Click the **Edit Coordinates** button and see that the form shows **None** in both inputs
5. Go to https://deploy-preview-1448--atd-vze-staging.netlify.app/#/crashes/19540057 to see a crash with coordinates
6. Click the **Edit Coordinates** button and see that the form shows the coordinates of the crash
7. Test updating and saving any crash besides the one above without coordinates to make sure it still works. Trying to keep the example above intact. 🙏

---
#### Ship list
- [ ] ~Check migrations for any conflicts with latest migrations in master branch~
- [ ] ~Confirm Hasura role permissions for necessary access~
- [x] Code reviewed
- [x] Product manager approved