### PR TITLE
Remove page and record counts from grid table pagination controls

### DIFF
--- a/atd-vze/src/Components/GridTable.js
+++ b/atd-vze/src/Components/GridTable.js
@@ -229,6 +229,7 @@ const GridTable = ({
   const handleRowClick = e => {
     const rowNumber = parseInt(e.target.value);
     setLimit(rowNumber);
+    changePage(1);
   };
 
   /**

--- a/atd-vze/src/Components/GridTable.js
+++ b/atd-vze/src/Components/GridTable.js
@@ -182,7 +182,9 @@ const GridTable = ({
     } else if (sortColumn === col) {
       // Else if the current sortColumn is the same as the new
       // then invert values and repeat sort on column
-      sortOrder === "desc_nulls_last" ? setSortOrder("asc") : setSortOrder("desc_nulls_last");
+      sortOrder === "desc_nulls_last"
+        ? setSortOrder("asc")
+        : setSortOrder("desc_nulls_last");
     } else if (sortColumn !== col) {
       // Sort different column after initial sort, then reset
       setSortOrder("desc_nulls_last");
@@ -377,7 +379,7 @@ const GridTable = ({
     query.setOrder(sortColumn, sortOrder);
   }
 
-  // Mange LIMIT & OFFSET
+  // Manage LIMIT & OFFSET
   query.limit = limit;
   query.offset = offset;
 
@@ -395,14 +397,9 @@ const GridTable = ({
   if (error) return `Error! ${error.message}`;
 
   let dataEntries = [];
-  let totalRecords = 0;
-  let totalPages = 1;
 
   // If we have data
   if (data[query.table]) {
-    totalRecords = data[query.table + "_aggregate"]["aggregate"]["count"];
-    totalPages = Math.ceil(totalRecords / limit);
-
     // DataEntries: For each item in the data array, generate a row with each column
     data[query.table].map((row, index) =>
       dataEntries.push(
@@ -526,15 +523,13 @@ const GridTable = ({
                     moveBack={moveBackPage}
                     pageNumber={page}
                     limit={limit}
-                    totalRecords={totalRecords}
-                    totalPages={totalPages}
                     handleRowClick={handleRowClick}
+                    recordsCount={dataEntries.length}
                   />
                   {columnsToExport && (
                     <GridExportData
                       query={query}
                       columnsToExport={columnsToExport}
-                      totalRecords={totalRecords}
                       roleSpecificColumns={roleSpecificColumns}
                       hasSpecificRole={hasSpecificRole}
                     />

--- a/atd-vze/src/Components/GridTableHeader.js
+++ b/atd-vze/src/Components/GridTableHeader.js
@@ -58,7 +58,7 @@ const GridTableHeader = ({
                       : null
                   }
                   key={`th-${index}`}
-                  style={{cursor: "pointer"}}
+                  style={{ cursor: "pointer" }}
                 >
                   {renderLabel(
                     // Get a human-readable label string

--- a/atd-vze/src/Components/GridTablePagination.js
+++ b/atd-vze/src/Components/GridTablePagination.js
@@ -21,10 +21,9 @@ const GridTablePagination = ({
   moveNext,
   moveBack,
   limit,
-  totalPages,
-  totalRecords,
   pageNumber,
   handleRowClick,
+  recordsCount,
 }) => {
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
 
@@ -46,15 +45,13 @@ const GridTablePagination = ({
             Prev
           </Button>
           <StyledDisableClick>
-            <Button color="light">
-              Page {pageNumber.toLocaleString()}/{totalPages === 0 ? 1 : totalPages.toLocaleString()}
-            </Button>
-            <Button color="light">Results: {totalRecords.toLocaleString()}</Button>
+            <Button color="light">Page {pageNumber.toLocaleString()}</Button>
           </StyledDisableClick>
 
           <Button
             onClick={moveNext}
-            disabled={pageNumber >= totalPages ? true : false}
+            // if record count on the current page is less than the limit or zero, disable next page button
+            disabled={recordsCount < limit || recordsCount === 0 ? true : false}
           >
             Next{" "}
             <StyledDisableClick>

--- a/atd-vze/src/queries/gqlAbstract.js
+++ b/atd-vze/src/queries/gqlAbstract.js
@@ -27,14 +27,7 @@ gqlAbstractTableName (
     gqlAbstractFilters
 ) {
     gqlAbstractColumns
-},
-gqlAbstractTableAggregateName (
-    gqlAbstractAggregateFilters
-) {
-    aggregate {
-      count
-    }
-  }
+}
 }`;
   }
 
@@ -462,17 +455,9 @@ gqlAbstractTableAggregateName (
 
     // Replace the name of the table
     query = query.replace("gqlAbstractTableName", this.config["table"]);
-    query = query.replace(
-      "gqlAbstractTableAggregateName",
-      this.config["table"] + "_aggregate"
-    );
 
     // Generate Filters
     query = query.replace("gqlAbstractFilters", this.generateFilters());
-    query = query.replace(
-      "gqlAbstractAggregateFilters",
-      this.generateFilters(true)
-    );
 
     // Generate Columns
     query = query.replace("gqlAbstractColumns", this.generateColumns());
@@ -494,17 +479,9 @@ gqlAbstractTableAggregateName (
 
     // Replace the name of the table
     query = query.replace("gqlAbstractTableName", this.config["table"]);
-    query = query.replace(
-      "gqlAbstractTableAggregateName",
-      this.config["table"] + "_aggregate"
-    );
 
     // Generate Filters
     query = query.replace("gqlAbstractFilters", this.generateFilters());
-    query = query.replace(
-      "gqlAbstractAggregateFilters",
-      this.generateFilters(true)
-    );
 
     // Generate Columns
     query = query.replace("gqlAbstractColumns", string);

--- a/atd-vze/src/queries/gqlAbstract.js
+++ b/atd-vze/src/queries/gqlAbstract.js
@@ -27,7 +27,7 @@ gqlAbstractTableName (
     gqlAbstractFilters
 ) {
     gqlAbstractColumns
-}
+  }
 }`;
   }
 

--- a/atd-vze/src/views/Crashes/crashGridTableParameters.js
+++ b/atd-vze/src/views/Crashes/crashGridTableParameters.js
@@ -60,75 +60,74 @@ export const crashGridTableColumns = {
   },
 };
 
-
 export const locationCrashGridTableColumns = {
-    record_locator: {
-      primary_key: true,
-      searchable: true,
-      sortable: true,
-      label_search: "Search by Crash ID",
-      label_table: "Crash ID",
-      type: "String",
-    },
-    case_id: {
-      searchable: true,
-      sortable: true,
-      label_search: "Search by Case ID",
-      label_table: "Case ID",
-      type: "String",
-    },
-    crash_timestamp: {
-      searchable: false,
-      sortable: true,
-      label_table: "Crash Date",
-      type: "date_iso",
-    },
-    address_primary: {
-      searchable: true,
-      sortable: true,
-      label_search: "Search by Primary Address",
-      label_table: "Primary Address",
-      type: "String",
-    },
-    address_secondary: {
-      searchable: true,
-      sortable: true,
-      label_search: "Search by Secondary Address",
-      label_table: "Secondary Address",
-      type: "String",
-    },
-    sus_serious_injry_count: {
-      searchable: false,
-      sortable: true,
-      label_table: "Suspected Serious Injury Count",
-      type: "Int",
-    },
-    vz_fatality_count: {
-      searchable: false,
-      sortable: true,
-      label_table: "Death Count",
-      type: "Date",
-    },
-    est_comp_cost_crash_based: {
-      searchable: false,
-      sortable: true,
-      label_table: "Est Comprehensive Cost",
-      type: "Currency",
-    },
-    collsn_desc: {
-      searchable: false,
-      sortable: true,
-      label_table: "Collision Description",
-      type: "String",
-    },
-    "units { unit_desc { label } }": {
-      searchable: false,
-      sortable: false,
-      label_table: "Unit Description",
-      type: "String",
-      hidden: true,
-    },
-  };
+  record_locator: {
+    primary_key: true,
+    searchable: true,
+    sortable: true,
+    label_search: "Search by Crash ID",
+    label_table: "Crash ID",
+    type: "String",
+  },
+  case_id: {
+    searchable: true,
+    sortable: true,
+    label_search: "Search by Case ID",
+    label_table: "Case ID",
+    type: "String",
+  },
+  crash_timestamp: {
+    searchable: false,
+    sortable: true,
+    label_table: "Crash Date",
+    type: "date_iso",
+  },
+  address_primary: {
+    searchable: true,
+    sortable: true,
+    label_search: "Search by Primary Address",
+    label_table: "Primary Address",
+    type: "String",
+  },
+  address_secondary: {
+    searchable: true,
+    sortable: true,
+    label_search: "Search by Secondary Address",
+    label_table: "Secondary Address",
+    type: "String",
+  },
+  sus_serious_injry_count: {
+    searchable: false,
+    sortable: true,
+    label_table: "Suspected Serious Injury Count",
+    type: "Int",
+  },
+  vz_fatality_count: {
+    searchable: false,
+    sortable: true,
+    label_table: "Death Count",
+    type: "Date",
+  },
+  est_comp_cost_crash_based: {
+    searchable: false,
+    sortable: true,
+    label_table: "Est Comprehensive Cost",
+    type: "Currency",
+  },
+  collsn_desc: {
+    searchable: false,
+    sortable: true,
+    label_table: "Collision Description",
+    type: "String",
+  },
+  "units { unit_desc { label } }": {
+    searchable: false,
+    sortable: false,
+    label_table: "Unit Description",
+    type: "String",
+    hidden: true,
+  },
+};
 
 export const nonCR3CrashGridTableColumns = {
   case_id: {


### PR DESCRIPTION
## Associated issues
Closes https://github.com/cityofaustin/atd-data-tech/issues/18622

## Testing
**URL to test:** <!-- VZ URL or Netlify -->
Local data model

**Steps to test:**
1. Go to the Crashes page, see that the total records and total pages counts arent there anymore. Do you notice a faster loading time if you have a big cris import loaded in your database?
2. The next page button should be disabled if the current page total record count is less than the limit, ie. rows per page. Test this. 
3. This also means that if the last page happens to have exactly the number of records that is the limit, the user will be able to click the next page button and the next page will just have 0 records. There is really no way around this without querying aggregate total record counts, so this is a bug we will have to live with for the time being. Good news is its not super likely that the last page should have exactly the number of rows per page the user picks.
4. When the above happens, test that the next page button is disabled when the current page has 0 records.
5. Test the Locations list page as well.
6. Test that nothing broke on the Location details page, this also contains a gridTable.


---
#### Ship list
- [ ] Check migrations for any conflicts with latest migrations in master branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved