### PR TITLE
Better error handling when there are no crashes to process

### DIFF
--- a/atd-etl/cris_import/utils/process_pdfs.py
+++ b/atd-etl/cris_import/utils/process_pdfs.py
@@ -139,10 +139,8 @@ def process_pdfs(extract_dir, s3_upload, max_workers):
         for filename in os.listdir(os.path.join(extract_dir, "crashReports"))
         if filename.endswith(".pdf")
     ]
-    pdf_count = len(pdfs)
 
-    if not pdf_count:
-        raise IOError("No PDFs found in extract")
+    pdf_count = len(pdfs)
 
     logger.info(f"Found {pdf_count} PDFs to process")
 


### PR DESCRIPTION
## Associated issues

- https://github.com/cityofaustin/atd-data-tech/issues/18719

This issue cropped up when processing ~30 daily CRIS extracts. It seems that occasionally, but not always, the `crashReports` directory is completely missing from the extracts with no crashes. The CSV files are always present.

This script makes the following changes:
- Skips PDF processing entirely when (1) the script is invoked with both `--csv` and `--pdf` and (2) there were no crashes found in the CSV
- Adds a final test at the end of processing to make sure that the number of PDFs processed matches the number of crashes processed via CSV (again, only when the script is invoked with both `--csv` and `--pdf`)
- Raises an error if no extracts are retrieved from the S3 bucket. This was an earlier oversight.

## Testing

I've left ~30 extracts in the dev inbox which you can use for testing.

1. Start your local stack
2. Run the cris import with the `--s3-download` command:

```shell
$ ./cris_import.py --csv --pdf --s3-download
```

---
#### Ship list
- [ ] Check migrations for any conflicts with latest migrations in master branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved