### PR TITLE
Crash details page: crash diagram + narrative

### DIFF
--- a/atd-vze/src/queries/crashes.js
+++ b/atd-vze/src/queries/crashes.js
@@ -160,6 +160,9 @@ export const GET_CRASH = gql`
       schl_bus_fl
       toll_road_fl
       law_enforcement_fatality_num
+      investigator_narrative
+      cr3_stored_flag
+      cr3_file_metadata
       crash_injury_metrics_view {
         vz_fatality_count
         sus_serious_injry_count

--- a/atd-vze/src/views/Crashes/Crash.js
+++ b/atd-vze/src/views/Crashes/Crash.js
@@ -124,11 +124,8 @@ function Crash(props) {
   const {
     latitude_primary: latitude,
     longitude_primary: longitude,
-    cr3_stored_flag: cr3StoredFlag,
     temp_record: tempRecord,
     geocode_method: geocodeMethod,
-    cr3_file_metadata: cr3FileMetadata,
-    investigator_narrative_ocr: investigatorNarrative,
   } = !!data?.atd_txdot_crashes[0] ? data?.atd_txdot_crashes[0] : {};
 
   const {
@@ -137,6 +134,9 @@ function Crash(props) {
     address_primary: primaryAddress,
     address_secondary: secondaryAddress,
     crash_injury_metrics_view: { years_of_life_lost: yearsOfLifeLost },
+    investigator_narrative: investigatorNarrative,
+    cr3_stored_flag: cr3StoredFlag,
+    cr3_file_metadata: cr3FileMetadata,
   } = crashData?.crashes_by_pk ? crashData?.crashes_by_pk : {};
 
   const mapGeocoderAddress = createGeocoderAddressString(data);
@@ -256,7 +256,7 @@ function Crash(props) {
         <Col xs="12" md="6" className="mb-4">
           <CrashDiagram
             crashId={crashId}
-            isCr3Stored={cr3StoredFlag === "Y"}
+            isCr3Stored={cr3StoredFlag}
             isTempRecord={tempRecord}
             cr3FileMetadata={cr3FileMetadata}
           />

--- a/atd-vze/src/views/Crashes/CrashDiagram.js
+++ b/atd-vze/src/views/Crashes/CrashDiagram.js
@@ -14,7 +14,12 @@ import axios from "axios";
 import { TransformWrapper, TransformComponent } from "react-zoom-pan-pinch";
 import { isDev } from "../../helpers/environment";
 
-const CrashDiagram = props => {
+const CrashDiagram = ({
+  crashId,
+  isCr3Stored,
+  isTempRecord,
+  cr3FileMetadata,
+}) => {
   const [rotation, setRotation] = useState(0);
 
   // Set S3 folder for diagram depending on environment
@@ -22,7 +27,7 @@ const CrashDiagram = props => {
     process.env.NODE_ENV === "production" || isDev ? "production" : "staging";
 
   const requestCR3 = () => {
-    const requestUrl = `${process.env.REACT_APP_CR3_API_DOMAIN}/cr3/download/${props.crashId}`;
+    const requestUrl = `${process.env.REACT_APP_CR3_API_DOMAIN}/cr3/download/${crashId}`;
     const token = window.localStorage.getItem("id_token");
 
     axios
@@ -51,7 +56,7 @@ const CrashDiagram = props => {
         <Row className="d-flex align-items-center">
           <Col>Crash Diagram</Col>
           <Col className="d-flex justify-content-end">
-            {props.isCr3Stored ? (
+            {isCr3Stored ? (
               <Button color="primary" onClick={requestCR3}>
                 Download CR-3 PDF
               </Button>
@@ -62,7 +67,7 @@ const CrashDiagram = props => {
         </Row>
       </CardHeader>
       <CardBody className="py-0">
-        {!!props.cr3FileMetadata && props.cr3FileMetadata.diagram_s3_file ? (
+        {!!cr3FileMetadata && cr3FileMetadata.diagram_s3_file ? (
           <TransformWrapper
             defaultScale={1}
             options={{
@@ -110,7 +115,7 @@ const CrashDiagram = props => {
                           maxWidth: "100%",
                           transform: `rotate(${rotation}deg)`,
                         }}
-                        src={`https://atd-vision-zero-website.s3.amazonaws.com/cr3_crash_diagrams/${s3Folder}/${props.cr3FileMetadata.diagram_s3_file}`}
+                        src={`https://atd-vision-zero-website.s3.amazonaws.com/cr3_crash_diagrams/${s3Folder}/${cr3FileMetadata.diagram_s3_file}`}
                         alt="crash diagram"
                       />
                     </TransformComponent>
@@ -119,27 +124,27 @@ const CrashDiagram = props => {
               </>
             )}
           </TransformWrapper>
-        ) : props.isTempRecord ? (
-          <div className="mt-2">
-            CR-3 PDFs, diagrams and narratives are not available for temporary
-            records. Using the case id, check the{" "}
-            <a
-              href={"https://cris.dot.state.tx.us/"}
-              target={"_blank"}
-              rel="noopener noreferrer"
-            >
-              CRIS website
-            </a>{" "}
-            for the latest status of this crash.
-          </div>
         ) : (
+          // ) : props.isTempRecord ? (
+          //   <div className="mt-2">
+          //     CR-3 PDFs, diagrams and narratives are not available for temporary
+          //     records. Using the case id, check the{" "}
+          //     <a
+          //       href={"https://cris.dot.state.tx.us/"}
+          //       target={"_blank"}
+          //       rel="noopener noreferrer"
+          //     >
+          //       CRIS website
+          //     </a>{" "}
+          //     for the latest status of this crash.
+          //   </div>
           <div className="mt-2">
             The crash diagram and investigator narrative are not available at
             this time.
           </div>
         )}
       </CardBody>
-      {!!props.cr3FileMetadata && props.cr3FileMetadata.diagram_s3_file ? (
+      {!!cr3FileMetadata && cr3FileMetadata.diagram_s3_file ? (
         <CardFooter className="py-0">
           <form>
             <Row className="form-group d-flex align-items-center mb-0">


### PR DESCRIPTION
## Associated issues
Closes https://github.com/cityofaustin/atd-data-tech/issues/17183

## Testing
**URL to test:** <!-- VZ URL or Netlify -->
Local

**Steps to test:**
1. Follow instructions in https://github.com/cityofaustin/atd-vz-data/pull/1440 to start the data model collector branch and run the CRIS import ETL, or if you already have it set up use that!
2. Because all of the cr3 columns the crash diagram component uses are currently `null` until we do a back fill in the new `crashes` table, to test you will need to manually copy over some fields to a record.
3. In your db client, find a crash record in the new `crashes` table. Now find that same crash in the old `atd_txdot_crashes` table. Copy over the following columns from `atd_txdot_crashes` to the record in `crashes`: `cr3_stored_flag` (now a boolean instead of a string) and `cr3_file_metadata`
4. Now if you go to the crash details page for that crash id you should see the crash diagram there. You should also see a button to download CR3 pdf though you wont actually be able to locally.
5. Observe that the crash narrative is also pulling from the new table


---
#### Ship list
- [ ] Check migrations for any conflicts with latest migrations in master branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved