### PR TITLE
Remove empty <CardFooter/> components from various pages

### DIFF
--- a/atd-vze/src/Components/DataTable.js
+++ b/atd-vze/src/Components/DataTable.js
@@ -221,7 +221,7 @@ const DataTable = ({
                   </tbody>
                 </Table>
               </CardBody>
-              <CardFooter>{downloadGlobal}</CardFooter>
+              {!!downloadGlobal && <CardFooter>{downloadGlobal}</CardFooter>}
             </Card>
           </Col>
         );

--- a/atd-vze/src/Components/Notes/Notes.js
+++ b/atd-vze/src/Components/Notes/Notes.js
@@ -1,14 +1,6 @@
 import React, { useState } from "react";
 import { useMutation } from "@apollo/react-hooks";
-import {
-  Card,
-  CardHeader,
-  CardBody,
-  CardFooter,
-  Table,
-  Input,
-  Button,
-} from "reactstrap";
+import { Card, CardHeader, CardBody, Table, Input, Button } from "reactstrap";
 import ConfirmDeleteButton from "../ConfirmDeleteButton.js";
 import { format, parseISO } from "date-fns";
 import { notesDataMap } from "./notesDataMap.js";
@@ -286,7 +278,6 @@ const Notes = ({
           </tbody>
         </Table>
       </CardBody>
-      <CardFooter></CardFooter>
     </Card>
   );
 };

--- a/atd-vze/src/views/Crashes/Recommendations/Recommendations.js
+++ b/atd-vze/src/views/Crashes/Recommendations/Recommendations.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { useQuery, useMutation } from "@apollo/react-hooks";
-import { Card, CardHeader, CardBody, CardFooter } from "reactstrap";
+import { Card, CardHeader, CardBody } from "reactstrap";
 import { recommendationsDataMap } from "./recommendationsDataMap";
 import {
   GET_RECOMMENDATION_LOOKUPS,
@@ -180,7 +180,6 @@ const Recommendations = ({ crashPk, recommendation, refetch }) => {
           </div>
         </div>
       </CardBody>
-      <CardFooter></CardFooter>
     </Card>
   );
 };


### PR DESCRIPTION
## Associated issues
Closes https://github.com/cityofaustin/atd-data-tech/issues/18150

## Testing
**URL to test:** <!-- VZ URL or Netlify -->
Local data model

**Steps to test:**
1. See that the card footer is removed from notes, recommendations, and the data tables on the crash details page.
2. The card footer should still render on the location details page data table thats titled "Details", there should be a Download crashes button.


---
#### Ship list
- [ ] Check migrations for any conflicts with latest migrations in master branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved