### PR TITLE
 Ability to view temp records in the crashes list and also soft-delete them

### DIFF
--- a/atd-toolbox/data_model/python/sql_templates/crashes_list_view.sql
+++ b/atd-toolbox/data_model/python/sql_templates/crashes_list_view.sql
@@ -173,6 +173,7 @@ create or replace view person_injury_metrics_view as (
     left join
         public.crashes as crashes
         on units.crash_id = crashes.id
+    where people.is_deleted = false
 );
 
 create or replace view unit_injury_metrics_view as
@@ -215,6 +216,7 @@ create or replace view unit_injury_metrics_view as
     left join
         person_injury_metrics_view
         on units.id = person_injury_metrics_view.unit_id
+    where units.is_deleted = false
     group by
         units.id
 );
@@ -320,6 +322,7 @@ create or replace view crash_injury_metrics_view as
     left join
         person_injury_metrics_view
         on crashes.id = person_injury_metrics_view.crash_id
+    where crashes.is_deleted = false
     group by
         crashes.id,
         crashes.crash_id
@@ -562,7 +565,7 @@ left join lateral (
 left join
     lookups.collsn_lkp
     on public.crashes.fhe_collsn_id = lookups.collsn_lkp.id
-where crashes.crash_timestamp >= (now() - '5 years'::interval)::date
+where crashes.is_deleted = false and crashes.crash_timestamp >= (now() - '5 years'::interval)::date
 union all
 select
     aab.form_id as crash_id,

--- a/atd-toolbox/data_model/python/sql_templates/crashes_list_view.sql
+++ b/atd-toolbox/data_model/python/sql_templates/crashes_list_view.sql
@@ -419,6 +419,7 @@ left join
 left join
     lookups.injry_sev_lkp
     on lookups.injry_sev_lkp.id = crash_injury_metrics_view.crash_injry_sev_id
+where crashes.is_deleted = false
 order by id asc;
 
 create view locations_list_view as (

--- a/atd-toolbox/data_model/python/sql_templates/fatalities_view.sql
+++ b/atd-toolbox/data_model/python/sql_templates/fatalities_view.sql
@@ -11,6 +11,7 @@ select
 people.id as person_id,
 crashes.id as crash_id,
 crashes.crash_id as cris_crash_id,
+crashes.record_locator,
 units.id as unit_id,
 CONCAT_WS(' ', people.prsn_first_name, people.prsn_mid_name, people.prsn_last_name) as victim_name,
 TO_CHAR(crashes.crash_timestamp at time zone 'US/Central', 'yyyy') AS year,
@@ -48,4 +49,4 @@ crashes.engineering_area
     people 
   left join units on people.unit_id = units.id
   left join crashes on units.crash_id = crashes.id
-where crashes.in_austin_full_purpose = true AND people.prsn_injry_sev_id = 4 AND crashes.private_dr_fl = false;
+where crashes.in_austin_full_purpose = true AND people.prsn_injry_sev_id = 4 AND crashes.private_dr_fl = false AND crashes.is_deleted = false;

--- a/atd-vzd/metadata/databases/default/tables/public_crashes_cris.yaml
+++ b/atd-vzd/metadata/databases/default/tables/public_crashes_cris.yaml
@@ -290,3 +290,20 @@ select_permissions:
         - wthr_cond_id
       filter: {}
     comment: ""
+update_permissions:
+  - role: editor
+    permission:
+      columns:
+        - is_deleted
+        - updated_by
+      filter: {}
+      check: {}
+    comment: ""
+  - role: vz-admin
+    permission:
+      columns:
+        - is_deleted
+        - updated_by
+      filter: {}
+      check: {}
+    comment: ""

--- a/atd-vzd/metadata/databases/default/tables/public_crashes_cris.yaml
+++ b/atd-vzd/metadata/databases/default/tables/public_crashes_cris.yaml
@@ -53,63 +53,6 @@ array_relationships:
           name: units_edits
           schema: public
 insert_permissions:
-  - role: editor
-    permission:
-      check: {}
-      columns:
-        - active_school_zone_fl
-        - at_intrsct_fl
-        - case_id
-        - crash_speed_limit
-        - crash_timestamp
-        - created_by
-        - cris_schema_version
-        - fhe_collsn_id
-        - intrsct_relat_id
-        - investigat_agency_id
-        - investigator_narrative
-        - is_temp_record
-        - latitude
-        - light_cond_id
-        - longitude
-        - medical_advisory_fl
-        - obj_struck_id
-        - onsys_fl
-        - private_dr_fl
-        - road_constr_zone_fl
-        - road_constr_zone_wrkr_fl
-        - rpt_block_num
-        - rpt_city_id
-        - rpt_cris_cnty_id
-        - rpt_hwy_num
-        - rpt_rdwy_sys_id
-        - rpt_ref_mark_dir
-        - rpt_ref_mark_dist_uom
-        - rpt_ref_mark_offset_amt
-        - rpt_road_part_id
-        - rpt_sec_block_num
-        - rpt_sec_hwy_num
-        - rpt_sec_rdwy_sys_id
-        - rpt_sec_road_part_id
-        - rpt_sec_street_desc
-        - rpt_sec_street_name
-        - rpt_sec_street_pfx
-        - rpt_sec_street_sfx
-        - rpt_street_desc
-        - rpt_street_name
-        - rpt_street_pfx
-        - rpt_street_sfx
-        - rr_relat_fl
-        - schl_bus_fl
-        - surf_cond_id
-        - surf_type_id
-        - thousand_damage_fl
-        - toll_road_fl
-        - traffic_cntl_id
-        - txdot_rptable_fl
-        - updated_by
-        - wthr_cond_id
-    comment: ""
   - role: vz-admin
     permission:
       check: {}
@@ -168,67 +111,6 @@ insert_permissions:
         - wthr_cond_id
     comment: ""
 select_permissions:
-  - role: editor
-    permission:
-      columns:
-        - active_school_zone_fl
-        - at_intrsct_fl
-        - case_id
-        - crash_id
-        - crash_speed_limit
-        - crash_timestamp
-        - created_at
-        - created_by
-        - cris_schema_version
-        - fhe_collsn_id
-        - id
-        - intrsct_relat_id
-        - investigat_agency_id
-        - investigator_narrative
-        - is_temp_record
-        - latitude
-        - light_cond_id
-        - longitude
-        - medical_advisory_fl
-        - obj_struck_id
-        - onsys_fl
-        - private_dr_fl
-        - road_constr_zone_fl
-        - road_constr_zone_wrkr_fl
-        - rpt_block_num
-        - rpt_city_id
-        - rpt_cris_cnty_id
-        - rpt_hwy_num
-        - rpt_rdwy_sys_id
-        - rpt_ref_mark_dir
-        - rpt_ref_mark_dist_uom
-        - rpt_ref_mark_offset_amt
-        - rpt_road_part_id
-        - rpt_sec_block_num
-        - rpt_sec_hwy_num
-        - rpt_sec_rdwy_sys_id
-        - rpt_sec_road_part_id
-        - rpt_sec_street_desc
-        - rpt_sec_street_name
-        - rpt_sec_street_pfx
-        - rpt_sec_street_sfx
-        - rpt_street_desc
-        - rpt_street_name
-        - rpt_street_pfx
-        - rpt_street_sfx
-        - rr_relat_fl
-        - schl_bus_fl
-        - surf_cond_id
-        - surf_type_id
-        - thousand_damage_fl
-        - toll_road_fl
-        - traffic_cntl_id
-        - txdot_rptable_fl
-        - updated_at
-        - updated_by
-        - wthr_cond_id
-      filter: {}
-    comment: ""
   - role: vz-admin
     permission:
       columns:
@@ -291,14 +173,6 @@ select_permissions:
       filter: {}
     comment: ""
 update_permissions:
-  - role: editor
-    permission:
-      columns:
-        - is_deleted
-        - updated_by
-      filter: {}
-      check: {}
-    comment: ""
   - role: vz-admin
     permission:
       columns:

--- a/atd-vzd/metadata/databases/default/tables/public_crashes_list_view.yaml
+++ b/atd-vzd/metadata/databases/default/tables/public_crashes_list_view.yaml
@@ -48,7 +48,6 @@ select_permissions:
         - in_austin_full_purpose
         - intrsct_relat_id
         - is_manual_geocode
-        - is_temp_record
         - latitude
         - law_enf_fatality_count
         - light_cond_id
@@ -109,7 +108,6 @@ select_permissions:
         - in_austin_full_purpose
         - intrsct_relat_id
         - is_manual_geocode
-        - is_temp_record
         - latitude
         - law_enf_fatality_count
         - light_cond_id
@@ -163,7 +161,6 @@ select_permissions:
         - has_no_cris_coordinates
         - in_austin_full_purpose
         - is_manual_geocode
-        - is_temp_record
         - onsys_fl
         - private_dr_fl
         - road_constr_zone_fl

--- a/atd-vzd/metadata/databases/default/tables/public_crashes_list_view.yaml
+++ b/atd-vzd/metadata/databases/default/tables/public_crashes_list_view.yaml
@@ -25,50 +25,43 @@ select_permissions:
   - role: editor
     permission:
       columns:
-        - cris_fatality_count
-        - fatality_count
-        - law_enf_fatality_count
-        - nonincap_injry_count
-        - non_injry_count
-        - poss_injry_count
-        - sus_serious_injry_count
-        - unkn_injry_count
-        - vz_fatality_count
-        - years_of_life_lost
         - active_school_zone_fl
-        - at_intrsct_fl
-        - has_no_cris_coordinates
-        - in_austin_full_purpose
-        - is_manual_geocode
-        - onsys_fl
-        - private_dr_fl
-        - road_constr_zone_fl
-        - rr_relat_fl
-        - schl_bus_fl
-        - toll_road_fl
-        - council_district
-        - crash_id
-        - crash_injry_sev_id
-        - crash_speed_limit
-        - est_comp_cost_crash_based
-        - id
-        - intrsct_relat_id
-        - light_cond_id
-        - obj_struck_id
-        - traffic_cntl_id
-        - wthr_cond_id
-        - latitude
-        - longitude
         - address_primary
         - address_secondary
+        - at_intrsct_fl
         - case_id
         - collsn_desc
+        - council_district
         - crash_date_ct
         - crash_day_of_week
+        - crash_id
         - crash_injry_sev_desc
+        - crash_injry_sev_id
+        - crash_speed_limit
         - crash_time_ct
+        - crash_timestamp
+        - cris_fatality_count
+        - est_comp_cost_crash_based
+        - fatality_count
+        - has_no_cris_coordinates
+        - id
+        - in_austin_full_purpose
+        - intrsct_relat_id
+        - is_manual_geocode
+        - is_temp_record
+        - latitude
+        - law_enf_fatality_count
+        - light_cond_id
         - location_id
+        - longitude
+        - non_injry_count
+        - nonincap_injry_count
+        - obj_struck_id
+        - onsys_fl
+        - poss_injry_count
+        - private_dr_fl
         - record_locator
+        - road_constr_zone_fl
         - rpt_block_num
         - rpt_sec_block_num
         - rpt_sec_street_name
@@ -77,57 +70,59 @@ select_permissions:
         - rpt_street_name
         - rpt_street_pfx
         - rpt_street_sfx
-        - crash_timestamp
+        - rr_relat_fl
+        - schl_bus_fl
+        - sus_serious_injry_count
+        - toll_road_fl
+        - tot_injry_count
+        - traffic_cntl_id
+        - unkn_injry_count
+        - vz_fatality_count
+        - wthr_cond_id
+        - years_of_life_lost
       filter: {}
       allow_aggregations: true
     comment: ""
   - role: readonly
     permission:
       columns:
-        - cris_fatality_count
-        - fatality_count
-        - law_enf_fatality_count
-        - nonincap_injry_count
-        - non_injry_count
-        - poss_injry_count
-        - sus_serious_injry_count
-        - unkn_injry_count
-        - vz_fatality_count
-        - years_of_life_lost
         - active_school_zone_fl
-        - at_intrsct_fl
-        - has_no_cris_coordinates
-        - in_austin_full_purpose
-        - is_manual_geocode
-        - onsys_fl
-        - private_dr_fl
-        - road_constr_zone_fl
-        - rr_relat_fl
-        - schl_bus_fl
-        - toll_road_fl
-        - council_district
-        - crash_id
-        - crash_injry_sev_id
-        - crash_speed_limit
-        - est_comp_cost_crash_based
-        - id
-        - intrsct_relat_id
-        - light_cond_id
-        - obj_struck_id
-        - traffic_cntl_id
-        - wthr_cond_id
-        - latitude
-        - longitude
         - address_primary
         - address_secondary
+        - at_intrsct_fl
         - case_id
         - collsn_desc
+        - council_district
         - crash_date_ct
         - crash_day_of_week
+        - crash_id
         - crash_injry_sev_desc
+        - crash_injry_sev_id
+        - crash_speed_limit
         - crash_time_ct
+        - crash_timestamp
+        - cris_fatality_count
+        - est_comp_cost_crash_based
+        - fatality_count
+        - has_no_cris_coordinates
+        - id
+        - in_austin_full_purpose
+        - intrsct_relat_id
+        - is_manual_geocode
+        - is_temp_record
+        - latitude
+        - law_enf_fatality_count
+        - light_cond_id
         - location_id
+        - longitude
+        - non_injry_count
+        - nonincap_injry_count
+        - obj_struck_id
+        - onsys_fl
+        - poss_injry_count
+        - private_dr_fl
         - record_locator
+        - road_constr_zone_fl
         - rpt_block_num
         - rpt_sec_block_num
         - rpt_sec_street_name
@@ -136,7 +131,16 @@ select_permissions:
         - rpt_street_name
         - rpt_street_pfx
         - rpt_street_sfx
-        - crash_timestamp
+        - rr_relat_fl
+        - schl_bus_fl
+        - sus_serious_injry_count
+        - toll_road_fl
+        - tot_injry_count
+        - traffic_cntl_id
+        - unkn_injry_count
+        - vz_fatality_count
+        - wthr_cond_id
+        - years_of_life_lost
       filter: {}
       allow_aggregations: true
     comment: ""
@@ -150,6 +154,7 @@ select_permissions:
         - non_injry_count
         - poss_injry_count
         - sus_serious_injry_count
+        - tot_injry_count
         - unkn_injry_count
         - vz_fatality_count
         - years_of_life_lost
@@ -158,6 +163,7 @@ select_permissions:
         - has_no_cris_coordinates
         - in_austin_full_purpose
         - is_manual_geocode
+        - is_temp_record
         - onsys_fl
         - private_dr_fl
         - road_constr_zone_fl

--- a/atd-vzd/metadata/databases/default/tables/public_fatalities_view.yaml
+++ b/atd-vzd/metadata/databases/default/tables/public_fatalities_view.yaml
@@ -37,14 +37,15 @@ select_permissions:
         - ytd_fatality
         - crash_id
         - cris_crash_id
+        - engineering_area
         - person_id
         - unit_id
         - case_id
         - crash_date_ct
         - crash_time_ct
-        - engineering_area
         - law_enforcement_ytd_fatality_num
         - location
+        - record_locator
         - victim_name
         - year
       filter: {}
@@ -57,14 +58,15 @@ select_permissions:
         - ytd_fatality
         - crash_id
         - cris_crash_id
+        - engineering_area
         - person_id
         - unit_id
         - case_id
         - crash_date_ct
         - crash_time_ct
-        - engineering_area
         - law_enforcement_ytd_fatality_num
         - location
+        - record_locator
         - victim_name
         - year
       filter: {}
@@ -77,14 +79,15 @@ select_permissions:
         - ytd_fatality
         - crash_id
         - cris_crash_id
+        - engineering_area
         - person_id
         - unit_id
         - case_id
         - crash_date_ct
         - crash_time_ct
-        - engineering_area
         - law_enforcement_ytd_fatality_num
         - location
+        - record_locator
         - victim_name
         - year
       filter: {}

--- a/atd-vzd/metadata/databases/default/tables/public_people_cris.yaml
+++ b/atd-vzd/metadata/databases/default/tables/public_people_cris.yaml
@@ -31,43 +31,6 @@ array_relationships:
           name: charges_cris
           schema: public
 insert_permissions:
-  - role: editor
-    permission:
-      check: {}
-      columns:
-        - created_by
-        - cris_crash_id
-        - cris_schema_version
-        - drvr_city_name
-        - drvr_drg_cat_1_id
-        - drvr_zip
-        - is_primary_person
-        - prsn_age
-        - prsn_alc_rslt_id
-        - prsn_alc_spec_type_id
-        - prsn_bac_test_rslt
-        - prsn_death_timestamp
-        - prsn_drg_rslt_id
-        - prsn_drg_spec_type_id
-        - prsn_ethnicity_id
-        - prsn_exp_homelessness
-        - prsn_first_name
-        - prsn_gndr_id
-        - prsn_helmet_id
-        - prsn_injry_sev_id
-        - prsn_last_name
-        - prsn_mid_name
-        - prsn_name_sfx
-        - prsn_nbr
-        - prsn_occpnt_pos_id
-        - prsn_rest_id
-        - prsn_taken_by
-        - prsn_taken_to
-        - prsn_type_id
-        - unit_id
-        - unit_nbr
-        - updated_by
-    comment: ""
   - role: vz-admin
     permission:
       check: {}
@@ -104,4 +67,21 @@ insert_permissions:
         - unit_id
         - unit_nbr
         - updated_by
+    comment: ""
+select_permissions:
+  - role: vz-admin
+    permission:
+      columns:
+        - id
+        - unit_id
+      filter: {}
+    comment: ""
+update_permissions:
+  - role: vz-admin
+    permission:
+      columns:
+        - is_deleted
+        - updated_by
+      filter: {}
+      check: null
     comment: ""

--- a/atd-vzd/metadata/databases/default/tables/public_units_cris.yaml
+++ b/atd-vzd/metadata/databases/default/tables/public_units_cris.yaml
@@ -35,43 +35,6 @@ array_relationships:
           name: people_edits
           schema: public
 insert_permissions:
-  - role: editor
-    permission:
-      check: {}
-      columns:
-        - autonomous_unit_id
-        - contrib_factr_1_id
-        - contrib_factr_2_id
-        - contrib_factr_3_id
-        - contrib_factr_p1_id
-        - contrib_factr_p2_id
-        - crash_id
-        - created_by
-        - cris_crash_id
-        - cris_schema_version
-        - e_scooter_id
-        - first_harm_evt_inv_id
-        - pbcat_pedalcyclist_id
-        - pbcat_pedestrian_id
-        - pedalcyclist_action_id
-        - pedestrian_action_id
-        - rpt_autonomous_level_engaged_id
-        - unit_desc_id
-        - unit_nbr
-        - updated_by
-        - veh_body_styl_id
-        - veh_damage_description1_id
-        - veh_damage_description2_id
-        - veh_damage_direction_of_force1_id
-        - veh_damage_direction_of_force2_id
-        - veh_damage_severity1_id
-        - veh_damage_severity2_id
-        - veh_make_id
-        - veh_mod_id
-        - veh_mod_year
-        - veh_trvl_dir_id
-        - vin
-    comment: ""
   - role: vz-admin
     permission:
       check: {}
@@ -108,4 +71,21 @@ insert_permissions:
         - veh_mod_year
         - veh_trvl_dir_id
         - vin
+    comment: ""
+select_permissions:
+  - role: vz-admin
+    permission:
+      columns:
+        - crash_id
+        - id
+      filter: {}
+    comment: ""
+update_permissions:
+  - role: vz-admin
+    permission:
+      columns:
+        - is_deleted
+        - updated_by
+      filter: {}
+      check: null
     comment: ""

--- a/atd-vzd/migrations/default/1715960020005_crashes_list_and_fatality_metrics_views/up.sql
+++ b/atd-vzd/migrations/default/1715960020005_crashes_list_and_fatality_metrics_views/up.sql
@@ -419,6 +419,7 @@ left join
 left join
     lookups.injry_sev_lkp
     on lookups.injry_sev_lkp.id = crash_injury_metrics_view.crash_injry_sev_id
+where crashes.is_deleted = false
 order by id asc;
 
 create view locations_list_view as (

--- a/atd-vzd/migrations/default/1715960020005_crashes_list_and_fatality_metrics_views/up.sql
+++ b/atd-vzd/migrations/default/1715960020005_crashes_list_and_fatality_metrics_views/up.sql
@@ -173,6 +173,7 @@ create or replace view person_injury_metrics_view as (
     left join
         public.crashes as crashes
         on units.crash_id = crashes.id
+    where people.is_deleted = false
 );
 
 create or replace view unit_injury_metrics_view as
@@ -215,6 +216,7 @@ create or replace view unit_injury_metrics_view as
     left join
         person_injury_metrics_view
         on units.id = person_injury_metrics_view.unit_id
+    where units.is_deleted = false
     group by
         units.id
 );
@@ -320,6 +322,7 @@ create or replace view crash_injury_metrics_view as
     left join
         person_injury_metrics_view
         on crashes.id = person_injury_metrics_view.crash_id
+    where crashes.is_deleted = false
     group by
         crashes.id,
         crashes.crash_id
@@ -562,7 +565,7 @@ left join lateral (
 left join
     lookups.collsn_lkp
     on public.crashes.fhe_collsn_id = lookups.collsn_lkp.id
-where crashes.crash_timestamp >= (now() - '5 years'::interval)::date
+where crashes.is_deleted = false and crashes.crash_timestamp >= (now() - '5 years'::interval)::date 
 union all
 select
     aab.form_id as crash_id,

--- a/atd-vzd/migrations/default/1715960026005_fatalities_view/up.sql
+++ b/atd-vzd/migrations/default/1715960026005_fatalities_view/up.sql
@@ -11,6 +11,7 @@ select
 people.id as person_id,
 crashes.id as crash_id,
 crashes.crash_id as cris_crash_id,
+crashes.record_locator,
 units.id as unit_id,
 CONCAT_WS(' ', people.prsn_first_name, people.prsn_mid_name, people.prsn_last_name) as victim_name,
 TO_CHAR(crashes.crash_timestamp at time zone 'US/Central', 'yyyy') AS year,
@@ -48,5 +49,5 @@ crashes.engineering_area
     people 
   left join units on people.unit_id = units.id
   left join crashes on units.crash_id = crashes.id
-where crashes.in_austin_full_purpose = true AND people.prsn_injry_sev_id = 4 AND crashes.private_dr_fl = false;
+where crashes.in_austin_full_purpose = true AND people.prsn_injry_sev_id = 4 AND crashes.private_dr_fl = false AND crashes.is_deleted = false;
 

--- a/atd-vze/src/queries/crashes.js
+++ b/atd-vze/src/queries/crashes.js
@@ -48,6 +48,7 @@ export const GET_CRASH = gql`
       latitude
       longitude
       location_id
+      is_temp_record
       crash_injury_metrics_view {
         vz_fatality_count
         sus_serious_injry_count

--- a/atd-vze/src/queries/tempRecords.js
+++ b/atd-vze/src/queries/tempRecords.js
@@ -21,8 +21,14 @@ export const GET_TEMP_RECORDS = gql`
   }
 `;
 
-export const SOFT_DELETE_TEMP_UNITS_CRASH = gql`
-  mutation softDeleteTempRecord($recordId: Int!, $updatedBy: String!) {
+export const SOFT_DELETE_TEMP_RECORDS = gql`
+  mutation softDeleteTempRecords($recordId: Int!, $updatedBy: String!) {
+    update_crashes_cris_by_pk(
+      pk_columns: { id: $recordId }
+      _set: { is_deleted: true, updated_by: $updatedBy }
+    ) {
+      id
+    }
     update_units_cris(
       where: { crash_id: { _eq: $recordId } }
       _set: { is_deleted: true, updated_by: $updatedBy }
@@ -32,19 +38,8 @@ export const SOFT_DELETE_TEMP_UNITS_CRASH = gql`
         crash_id
       }
     }
-    update_crashes_cris_by_pk(
-      pk_columns: { id: $recordId }
-      _set: { is_deleted: true, updated_by: $updatedBy }
-    ) {
-      id
-    }
-  }
-`;
-
-export const SOFT_DELETE_TEMP_PEOPLE = gql`
-  mutation softDeletePersonRecord($unitId: Int!, $updatedBy: String!) {
     update_people_cris(
-      where: { unit_id: { _eq: $unitId } }
+      where: { units_cri: { crash_id: { _eq: $recordId } } }
       _set: { is_deleted: true, updated_by: $updatedBy }
     ) {
       returning {

--- a/atd-vze/src/queries/tempRecords.js
+++ b/atd-vze/src/queries/tempRecords.js
@@ -17,26 +17,43 @@ export const GET_TEMP_RECORDS = gql`
       units {
         id
         people {
+          id
         }
       }
     }
   }
 `;
 
-export const SOFT_DELETE_TEMP_RECORD = gql`
-  mutation softDeleteTempRecord($recordId: Int!) {
+export const SOFT_DELETE_TEMP_UNITS_CRASH = gql`
+  mutation softDeleteTempRecord($recordId: Int!, $updatedBy: String!) {
+    update_units_cris(
+      where: { crash_id: { _eq: $recordId } }
+      _set: { is_deleted: true, updated_by: $updatedBy }
+    ) {
+      returning {
+        id
+        crash_id
+      }
+    }
     update_crashes_cris_by_pk(
       pk_columns: { id: $recordId }
-      _set: { is_deleted: true }
+      _set: { is_deleted: true, updated_by: $updatedBy }
     ) {
       id
     }
-    update_units_cris(
-      where: { crash_id: { _eq: $recordId } }
-      _set: { is_deleted: true }
+  }
+`;
+
+export const SOFT_DELETE_TEMP_PEOPLE = gql`
+  mutation softDeletePersonRecord($unitId: Int!, $updatedBy: String!) {
+    update_people_cris(
+      where: { unit_id: { _eq: $unitId } }
+      _set: { is_deleted: true, updated_by: $updatedBy }
     ) {
-      id
-      crash_id
+      returning {
+        id
+        unit_id
+      }
     }
   }
 `;

--- a/atd-vze/src/queries/tempRecords.js
+++ b/atd-vze/src/queries/tempRecords.js
@@ -16,9 +16,6 @@ export const GET_TEMP_RECORDS = gql`
       updated_at
       units {
         id
-        people {
-          id
-        }
       }
     }
   }

--- a/atd-vze/src/queries/tempRecords.js
+++ b/atd-vze/src/queries/tempRecords.js
@@ -3,14 +3,40 @@ import { gql } from "apollo-boost";
 export const GET_TEMP_RECORDS = gql`
   query getTempRecords {
     crashes(
-      where: { is_temp_record: { _eq: true } }
-      order_by: { record_locator: desc }
+      where: {
+        is_temp_record: { _eq: true }
+        _and: { is_deleted: { _eq: false } }
+      }
     ) {
+      id
       record_locator
       case_id
       crash_timestamp
       updated_by
       updated_at
+      units {
+        id
+        people {
+        }
+      }
+    }
+  }
+`;
+
+export const SOFT_DELETE_TEMP_RECORD = gql`
+  mutation softDeleteTempRecord($recordId: Int!) {
+    update_crashes_cris_by_pk(
+      pk_columns: { id: $recordId }
+      _set: { is_deleted: true }
+    ) {
+      id
+    }
+    update_units_cris(
+      where: { crash_id: { _eq: $recordId } }
+      _set: { is_deleted: true }
+    ) {
+      id
+      crash_id
     }
   }
 `;

--- a/atd-vze/src/views/Crashes/Crash.js
+++ b/atd-vze/src/views/Crashes/Crash.js
@@ -126,15 +126,9 @@ function Crash(props) {
     <div className="animated fadeIn">
       <Row>
         <Col>
-          {primaryAddress && secondaryAddress ? (
-            <h2 className="h2 mb-3">{`${primaryAddress} & ${secondaryAddress}`}</h2>
-          ) : (
-            <h2 className="h2 mb-3">{`${
-              primaryAddress ? primaryAddress : "PRIMARY ADDRESS MISSING"
-            } & ${
-              secondaryAddress ? secondaryAddress : "SECONDARY ADDRESS MISSING"
-            }`}</h2>
-          )}
+          <h2 className="h2 mb-3">{`${primaryAddress ? primaryAddress : ""} ${
+            secondaryAddress ? "& " + secondaryAddress : ""
+          }`}</h2>
         </Col>
       </Row>
       <Row>

--- a/atd-vze/src/views/Crashes/CrashDiagram.js
+++ b/atd-vze/src/views/Crashes/CrashDiagram.js
@@ -150,25 +150,33 @@ const CrashDiagram = ({ crashId, isCr3Stored, isTempRecord }) => {
           </CardFooter>
         </>
       )}
-      {diagramError && (
-        <CardBody>
-          <p>
-            The crash diagram is not available. Typically, this indicates there
-            was an error when processing this crash's CR3 PDF.
-          </p>
-          <p>
-            For additional assistance, you can
-            <a
-              href="https://atd.knack.com/dts#new-service-request/?view_249_vars=%7B%22field_398%22%3A%22Bug%20Report%20%E2%80%94%20Something%20is%20not%20working%22%2C%22field_399%22%3A%22Vision%20Zero%20(Editor)%22%7D"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              &nbsp;report a bug&nbsp;&nbsp; <i class="fa fa-external-link"></i>
-            </a>
-            .
-          </p>
-        </CardBody>
-      )}
+      {diagramError &&
+        (isTempRecord ? (
+          <CardBody>
+            <p>
+              Crash diagrams are not available for user-created crash records.
+            </p>
+          </CardBody>
+        ) : (
+          <CardBody>
+            <p>
+              The crash diagram is not available. Typically, this indicates
+              there was an error when processing this crash's CR3 PDF.
+            </p>
+            <p>
+              For additional assistance, you can
+              <a
+                href="https://atd.knack.com/dts#new-service-request/?view_249_vars=%7B%22field_398%22%3A%22Bug%20Report%20%E2%80%94%20Something%20is%20not%20working%22%2C%22field_399%22%3A%22Vision%20Zero%20(Editor)%22%7D"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                &nbsp;report a bug&nbsp;&nbsp;{" "}
+                <i class="fa fa-external-link"></i>
+              </a>
+              .
+            </p>
+          </CardBody>
+        ))}
     </Card>
   );
 };

--- a/atd-vze/src/views/Crashes/crashDataMap.js
+++ b/atd-vze/src/views/Crashes/crashDataMap.js
@@ -3,7 +3,7 @@ export const createCrashDataMap = isTempRecord => {
     {
       title: "Details",
       fields: {
-        crash_id: {
+        record_locator: {
           label: "Crash ID",
           editable: false,
         },

--- a/atd-vze/src/views/Fatalities/fatalityGridTableParameters.js
+++ b/atd-vze/src/views/Fatalities/fatalityGridTableParameters.js
@@ -5,13 +5,13 @@ export const fatalityGridTableColumns = {
     label_table: "Year",
     type: "Int",
   },
-  cris_crash_id: {
+  record_locator: {
     primary_key: true,
     searchable: true,
     sortable: true,
     label_search: "Search by Crash ID",
     label_table: "Crash ID",
-    type: "Int",
+    type: "String",
   },
   case_id: {
     searchable: true,

--- a/atd-vze/src/views/Tools/CreateCrashRecord.js
+++ b/atd-vze/src/views/Tools/CreateCrashRecord.js
@@ -388,6 +388,7 @@ const CreateCrashRecord = ({ client }) => {
             error={error}
             refetch={refetch}
             userEmail={userEmail}
+            setSuccessfulNewRecordId={setSuccessfulNewRecordId}
           />
         </Col>
       </Row>

--- a/atd-vze/src/views/Tools/CreateCrashRecord.js
+++ b/atd-vze/src/views/Tools/CreateCrashRecord.js
@@ -232,7 +232,7 @@ const CreateCrashRecord = ({ client }) => {
                       id="hf-case-id"
                       name="hf-case-id"
                       placeholder="Enter Case ID..."
-                      autocomplete="off"
+                      autoComplete="off"
                       value={caseId}
                       onChange={e => setCaseId(e.target.value)}
                     />
@@ -282,7 +282,7 @@ const CreateCrashRecord = ({ client }) => {
                       id="primary-address-input"
                       name="primary-address-input"
                       placeholder="ex: S 900 AUSTIN AVE"
-                      autocomplete="off"
+                      autoComplete="off"
                       value={primaryStreetName?.toUpperCase() || ""}
                       onChange={e => setPrimaryStreetName(e.target.value)}
                     />
@@ -300,7 +300,7 @@ const CreateCrashRecord = ({ client }) => {
                       type="text"
                       id="secondary-address-input"
                       name="secondary-address-input"
-                      autocomplete="off"
+                      autoComplete="off"
                       placeholder="ex: N MOPAC BLVD"
                       value={secondaryStreetName?.toUpperCase() || ""}
                       onChange={e => setSecondaryStreetName(e.target.value)}

--- a/atd-vze/src/views/Tools/CreateCrashRecord.js
+++ b/atd-vze/src/views/Tools/CreateCrashRecord.js
@@ -193,6 +193,7 @@ const CreateCrashRecord = ({ client }) => {
             created_by: userEmail,
             cris_schema_version: "2023",
             is_temp_record: true,
+            private_dr_fl: false,
             units_cris: {
               data: unitObjects,
             },
@@ -385,6 +386,7 @@ const CreateCrashRecord = ({ client }) => {
             crashesData={data.crashes}
             loading={loading}
             error={error}
+            refetch={refetch}
           />
         </Col>
       </Row>

--- a/atd-vze/src/views/Tools/CreateCrashRecord.js
+++ b/atd-vze/src/views/Tools/CreateCrashRecord.js
@@ -387,6 +387,7 @@ const CreateCrashRecord = ({ client }) => {
             loading={loading}
             error={error}
             refetch={refetch}
+            userEmail={userEmail}
           />
         </Col>
       </Row>

--- a/atd-vze/src/views/Tools/CreateCrashRecordTable.js
+++ b/atd-vze/src/views/Tools/CreateCrashRecordTable.js
@@ -23,6 +23,7 @@ import {
   SOFT_DELETE_TEMP_PEOPLE,
   SOFT_DELETE_TEMP_UNITS_CRASH,
 } from "../../queries/tempRecords";
+import { formatDateTimeString } from "../../helpers/format";
 
 const CreateCrashRecordTable = ({
   crashesData,
@@ -152,9 +153,9 @@ const CreateCrashRecordTable = ({
                           </Link>
                         </td>
                         <td>{item.case_id}</td>
-                        <td>{item.crash_timestamp}</td>
+                        <td>{formatDateTimeString(item.crash_timestamp)}</td>
                         <td>{item.updated_by}</td>
-                        <td>{item.updated_at}</td>
+                        <td>{formatDateTimeString(item.updated_at)}</td>
                         <td>
                           <Button
                             color="danger"

--- a/atd-vze/src/views/Tools/CreateCrashRecordTable.js
+++ b/atd-vze/src/views/Tools/CreateCrashRecordTable.js
@@ -50,7 +50,7 @@ const CreateCrashRecordTable = ({
   };
 
   /**
-   * Deletes all the temporary records in the database
+   * Soft deletes all the temporary records in the database
    */
   const handleDelete = () => {
     const unitsData = crashesData.filter(crash => crash.id === deleteId)[0]

--- a/atd-vze/src/views/Tools/CreateCrashRecordTable.js
+++ b/atd-vze/src/views/Tools/CreateCrashRecordTable.js
@@ -19,10 +19,7 @@ import {
   ModalHeader,
   Table,
 } from "reactstrap";
-import {
-  SOFT_DELETE_TEMP_PEOPLE,
-  SOFT_DELETE_TEMP_UNITS_CRASH,
-} from "../../queries/tempRecords";
+import { SOFT_DELETE_TEMP_RECORDS } from "../../queries/tempRecords";
 import { formatDateTimeString } from "../../helpers/format";
 
 const CreateCrashRecordTable = ({
@@ -36,8 +33,7 @@ const CreateCrashRecordTable = ({
   const [modalOpen, setModalOpen] = useState(false);
   const [deleteId, setDeleteId] = useState(null);
   const [feedback, setFeedback] = useState(null);
-  const [deleteUnitAndCrash] = useMutation(SOFT_DELETE_TEMP_UNITS_CRASH);
-  const [deletePerson] = useMutation(SOFT_DELETE_TEMP_PEOPLE);
+  const [deleteTempRecords] = useMutation(SOFT_DELETE_TEMP_RECORDS);
 
   if (loading) return "Loading...";
   if (error) return `Error! ${error.message}`;
@@ -51,24 +47,10 @@ const CreateCrashRecordTable = ({
   };
 
   /**
-   * Soft deletes all the temporary records in the database
+   * Soft deletes the temporary crash and all its associated unit and people records
    */
   const handleDelete = () => {
-    const unitsData = crashesData.filter(crash => crash.id === deleteId)[0]
-      .units;
-    // Loop through an array of units for the crash we are deleting
-    unitsData.forEach(unit => {
-      // Soft delete all the person records associated with that unit id
-      deletePerson({
-        variables: { unitId: unit.id, updatedBy: userEmail },
-      }).catch(err => {
-        setFeedback(String(err));
-        setDeleteId(null);
-      });
-    });
-    setFeedback(null);
-    // Now we can soft delete all the units and the crash associated with the crash id
-    deleteUnitAndCrash({
+    deleteTempRecords({
       variables: { recordId: deleteId, updatedBy: userEmail },
     })
       .then(() => {
@@ -91,7 +73,7 @@ const CreateCrashRecordTable = ({
   };
 
   /**
-   * Commits the crash_id to be deleted to state, and prompts for deletion.
+   * Commits the crash record id to be deleted to state, and prompts for deletion.
    * @param {int} recordId - The record id to be deleted.
    */
   const openModalDelete = recordId => {

--- a/atd-vze/src/views/Tools/CreateCrashRecordTable.js
+++ b/atd-vze/src/views/Tools/CreateCrashRecordTable.js
@@ -28,6 +28,7 @@ const CreateCrashRecordTable = ({
   error,
   refetch,
   userEmail,
+  setSuccessfulNewRecordId,
 }) => {
   const [crashSearch, setCrashSearch] = useState("");
   const [modalOpen, setModalOpen] = useState(false);
@@ -54,6 +55,7 @@ const CreateCrashRecordTable = ({
       variables: { recordId: deleteId, updatedBy: userEmail },
     })
       .then(() => {
+        setSuccessfulNewRecordId(null);
         setDeleteId(null);
         setFeedback(`Crash ID ${deleteId} has been deleted.`);
         toggleModalDelete();

--- a/atd-vze/src/views/Tools/CreateCrashRecordTable.js
+++ b/atd-vze/src/views/Tools/CreateCrashRecordTable.js
@@ -168,7 +168,6 @@ const CreateCrashRecordTable = ({
         </ModalHeader>
         <ModalBody>
           Are you sure you want to delete crash id <strong>T{deleteId}</strong>?
-          This cannot be undone.
         </ModalBody>
         <ModalFooter>
           <Button color="danger" onClick={handleDelete}>


### PR DESCRIPTION
## Associated issues
Closes https://github.com/cityofaustin/atd-data-tech/issues/18429

## Testing
**URL to test:** <!-- VZ URL or Netlify -->
Local

**Steps to test:**
1. Start up your VZ data model, run the migrations and apply metadata from this branch. You can run the cris import script to get some more data.
2. Create some temp records with varying units, injuries, etc.
3. Test deleting the temp record. In the database make sure the crash and all its associated units and people records all had their `is_deleted` columns updated to `true`.
4. Make sure the temp records you deleted are no longer showing up in the crashes list page, the fatalities page, or in the dashboard totals.
5. Will crash if you try to go to the old temp crash details page but I think there is another issue open to address routing to the 404 page so i think we can address this in that PR


---
#### Ship list
- [ ] Check migrations for any conflicts with latest migrations in master branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved