### PR TITLE
bump paths-filter version and use  setting

### DIFF
--- a/.github/workflows/build_docker_images.yml
+++ b/.github/workflows/build_docker_images.yml
@@ -40,12 +40,13 @@ jobs:
           password: ${{ secrets.DOCKER_TOKEN }}
 
       - name: "Checkout"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: "Paths filter"
-        uses: dorny/paths-filter@v2
+        uses: dorny/paths-filter@v3
         id: changes
         with:
+          base: ${{ github.ref }}
           filters: |
             afd_ems:
               - 'atd-etl/afd_ems_import/**'

--- a/atd-etl/socrata_export/README.md
+++ b/atd-etl/socrata_export/README.md
@@ -14,3 +14,7 @@ $ docker compose run --build -it socrata_export python socrata_export.py
 
 In production, they will be run from a DAG which handles starting the containers with
 the needed environment and other parameters.
+
+### Continuous integration
+
+This ETL image is published as `atd-etl/socrata_export` to DockerHub automatically via Github Action. It is tagged with `:production` when changes to this directory are merged to the `production` branch, otherwise the updated image is published with the `development` tag.


### PR DESCRIPTION
## Associated issues
- https://github.com/cityofaustin/atd-data-tech/issues/17354

The [paths-filter docs](https://github.com/dorny/paths-filter/tree/master?tab=readme-ov-file#examples) has an example called `Long lived branches: Detect changes against the most recent commit on the same branch before the push` that covers the behavior that i think we want, by adding  `base: ${{ github.ref }}` to our settings.

## Testing

I think we need to merge this to master and then prod. Got any better ideas?

---
#### Ship list
- [ ] Check migrations for any conflicts with latest migrations in master branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved