### PR TITLE
Small VZV timestamp bug

### DIFF
--- a/atd-vzv/src/views/map/InfoBox/MapInfoBox.js
+++ b/atd-vzv/src/views/map/InfoBox/MapInfoBox.js
@@ -29,7 +29,7 @@ const MapInfoBox = React.memo(
     const buildSeriousInjuriesOrFatalitiesConfig = (info) => [
       {
         title: "Date/Time",
-        content: format(new Date(info.crash_date), "MM/dd/yyyy H:m a"),
+        content: format(new Date(info.crash_date), "MM/dd/yyyy hh:mm a"),
       },
       { title: "Fatalities", content: info.death_cnt },
       { title: "Serious Injuries", content: info.sus_serious_injry_cnt },


### PR DESCRIPTION
Hour and minute were not displaying correctly when the number of digits were < 2 and was using 24h time with am/pm. Not sure if I'm supposed to be merging into master or not apologies... 

[date-fns format docs](https://date-fns.org/v3.6.0/docs/format)

Before:
<img width="443" alt="Screenshot 2024-06-10 at 5 19 40 PM" src="https://github.com/cityofaustin/atd-vz-data/assets/30810522/19b7d923-bf27-43e1-9cc8-5fcfa5b2df04">

After:
<img width="437" alt="Screenshot 2024-06-10 at 5 19 37 PM" src="https://github.com/cityofaustin/atd-vz-data/assets/30810522/3721e130-6b89-4e17-8b2f-54fa4f740117">

## Associated issues

## Testing
**URL to test:** https://deploy-preview-1474--atd-vzv-staging.netlify.app/viewer/map

**Steps to test:**


---
#### Ship list
- [ ] Check migrations for any conflicts with latest migrations in master branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved