### PR TITLE
 Make sure the 404 page renders when a crash ID is not found

### DIFF
--- a/atd-vze/src/views/Crashes/Crash.js
+++ b/atd-vze/src/views/Crashes/Crash.js
@@ -94,7 +94,10 @@ function Crash(props) {
   };
 
   const crashRecord = {
-    crash: crashData?.crashes?.[0] || { crash_injury_metrics_view: {} },
+    crash: crashData?.crashes?.[0] || {
+      crash_injury_metrics_view: {},
+      crashes_list_view: {},
+    },
   };
   const crashPk = crashRecord?.crash?.id;
 
@@ -120,7 +123,7 @@ function Crash(props) {
   const hasLocation = crashRecord?.crash["location_id"];
   const hasCoordinates = !!latitude && !!longitude;
 
-  return !crashData ? (
+  return !crashData.crashes[0] ? (
     <Page404 />
   ) : (
     <div className="animated fadeIn">


### PR DESCRIPTION
## Associated issues
Closes https://github.com/cityofaustin/atd-data-tech/issues/18479

## Testing
**URL to test:** <!-- VZ URL or Netlify -->
Local/data model

**Steps to test:**
1. Go to a crash details page, type in a nonexistent crash id like http://localhost:3000/#/crashes/hello123
2. The 404 page should render now


---
#### Ship list
- [ ] Check migrations for any conflicts with latest migrations in master branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved