### PR TITLE
Do not merge: CRIS import dry run for launch prep

### DIFF
--- a/atd-etl/cris_import/README.md
+++ b/atd-etl/cris_import/README.md
@@ -6,6 +6,25 @@ It adds one new flag to the etl:
 
 - `--skip-db`: you can process pdfs and upload them to S3 without updating any CR3 metadata in the db. It also skips the import log entry. you cannot use this with `--csv`
 
+For example, you can use this command to process a bunch of local PDFs up into the S3 bucket:
+
+```shell
+$ ./cris_import.py --pdf --skip-unzip --skip-db --s3-upload --workers 30
+```
+
+It also adds a special script, `_update_db_from_bucket.py`, which will update CR3 metadata in the DB based on the PDFs available in the S3 bucket.
+
+Remember to set your env variables first:
+
+- `BUCKET_NAME`: the name of the bucket that will be scanned
+- `ENV`: `prod`, `staging`, or `dev`: which bucket subdir will be sourced for PDF metadata
+- `ENDPOINT`: the hasura graphql endpoint to target for updating the DB
+- `ADMIN_SECRET`: the hasura graphql admin secret to be used when updating the db
+
+```shell
+$ python _update_db_from_bucket.py
+```
+
 
 # CRIS Import ETL
 

--- a/atd-etl/cris_import/README.md
+++ b/atd-etl/cris_import/README.md
@@ -1,3 +1,12 @@
+# this is a special version of the ETL
+
+...t is not meant to be merged!
+
+It adds one new flag to the etl:
+
+- `--skip-db`: you can process pdfs and upload them to S3 without updating any CR3 metadata in the db. It also skips the import log entry. you cannot use this with `--csv`
+
+
 # CRIS Import ETL
 
 This ETL manages the processing and importing of TxDOT CRIS data into the Vision Zero database.

--- a/atd-etl/cris_import/_update_db_from_bucket.py
+++ b/atd-etl/cris_import/_update_db_from_bucket.py
@@ -13,7 +13,6 @@ from utils.graphql import make_hasura_request
 
 ENV = os.environ["ENV"]
 BUCKET_NAME = os.environ["BUCKET_NAME"]
-EXTRACT_PASSWORD = os.environ["EXTRACT_PASSWORD"]
 
 UPDATE_CRASH_CR3_FIELDS_MANY = """
 mutation UpdateCrashCR3FieldsMany($updates: [crashes_cris_updates!]! ) {

--- a/atd-etl/cris_import/_update_db_from_bucket.py
+++ b/atd-etl/cris_import/_update_db_from_bucket.py
@@ -1,0 +1,76 @@
+"""Searches the cr3/pdfs subdirectory of the S3 bucket given an environment
+(dev, staging, prod), and updates `crashes` records with CR3 metadata
+accordingly.
+
+If a CR3 pdf exists in the Bucket but not in the target DB, the update
+is ignored"""
+
+import os
+
+from boto3 import client
+
+from utils.graphql import make_hasura_request
+
+ENV = os.environ["ENV"]
+BUCKET_NAME = os.environ["BUCKET_NAME"]
+EXTRACT_PASSWORD = os.environ["EXTRACT_PASSWORD"]
+
+UPDATE_CRASH_CR3_FIELDS_MANY = """
+mutation UpdateCrashCR3FieldsMany($updates: [crashes_cris_updates!]! ) {
+    update_crashes_cris_many(updates: $updates) {
+        affected_rows
+    }
+}
+"""
+
+
+def get_crash_id_from_key(key):
+    fname = key.split("/")[-1].split(".")[0]
+    return int(fname)
+
+
+def parse_res_data(res_data):
+    for row in res_data:
+        if row["affected_rows"] > 0:
+            print("omg found one")
+
+
+def main():
+    s3_client = client("s3")
+    paginator = s3_client.get_paginator("list_objects_v2")
+    prefix = f"{ENV}/cr3s/pdfs"
+
+    total_files_found = 0
+    # iterate through the all files in the bucket that match our prefix
+    for page in paginator.paginate(
+        Bucket=BUCKET_NAME,
+        Prefix=prefix,
+    ):
+        updates = []
+        if "Contents" in page:
+            # extract the crash ID and modified date from each file
+            for obj in page["Contents"]:
+                cris_crash_id = get_crash_id_from_key(obj["Key"])
+                cr3_processed_at = obj["LastModified"].isoformat()
+                # build a Hasura 'update many' payload
+                row_update = {
+                    "where": {"cris_crash_id": {"_eq": cris_crash_id}},
+                    "_set": {
+                        "cr3_processed_at": cr3_processed_at,
+                        "cr3_stored_fl": True,
+                    },
+                }
+                updates.append(row_update)
+
+        total_files_found += len(updates)
+        print(f"Updating {len(updates)} crashes. Total will be {total_files_found}")
+
+        res_data = make_hasura_request(
+            query=UPDATE_CRASH_CR3_FIELDS_MANY, variables={"updates": updates}
+        )["update_crashes_cris_many"]
+
+        parse_res_data(res_data)
+
+
+if __name__ == "__main__":
+    main()

--- a/atd-etl/cris_import/utils/cli.py
+++ b/atd-etl/cris_import/utils/cli.py
@@ -44,6 +44,11 @@ def get_cli_args():
         help="Only process files that are already unzipped in the local directory",
     )
     parser.add_argument(
+        "--skip-db",
+        action="store_true",
+        help="Upload PDFs and crash diagrams to S3 without updating the DB",
+    )
+    parser.add_argument(
         "--verbose",
         "-v",
         action="store_true",


### PR DESCRIPTION
## Associated issues

- https://github.com/cityofaustin/atd-data-tech/issues/18457

These are helper tools for the launch that will not merger. I've already run `--skip-db` to backfill all of the CR3 PDFs into our S3 buckets. We will need to run `_update_db_from_bucket.py` after we launch in order to bring the CR3 metadata in the DB in sync with S3.

Both of these are conveniences that save us a few hours of waiting on launch day.

## Testing

Start your local stack and run your CRIS import with `--skip-db` and `--pdf`:

```shell
$ ./cris_import.py --s3-download --s3-upload --pdf --skip-db --verbose
```

You can also test the new helper script, but you're going to have to cancel after a few seconds because it's going to try to update your DB by processing all ~350k pdfs in chunks of a 1k.

```shell
$ python _update_db_from_bucket.py
```

---
#### Ship list
- [ ] Check migrations for any conflicts with latest migrations in master branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved