### PR TITLE
Fixes WSOD on location details page for non-AFP location polygons

### DIFF
--- a/atd-vzd/metadata/databases/default/tables/public_locations_list_view.yaml
+++ b/atd-vzd/metadata/databases/default/tables/public_locations_list_view.yaml
@@ -5,10 +5,12 @@ select_permissions:
   - role: editor
     permission:
       columns:
+        - council_district
         - cr3_crash_count
         - crash_count
         - description
         - location_id
+        - location_group
         - non_cr3_crash_count
         - total_est_comp_cost
       filter: {}
@@ -17,10 +19,12 @@ select_permissions:
   - role: readonly
     permission:
       columns:
+        - council_district
         - cr3_crash_count
         - crash_count
         - description
         - location_id
+        - location_group
         - non_cr3_crash_count
         - total_est_comp_cost
       filter: {}
@@ -29,10 +33,12 @@ select_permissions:
   - role: vz-admin
     permission:
       columns:
+        - council_district
         - cr3_crash_count
         - crash_count
         - description
         - location_id
+        - location_group
         - non_cr3_crash_count
         - total_est_comp_cost
       filter: {}

--- a/atd-vzd/migrations/default/1724206665257_locations_list_afp/down.sql
+++ b/atd-vzd/migrations/default/1724206665257_locations_list_afp/down.sql
@@ -1,0 +1,62 @@
+-- revert to 1715960021005_crashes_list_and_fatality_metrics_views
+drop view if exists locations_list_view;
+create view locations_list_view as
+with cr3_comp_costs as (
+    select
+        location_id,
+        sum(est_comp_cost_crash_based) as cr3_comp_costs_total
+    from crashes_list_view group by location_id
+),
+
+cr3_crash_counts as (
+    select
+        location_id,
+        count(location_id) as crash_count
+    from
+        crashes
+    where
+        crashes.private_dr_fl = false
+        and crashes.location_id is not null
+        and crashes.crash_timestamp > (now() - '5 years'::interval)
+    group by
+        location_id
+),
+
+non_cr3_crash_counts as (
+    select
+        location_id,
+        count(location_id) as crash_count,
+        count(location_id) * 10000 as noncr3_comp_costs_total
+    from
+        atd_apd_blueform
+    where
+        atd_apd_blueform.location_id is not null
+        and atd_apd_blueform.date > (now() - '5 years'::interval)
+    group by
+        location_id
+)
+
+select
+    locations.location_id,
+    locations.description,
+    coalesce(
+        cr3_comp_costs.cr3_comp_costs_total
+        + non_cr3_crash_counts.noncr3_comp_costs_total,
+        0
+    ) as total_est_comp_cost,
+    coalesce(cr3_crash_counts.crash_count, 0) as cr3_crash_count,
+    coalesce(non_cr3_crash_counts.crash_count, 0) as non_cr3_crash_count,
+    coalesce(cr3_crash_counts.crash_count, 0)
+    + coalesce(non_cr3_crash_counts.crash_count, 0) as crash_count
+from
+    atd_txdot_locations as locations
+left join
+    cr3_crash_counts
+    on locations.location_id = cr3_crash_counts.location_id
+left join
+    non_cr3_crash_counts
+    on locations.location_id = non_cr3_crash_counts.location_id
+left join cr3_comp_costs on locations.location_id = cr3_comp_costs.location_id
+where
+    locations.council_district > 0
+    and locations.location_group = 1;

--- a/atd-vzd/migrations/default/1724206665257_locations_list_afp/up.sql
+++ b/atd-vzd/migrations/default/1724206665257_locations_list_afp/up.sql
@@ -1,0 +1,60 @@
+drop view if exists locations_list_view;
+create view locations_list_view as
+with cr3_comp_costs as (
+    select
+        location_id,
+        sum(est_comp_cost_crash_based) as cr3_comp_costs_total
+    from crashes_list_view group by location_id
+),
+
+cr3_crash_counts as (
+    select
+        location_id,
+        count(location_id) as crash_count
+    from
+        crashes
+    where
+        crashes.private_dr_fl = false
+        and crashes.location_id is not null
+        and crashes.crash_timestamp > (now() - '5 years'::interval)
+    group by
+        location_id
+),
+
+non_cr3_crash_counts as (
+    select
+        location_id,
+        count(location_id) as crash_count,
+        count(location_id) * 10000 as noncr3_comp_costs_total
+    from
+        atd_apd_blueform
+    where
+        atd_apd_blueform.location_id is not null
+        and atd_apd_blueform.date > (now() - '5 years'::interval)
+    group by
+        location_id
+)
+
+select
+    locations.location_id,
+    locations.description,
+    locations.council_district,
+    locations.location_group,
+    coalesce(
+        cr3_comp_costs.cr3_comp_costs_total
+        + non_cr3_crash_counts.noncr3_comp_costs_total,
+        0
+    ) as total_est_comp_cost,
+    coalesce(cr3_crash_counts.crash_count, 0) as cr3_crash_count,
+    coalesce(non_cr3_crash_counts.crash_count, 0) as non_cr3_crash_count,
+    coalesce(cr3_crash_counts.crash_count, 0)
+    + coalesce(non_cr3_crash_counts.crash_count, 0) as crash_count
+from
+    atd_txdot_locations as locations
+left join
+    cr3_crash_counts
+    on locations.location_id = cr3_crash_counts.location_id
+left join
+    non_cr3_crash_counts
+    on locations.location_id = non_cr3_crash_counts.location_id
+left join cr3_comp_costs on locations.location_id = cr3_comp_costs.location_id;

--- a/atd-vzd/migrations/default/1724259574465_crash_position_index_gist/down.sql
+++ b/atd-vzd/migrations/default/1724259574465_crash_position_index_gist/down.sql
@@ -1,0 +1,2 @@
+drop index if exists crashes_position_idx;
+create index on public.crashes (position);

--- a/atd-vzd/migrations/default/1724259574465_crash_position_index_gist/up.sql
+++ b/atd-vzd/migrations/default/1724259574465_crash_position_index_gist/up.sql
@@ -1,0 +1,2 @@
+drop index if exists crashes_position_idx;
+create index crashes_position_idx on public.crashes using GIST (position);

--- a/atd-vze/src/Components/DataTable.js
+++ b/atd-vze/src/Components/DataTable.js
@@ -64,7 +64,7 @@ const DataTable = ({
                       let fieldValue = fieldConfigObject.relationshipName
                         ? data[fieldDataTable][
                             fieldConfigObject.relationshipName
-                          ][field]
+                          ]?.[field]
                         : data[fieldDataTable][field];
 
                       // Handle formatting the field value

--- a/atd-vze/src/views/Locations/Locations.js
+++ b/atd-vze/src/views/Locations/Locations.js
@@ -5,6 +5,7 @@ import { format, subYears } from "date-fns";
 import GridTable from "../../Components/GridTable";
 import gqlAbstract from "../../queries/gqlAbstract";
 import { locationQueryExportFields } from "../../queries/locations";
+import { locationsGridTableAdvancedFilters } from "./locationGridTableParameters";
 
 // Our initial query configuration
 let queryConf = {
@@ -66,6 +67,7 @@ let locationsQuery = new gqlAbstract(queryConf);
 const Locations = () => (
   <GridTable
     query={locationsQuery}
+    filters={locationsGridTableAdvancedFilters}
     title={"Locations"}
     columnsToExport={locationQueryExportFields}
     helperText={helperText}

--- a/atd-vze/src/views/Locations/locationGridTableParameters.js
+++ b/atd-vze/src/views/Locations/locationGridTableParameters.js
@@ -1,0 +1,32 @@
+export const locationsGridTableAdvancedFilters = {
+  groupGeography: {
+    icon: "map-marker",
+    label: "Geography",
+    filters: [
+      {
+        id: "geo_afd",
+        label: "Include Outside Of Austin Full Purpose",
+        invert_toggle_state: true,
+        filter: {
+          where: [
+            {
+              council_district: "_gt: 0",
+            },
+          ],
+        },
+      },
+      {
+        id: "level_1",
+        label: "Include \"Level 5\" polygons",
+        invert_toggle_state: true,
+        filter: {
+          where: [
+            {
+              location_group: "_eq: 1",
+            },
+          ],
+        },
+      },
+    ],
+  },
+};


### PR DESCRIPTION
- https://github.com/cityofaustin/atd-data-tech/issues/18715

This change fixes a bug that bombs the location details page when loading locations which are outside of the Austin Full Purpose jurisdiction or are so-called "Level 5" polygons.

The reason this bug came about is because  we consolidated the various views that provide location-level data into one which excluded non-afp and L5 polygons.  To fix this without creating yet another view, I went ahead and added an advanced filter config that is similar to the one we use on the crashes page, which is a kind of hack/workaround for being able to set default filters within the gridtable / gqlabstract magic.

I think this gets us close enough to the current/previous production state 👍 

By the way, I did test list view performance in staging with this modified view and it has no impact on query time.

## Testing
 Local

**Steps to test:**
1. Start your stack, apply migrations and run some CRIS import. 
2. Use your SQL client to query an `atd_txdot_locations` record that has no `council_district`. Take note of the location ID can try searching for it, and opening it, in the VZE.
3. I'm testing with location ID `24A1E99089` which is broken in staging.

---
#### Ship list
- [ ] Check migrations for any conflicts with latest migrations in master branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved