### PR TITLE
Organize 1PW entries for outgoing CRIS import script

### DIFF
--- a/atd-etl/cris_import/cris_import.py
+++ b/atd-etl/cris_import/cris_import.py
@@ -103,7 +103,8 @@ def main():
             align_records_token = align_records(typed_token)
             clean_up_import_schema(align_records_token)
         mark_extract_as_imported(archive_id)
-        move_extract_into_processed(filename_in_s3)
+        if not local_mode:
+            move_extract_into_processed(filename_in_s3)
 
 
 def move_extract_into_processed(extract):

--- a/atd-etl/cris_import/cris_import.py
+++ b/atd-etl/cris_import/cris_import.py
@@ -39,7 +39,6 @@ def main():
     secrets = get_secrets()
 
     # 😢 why not `global variable = value`??
-    global SFTP_ENDPOINT
     global ZIP_PASSWORD
 
     global AWS_ACCESS_KEY_ID
@@ -63,7 +62,6 @@ def main():
 
     global S3_EXTRACT_BUCKET
 
-    SFTP_ENDPOINT = secrets["SFTP_endpoint"]
     ZIP_PASSWORD = secrets["archive_extract_password"]
 
     AWS_ACCESS_KEY_ID = secrets["aws_access_key"]
@@ -179,11 +177,6 @@ def mark_extract_as_imported(id):
 
 def get_secrets():
     REQUIRED_SECRETS = {
-        "SFTP_endpoint": {
-            "opitem": "Vision Zero CRIS Import",
-            "opfield": f"Common.SFTP Endpoint",
-            "opvault": VAULT_ID,
-        },
         "sftp_endpoint_private_key": {
             "opitem": "SFTP Endpoint Key",
             "opfield": ".private key",

--- a/atd-etl/cris_import/cris_import.py
+++ b/atd-etl/cris_import/cris_import.py
@@ -190,6 +190,11 @@ def get_secrets():
             "opfield": f"{DEPLOYMENT_ENVIRONMENT}.ssh Username",
             "opvault": VAULT_ID,
         },
+        "database_host": {
+            "opitem": "Vision Zero Database",
+            "opfield": f"{DEPLOYMENT_ENVIRONMENT}.Database Host",
+            "opvault": VAULT_ID,
+        },
         "database_username": {
             "opitem": "Vision Zero Database",
             "opfield": f"{DEPLOYMENT_ENVIRONMENT}.Database Username",

--- a/atd-etl/cris_import/cris_import.py
+++ b/atd-etl/cris_import/cris_import.py
@@ -38,7 +38,6 @@ VAULT_ID = os.getenv("OP_VAULT_ID")
 def main():
     secrets = get_secrets()
 
-    # 😢 why not `global variable = value`??
     global ZIP_PASSWORD
 
     global AWS_ACCESS_KEY_ID

--- a/atd-etl/cris_import/cris_import.py
+++ b/atd-etl/cris_import/cris_import.py
@@ -42,7 +42,6 @@ def main():
 
     global AWS_ACCESS_KEY_ID
     global AWS_SECRET_ACCESS_KEY
-    global AWS_CSV_ARCHIVE_PATH
 
     global DB_HOST
     global DB_USER
@@ -64,7 +63,6 @@ def main():
 
     AWS_ACCESS_KEY_ID = secrets["aws_access_key"]
     AWS_SECRET_ACCESS_KEY = secrets["aws_secret_key"]
-    AWS_CSV_ARCHIVE_PATH = secrets["s3_archive_path"]
 
     DB_HOST = secrets["database_host"]
     DB_USER = secrets["database_username"]
@@ -227,11 +225,6 @@ def get_secrets():
         "aws_secret_key": {
             "opitem": "Vision Zero CRIS Import",
             "opfield": f"{DEPLOYMENT_ENVIRONMENT}.AWS Secret key",
-            "opvault": VAULT_ID,
-        },
-        "s3_archive_path": {
-            "opitem": "Vision Zero CRIS Import",
-            "opfield": f"{DEPLOYMENT_ENVIRONMENT}.S3 Archive Path",
             "opvault": VAULT_ID,
         },
         "graphql_endpoint": {

--- a/atd-etl/cris_import/cris_import.py
+++ b/atd-etl/cris_import/cris_import.py
@@ -43,7 +43,6 @@ def main():
     global AWS_ACCESS_KEY_ID
     global AWS_SECRET_ACCESS_KEY
 
-    global DB_HOST
     global DB_USER
     global DB_PASS
     global DB_NAME
@@ -64,7 +63,6 @@ def main():
     AWS_ACCESS_KEY_ID = secrets["aws_access_key"]
     AWS_SECRET_ACCESS_KEY = secrets["aws_secret_key"]
 
-    DB_HOST = secrets["database_host"]
     DB_USER = secrets["database_username"]
     DB_PASS = secrets["database_password"]
     DB_NAME = secrets["database_name"]
@@ -190,11 +188,6 @@ def get_secrets():
         "bastion_ssh_username": {
             "opitem": "RDS Bastion Host",
             "opfield": f"{DEPLOYMENT_ENVIRONMENT}.ssh Username",
-            "opvault": VAULT_ID,
-        },
-        "database_host": {
-            "opitem": "Vision Zero Database",
-            "opfield": f"{DEPLOYMENT_ENVIRONMENT}.Database Host",
             "opvault": VAULT_ID,
         },
         "database_username": {

--- a/atd-etl/cris_import/cris_import.py
+++ b/atd-etl/cris_import/cris_import.py
@@ -43,7 +43,6 @@ def main():
 
     global AWS_ACCESS_KEY_ID
     global AWS_SECRET_ACCESS_KEY
-    global AWS_CSV_ARCHIVE_BUCKET_NAME
     global AWS_CSV_ARCHIVE_PATH
 
     global DB_HOST
@@ -66,7 +65,6 @@ def main():
 
     AWS_ACCESS_KEY_ID = secrets["aws_access_key"]
     AWS_SECRET_ACCESS_KEY = secrets["aws_secret_key"]
-    AWS_CSV_ARCHIVE_BUCKET_NAME = secrets["s3_archive_bucket_name"]
     AWS_CSV_ARCHIVE_PATH = secrets["s3_archive_path"]
 
     DB_HOST = secrets["database_host"]
@@ -230,11 +228,6 @@ def get_secrets():
         "aws_secret_key": {
             "opitem": "Vision Zero CRIS Import",
             "opfield": f"{DEPLOYMENT_ENVIRONMENT}.AWS Secret key",
-            "opvault": VAULT_ID,
-        },
-        "s3_archive_bucket_name": {
-            "opitem": "Vision Zero CRIS Import",
-            "opfield": f"{DEPLOYMENT_ENVIRONMENT}.S3 Archive Bucket Name",
             "opvault": VAULT_ID,
         },
         "s3_archive_path": {


### PR DESCRIPTION
## Associated issues

This PR is part of the solution for https://github.com/cityofaustin/atd-data-tech/issues/17321. 

## Additional Changes

I believe this must be the first time we've used this script in a local development context since the recent PR #1445 which broke the local testing mechanism. This PR restores that functionality.

## Testing


* Fire up your local database
* Drop in a test extract from CRIS into `atd-etl/cris_import/development_extracts`. PM me, I'll wormhole you one if you'd like.
* `cd` into `atd-etl/cris_import`
* Ensure you have a `env` filled out with the 1PW trio (`OP_API_TOKEN`, `OP_CONNECT`, and `OP_VAULT_ID`). The new server's hostname is `https://coa.1password.austinmobility.io`.
* `docker compose run cris-import`
* Did the import run successfully?

## Post Merge
* Remove the following entries:
  * `Vision Zero CRIS Import.Common.SFTP Endpoint`
  * `Vision Zero CRIS Import.{DEPLOYMENT_ENVIRONMENT}.S3 Archive Bucket Name`
  * `Vision Zero CRIS Import.{DEPLOYMENT_ENVIRONMENT}.S3 Archive Path`


---
#### Ship list
- [ ] Code reviewed
- [ ] Product manager approved