### PR TITLE
Use Reset instead of NO DATA option in dropdowns

### DIFF
--- a/atd-vze/src/views/Crashes/RelatedRecordsTable.js
+++ b/atd-vze/src/views/Crashes/RelatedRecordsTable.js
@@ -218,7 +218,7 @@ const RelatedRecordsTable = ({
                                     }
                                     type="select"
                                   >
-                                    <option value={""}>NO DATA</option>
+                                    <option value={""}>RESET</option>
                                     {lookupOptions[
                                       fieldConfig.fields[field].lookupOptions
                                     ].map(option => {


### PR DESCRIPTION
## Associated issues
Closes https://github.com/cityofaustin/atd-data-tech/issues/18575

## Testing
**URL to test:** <!-- VZ URL or Netlify -->
Local data model

**Steps to test:**
1. Go to a crash, edit some values in the Units/Peoples tables. Then edit them again and click the RESET option. This will reset these edit values to be NULL in the edits table, so CRIS values will propagate to the top again. 
2. We should create a spin off issue to really address how we want to handle this long term; functionally and stylistically. For example, maybe be able to hover over a tooltip or something and see what the CRIS value is if there is a VZ edit covering it. And then have a reset option only if there is a VZ edit. Also currently can only reset with drop down fields, cant reset an age for example rn.

---
#### Ship list
- [ ] Check migrations for any conflicts with latest migrations in master branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved