### PR TITLE
Make crash notes and recommendations compatible with the new data model

### DIFF
--- a/atd-toolbox/data_model/python/80_update_notes_and_recs.py
+++ b/atd-toolbox/data_model/python/80_update_notes_and_recs.py
@@ -1,0 +1,14 @@
+from utils import save_file, make_migration_dir
+
+def load_sql_template(name):
+    with open(name, "r") as fin:
+        return fin.read()
+
+def main():
+    recommendations_and_notes_sql_up = load_sql_template("sql_templates/recommendations_and_notes_up.sql")
+    recommendations_and_notes_sql_down = load_sql_template("sql_templates/recommendations_and_notes_down.sql")
+    migration_path = make_migration_dir("update_recommendations_and_notes_fks")
+    save_file(f"{migration_path}/up.sql", recommendations_and_notes_sql_up)
+    save_file(f"{migration_path}/down.sql", recommendations_and_notes_sql_down)
+
+main()

--- a/atd-toolbox/data_model/python/sql_templates/recommendations_and_notes_down.sql
+++ b/atd-toolbox/data_model/python/sql_templates/recommendations_and_notes_down.sql
@@ -1,0 +1,5 @@
+alter table recommendations drop column crash_id;
+alter table recommendations rename column atd_txdot_crashes_crash_id to crash_id;
+
+alter table crash_notes drop column crash_id;
+alter table crash_notes rename column atd_txdot_crashes_crash_id to crash_id;

--- a/atd-toolbox/data_model/python/sql_templates/recommendations_and_notes_down.sql
+++ b/atd-toolbox/data_model/python/sql_templates/recommendations_and_notes_down.sql
@@ -1,5 +1,10 @@
 alter table recommendations drop column crash_id;
 alter table recommendations rename column atd_txdot_crashes_crash_id to crash_id;
+alter table recommendations add constraint recommendations_crash_id_key unique (crash_id);
+delete from recommendations where crash_id is null;
+alter table recommendations alter column crash_id set not null;
 
 alter table crash_notes drop column crash_id;
 alter table crash_notes rename column atd_txdot_crashes_crash_id to crash_id;
+delete from crash_notes where crash_id is null;
+alter table crash_notes alter column crash_id set not null;

--- a/atd-toolbox/data_model/python/sql_templates/recommendations_and_notes_up.sql
+++ b/atd-toolbox/data_model/python/sql_templates/recommendations_and_notes_up.sql
@@ -4,7 +4,11 @@ alter table recommendations
     add column crash_id integer,
     add constraint recommendations_crashes_id_fkey foreign key (
         crash_id
-    ) references crashes (id);
+    ) references crashes (id),
+    drop constraint recommendations_crash_id_key,
+    add constraint recommendations_crash_id_key unique (crash_id),
+    alter column atd_txdot_crashes_crash_id drop not null;
+;
 
 alter table crash_notes rename column crash_id to atd_txdot_crashes_crash_id;
 
@@ -12,4 +16,6 @@ alter table crash_notes
     add column crash_id integer,
     add constraint notes_crashes_id_fkey foreign key (
         crash_id
-    ) references crashes (id);
+    ) references crashes (id),
+    alter column atd_txdot_crashes_crash_id drop not null;
+;

--- a/atd-toolbox/data_model/python/sql_templates/recommendations_and_notes_up.sql
+++ b/atd-toolbox/data_model/python/sql_templates/recommendations_and_notes_up.sql
@@ -1,0 +1,15 @@
+alter table recommendations rename column crash_id to atd_txdot_crashes_crash_id;
+
+alter table recommendations
+    add column crash_id integer,
+    add constraint recommendations_crashes_id_fkey foreign key (
+        crash_id
+    ) references crashes (id);
+
+alter table crash_notes rename column crash_id to atd_txdot_crashes_crash_id;
+
+alter table crash_notes
+    add column crash_id integer,
+    add constraint notes_crashes_id_fkey foreign key (
+        crash_id
+    ) references crashes (id);

--- a/atd-vzd/metadata/databases/default/tables/public_atd_txdot_crashes.yaml
+++ b/atd-vzd/metadata/databases/default/tables/public_atd_txdot_crashes.yaml
@@ -96,7 +96,7 @@ array_relationships:
   - name: crash_notes
     using:
       foreign_key_constraint_on:
-        column: crash_id
+        column: atd_txdot_crashes_crash_id
         table:
           name: crash_notes
           schema: public

--- a/atd-vzd/metadata/databases/default/tables/public_crash_notes.yaml
+++ b/atd-vzd/metadata/databases/default/tables/public_crash_notes.yaml
@@ -2,7 +2,7 @@ table:
   name: crash_notes
   schema: public
 object_relationships:
-  - name: atd_txdot_crash
+  - name: crash
     using:
       foreign_key_constraint_on: crash_id
 insert_permissions:

--- a/atd-vzd/metadata/databases/default/tables/public_crashes.yaml
+++ b/atd-vzd/metadata/databases/default/tables/public_crashes.yaml
@@ -26,6 +26,13 @@ object_relationships:
         remote_table:
           name: crashes_list_view
           schema: public
+  - name: recommendation
+    using:
+      foreign_key_constraint_on:
+        column: crash_id
+        table:
+          name: recommendations
+          schema: public
 array_relationships:
   - name: change_logs
     using:
@@ -44,6 +51,13 @@ array_relationships:
         insertion_order: null
         remote_table:
           name: charges_cris
+          schema: public
+  - name: crash_notes
+    using:
+      foreign_key_constraint_on:
+        column: crash_id
+        table:
+          name: crash_notes
           schema: public
   - name: people_list_view
     using:

--- a/atd-vzd/metadata/databases/default/tables/public_recommendations.yaml
+++ b/atd-vzd/metadata/databases/default/tables/public_recommendations.yaml
@@ -5,7 +5,7 @@ object_relationships:
   - name: atd__recommendation_status_lkp
     using:
       foreign_key_constraint_on: recommendation_status_id
-  - name: atd_txdot_crash
+  - name: crash
     using:
       foreign_key_constraint_on: crash_id
 array_relationships:

--- a/atd-vzd/migrations/default/1715960023005_update_recommendations_and_notes_fks/down.sql
+++ b/atd-vzd/migrations/default/1715960023005_update_recommendations_and_notes_fks/down.sql
@@ -1,6 +1,10 @@
 alter table recommendations drop column crash_id;
 alter table recommendations rename column atd_txdot_crashes_crash_id to crash_id;
+alter table recommendations add constraint recommendations_crash_id_key unique (crash_id);
+delete from recommendations where crash_id is null;
+alter table recommendations alter column crash_id set not null;
 
 alter table crash_notes drop column crash_id;
 alter table crash_notes rename column atd_txdot_crashes_crash_id to crash_id;
-
+delete from crash_notes where crash_id is null;
+alter table crash_notes alter column crash_id set not null;

--- a/atd-vzd/migrations/default/1715960023005_update_recommendations_and_notes_fks/down.sql
+++ b/atd-vzd/migrations/default/1715960023005_update_recommendations_and_notes_fks/down.sql
@@ -1,0 +1,6 @@
+alter table recommendations drop column crash_id;
+alter table recommendations rename column atd_txdot_crashes_crash_id to crash_id;
+
+alter table crash_notes drop column crash_id;
+alter table crash_notes rename column atd_txdot_crashes_crash_id to crash_id;
+

--- a/atd-vzd/migrations/default/1715960023005_update_recommendations_and_notes_fks/up.sql
+++ b/atd-vzd/migrations/default/1715960023005_update_recommendations_and_notes_fks/up.sql
@@ -1,0 +1,16 @@
+alter table recommendations rename column crash_id to atd_txdot_crashes_crash_id;
+
+alter table recommendations
+    add column crash_id integer,
+    add constraint recommendations_crashes_id_fkey foreign key (
+        crash_id
+    ) references crashes (id);
+
+alter table crash_notes rename column crash_id to atd_txdot_crashes_crash_id;
+
+alter table crash_notes
+    add column crash_id integer,
+    add constraint notes_crashes_id_fkey foreign key (
+        crash_id
+    ) references crashes (id);
+

--- a/atd-vzd/migrations/default/1715960023005_update_recommendations_and_notes_fks/up.sql
+++ b/atd-vzd/migrations/default/1715960023005_update_recommendations_and_notes_fks/up.sql
@@ -4,7 +4,9 @@ alter table recommendations
     add column crash_id integer,
     add constraint recommendations_crashes_id_fkey foreign key (
         crash_id
-    ) references crashes (id);
+    ) references crashes (id),
+    drop constraint recommendations_crash_id_key,
+    add constraint recommendations_crash_id_key unique (crash_id);
 
 alter table crash_notes rename column crash_id to atd_txdot_crashes_crash_id;
 

--- a/atd-vzd/migrations/default/1715960023005_update_recommendations_and_notes_fks/up.sql
+++ b/atd-vzd/migrations/default/1715960023005_update_recommendations_and_notes_fks/up.sql
@@ -6,7 +6,9 @@ alter table recommendations
         crash_id
     ) references crashes (id),
     drop constraint recommendations_crash_id_key,
-    add constraint recommendations_crash_id_key unique (crash_id);
+    add constraint recommendations_crash_id_key unique (crash_id),
+    alter column atd_txdot_crashes_crash_id drop not null;
+;
 
 alter table crash_notes rename column crash_id to atd_txdot_crashes_crash_id;
 
@@ -14,5 +16,6 @@ alter table crash_notes
     add column crash_id integer,
     add constraint notes_crashes_id_fkey foreign key (
         crash_id
-    ) references crashes (id);
-
+    ) references crashes (id),
+    alter column atd_txdot_crashes_crash_id drop not null;
+;

--- a/atd-vze/src/Components/Notes/Notes.js
+++ b/atd-vze/src/Components/Notes/Notes.js
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { useQuery, useMutation } from "@apollo/react-hooks";
+import { useMutation } from "@apollo/react-hooks";
 import {
   Card,
   CardHeader,

--- a/atd-vze/src/queries/crashNotes.js
+++ b/atd-vze/src/queries/crashNotes.js
@@ -1,26 +1,9 @@
 import { gql } from "apollo-boost";
 
-export const GET_NOTES = gql`
-  query FindNotes($recordId: Int) {
-    crash_notes(
-      where: { crash_id: { _eq: $recordId } }
-      order_by: { date: desc }
-    ) {
-      id
-      created_at
-      updated_at
-      date
-      text
-      user_email
-      crash_id
-    }
-  }
-`;
-
 export const INSERT_NOTE = gql`
-  mutation InsertNote($note: String!, $recordId: Int!, $userEmail: String) {
+  mutation InsertNote($note: String!, $crashPk: Int!, $userEmail: String) {
     insert_crash_notes(
-      objects: { text: $note, crash_id: $recordId, user_email: $userEmail }
+      objects: { text: $note, crash_id: $crashPk, user_email: $userEmail }
     ) {
       returning {
         crash_id

--- a/atd-vze/src/queries/crashes.js
+++ b/atd-vze/src/queries/crashes.js
@@ -265,6 +265,35 @@ export const GET_CRASH = gql`
         record_type
         record_json
       }
+      recommendation {
+        id
+        created_at
+        rec_text
+        created_by
+        crash_id
+        rec_update
+        atd__recommendation_status_lkp {
+          rec_status_desc
+        }
+        recommendations_partners {
+          id
+          partner_id
+          recommendation_id
+          atd__coordination_partners_lkp {
+            id
+            coord_partner_desc
+          }
+        }
+      }
+      crash_notes(order_by: { date: desc }) {
+        id
+        created_at
+        updated_at
+        date
+        text
+        user_email
+        crash_id
+      }
     }
   }
 `;

--- a/atd-vze/src/queries/recommendations.js
+++ b/atd-vze/src/queries/recommendations.js
@@ -1,27 +1,7 @@
 import { gql } from "apollo-boost";
 
-export const GET_RECOMMENDATIONS = gql`
-  query FindRecommendations($crashId: Int) {
-    recommendations(where: { crash_id: { _eq: $crashId } }) {
-      id
-      created_at
-      rec_text
-      created_by
-      crash_id
-      rec_update
-      atd__recommendation_status_lkp {
-        rec_status_desc
-      }
-      recommendations_partners {
-        id
-        partner_id
-        recommendation_id
-        atd__coordination_partners_lkp {
-          id
-          coord_partner_desc
-        }
-      }
-    }
+export const GET_RECOMMENDATION_LOOKUPS = gql`
+  query FindRecommendationLookups {
     atd__coordination_partners_lkp(order_by: { coord_partner_desc: asc }) {
       id
       coord_partner_desc
@@ -37,7 +17,7 @@ export const INSERT_RECOMMENDATION = gql`
   mutation InsertRecommendation(
     $text: String
     $update: String
-    $crashId: Int
+    $crashPk: Int
     $userEmail: String
     $recommendation_status_id: Int
     $partner_id: Int
@@ -46,7 +26,7 @@ export const INSERT_RECOMMENDATION = gql`
       objects: {
         rec_text: $text
         rec_update: $update
-        crash_id: $crashId
+        crash_id: $crashPk
         created_by: $userEmail
         recommendation_status_id: $recommendation_status_id
         recommendations_partners: { data: { partner_id: $partner_id } }

--- a/atd-vze/src/views/Crashes/Crash.js
+++ b/atd-vze/src/views/Crashes/Crash.js
@@ -37,7 +37,6 @@ import "./crash.scss";
 
 import { GET_CRASH_OLD, UPDATE_CRASH, GET_CRASH } from "../../queries/crashes";
 import {
-  GET_NOTES,
   INSERT_NOTE,
   UPDATE_NOTE,
   DELETE_NOTE,
@@ -63,11 +62,6 @@ function Crash(props) {
 
   const { getRoles } = useAuth0();
   const roles = getRoles();
-
-  const isCrashFatal =
-    data?.atd_txdot_crashes?.[0]?.atd_fatality_count > 0 ? true : false;
-  const shouldShowFatalityRecommendations =
-    (isAdmin(roles) || isItSupervisor(roles)) && isCrashFatal;
 
   if (loading || crashLoading) return "Loading...";
   if (crashError) return `Error! ${crashError.message}`;
@@ -125,9 +119,13 @@ function Crash(props) {
     latitude,
     longitude,
     location_id: locationId,
-  } = crashRecord.crash;
+  } = crashRecord?.crash;
 
-  const hasLocation = crashRecord.crash["location_id"];
+  const isCrashFatal = deathCount > 0 ? true : false;
+  const shouldShowFatalityRecommendations =
+    (isAdmin(roles) || isItSupervisor(roles)) && isCrashFatal;
+
+  const hasLocation = crashRecord?.crash["location_id"];
   const hasCoordinates = !!latitude && !!longitude;
 
   return !crashData ? (
@@ -253,34 +251,39 @@ function Crash(props) {
       <Row>
         <Col>
           <UnitDetailsCard
-            data={crashRecord.crash.units}
+            data={crashRecord?.crash?.units}
             refetch={crashRefetch}
             {...props}
           />
           <PeopleDetailsCard
-            data={crashRecord.crash.people_list_view}
+            data={crashRecord?.crash?.people_list_view}
             refetch={crashRefetch}
             {...props}
           />
-          <ChargesDetailsCard data={crashRecord.crash.charges_cris} />
+          <ChargesDetailsCard data={crashRecord?.crash?.charges_cris} />
         </Col>
       </Row>
       {shouldShowFatalityRecommendations && (
         <Row>
           <Col>
-            <Recommendations crashId={props.match.params.id} />
+            <Recommendations
+              crashPk={crashPk}
+              recommendation={crashRecord?.crash?.recommendation}
+              refetch={crashRefetch}
+            />
           </Col>
         </Row>
       )}
       <Row>
         <Col>
           <Notes
-            recordId={props.match.params.id}
+            crashPk={crashPk}
             tableName={"crash_notes"}
-            GET_NOTES={GET_NOTES}
+            notes={crashRecord?.crash?.crash_notes}
             INSERT_NOTE={INSERT_NOTE}
             UPDATE_NOTE={UPDATE_NOTE}
             DELETE_NOTE={DELETE_NOTE}
+            refetch={crashRefetch}
           />
         </Col>
       </Row>

--- a/atd-vze/src/views/Crashes/Recommendations/Recommendations.js
+++ b/atd-vze/src/views/Crashes/Recommendations/Recommendations.js
@@ -3,7 +3,7 @@ import { useQuery, useMutation } from "@apollo/react-hooks";
 import { Card, CardHeader, CardBody, CardFooter } from "reactstrap";
 import { recommendationsDataMap } from "./recommendationsDataMap";
 import {
-  GET_RECOMMENDATIONS,
+  GET_RECOMMENDATION_LOOKUPS,
   INSERT_RECOMMENDATION,
   INSERT_RECOMMENDATION_PARTNER,
   REMOVE_RECOMMENDATION_PARTNER,
@@ -13,14 +13,12 @@ import RecommendationTextInput from "./RecommendationTextInput";
 import RecommendationSelectValueDropdown from "./RecommendationSelectValueDropdown";
 import RecommendationMultipleSelectDropdown from "./RecommendationMultipleSelectDropdown";
 
-const Recommendations = ({ crashId }) => {
+const Recommendations = ({ crashPk, recommendation, refetch }) => {
   // get current users email
   const userEmail = localStorage.getItem("hasura_user_email");
 
   // fetch recommendation table from database using graphQL query
-  const { loading, error, data, refetch } = useQuery(GET_RECOMMENDATIONS, {
-    variables: { crashId },
-  });
+  const { loading, error, data } = useQuery(GET_RECOMMENDATION_LOOKUPS);
 
   // declare mutation functions
   const [addRecommendation] = useMutation(INSERT_RECOMMENDATION);
@@ -32,7 +30,6 @@ const Recommendations = ({ crashId }) => {
   if (error) return `Error! ${error.message}`;
 
   const fieldConfig = recommendationsDataMap;
-  const recommendation = data?.recommendations?.[0];
   const partners = recommendation?.recommendations_partners;
   const doesRecommendationRecordExist = recommendation ? true : false;
   const recommendationRecordId = recommendation?.id;
@@ -47,7 +44,7 @@ const Recommendations = ({ crashId }) => {
 
   const onAdd = valuesObject => {
     const recommendationRecord = {
-      crashId,
+      crashPk,
       userEmail,
       ...valuesObject,
     };


### PR DESCRIPTION
## Associated issues
Closes https://github.com/cityofaustin/atd-data-tech/issues/18045

## Testing
**URL to test:** <!-- VZ URL or Netlify -->
1. Check out this branch and follow instructions in https://github.com/cityofaustin/atd-vz-data/pull/1440 to start the data model, apply migrations and run the CRIS import ETL
2. You will need to open up your hasura console or whatever database tool you prefer. Go to the `recommendations` table, find a recommendation. Copy the `atd_txdot_crashes_crash_id`. In the `crashes` table use that to find the `id` pkey for that crash, copy that. Now in the recommendations table edit the record and put the `id` pkey for the crash in the `crash_id` column of the recommendation.
3. Now in the VZE go to that crash, you should see the recommendation pop up for it now. Test editing diff parts of the recommendation.
4. Now create some new notes for the crash and edit/delete them.
5. You can also do the same thing you did in steps 2-3 but for a note.

Sorry these test instructions are weird, just wanted to get this PR aligned as much as possible with the new data model so that next we will just backfill the notes/recommendations with the correct `id` pkey in the `crash_id` column and then will be able to delete the `atd_txdot_crashes_crash_id` we have here all together.

**Steps to test:**


---
#### Ship list
- [ ] Check migrations for any conflicts with latest migrations in master branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved