### PR TITLE
Set minimum crash date to be OCR'd to 2020-01-01

### DIFF
--- a/atd-etl/cr3_extract_diagram/cr3_extract_diagram_ocr_narrative.py
+++ b/atd-etl/cr3_extract_diagram/cr3_extract_diagram_ocr_narrative.py
@@ -164,7 +164,7 @@ query find_cr3s($limit: Int) {
   atd_txdot_crashes(where: {
       cr3_ocr_extraction_date: {_is_null: true},
       crash_id: {_gt: 10000}
-      crash_date: {_gte: "2015-01-01"}
+      crash_date: {_gte: "2019-12-31"}
       cr3_file_metadata:{_is_null: false}
   },
   order_by: {crash_date: desc},

--- a/atd-etl/cr3_extract_diagram/cr3_extract_diagram_ocr_narrative.py
+++ b/atd-etl/cr3_extract_diagram/cr3_extract_diagram_ocr_narrative.py
@@ -164,7 +164,7 @@ query find_cr3s($limit: Int) {
   atd_txdot_crashes(where: {
       cr3_ocr_extraction_date: {_is_null: true},
       crash_id: {_gt: 10000}
-      crash_date: {_gte: "2019-12-31"}
+      crash_date: {_gte: "2020-01-01"}
       cr3_file_metadata:{_is_null: false}
   },
   order_by: {crash_date: desc},


### PR DESCRIPTION
## Associated issues
- https://github.com/cityofaustin/atd-data-tech/issues/17666

This is a stop-gap measure to temporarily ignore the backlog of CR3 PDFs that need to be OCR'd.

## Testing

I tested this by starting up a local prod backup and testing the updated query in the Hasura console.


---
#### Ship list
- [ ] Check migrations for any conflicts with latest migrations in master branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved