### PR TITLE
Add directory existence check to CRIS import script

### DIFF
--- a/atd-etl/cris_import/utils/process_pdfs.py
+++ b/atd-etl/cris_import/utils/process_pdfs.py
@@ -134,11 +134,11 @@ def process_pdfs(extract_dir, s3_upload, max_workers):
     # make the crash_diagram extract directory
     Path(os.path.join(extract_dir, "crash_diagrams")).mkdir(parents=True, exist_ok=True)
 
-    pdfs = [
-        filename
-        for filename in os.listdir(os.path.join(extract_dir, "crashReports"))
-        if filename.endswith(".pdf")
-    ]
+    pdfs_dir = os.path.join(extract_dir, "crashReports")
+    if not os.path.exists(pdfs_dir):
+        return
+
+    pdfs = [filename for filename in os.listdir(pdfs_dir) if filename.endswith(".pdf")]
     pdf_count = len(pdfs)
 
     if not pdf_count:


### PR DESCRIPTION
# Issue

While standing up the VZ data model locally, I found that there are a heterogeneous set of CRIS extracts in the dev inbox; some have PDFs in them, some don't, it appears. 

This small diff adds a check to `utils.process_pdfs()` to return early if there is not a directory of PDFs to process for a given zip.

# Associated issues

_nada_

# Testing

Import the CRIS extracts currently in the dev inbox.

---
#### Ship list
- [ ] Check migrations for any conflicts with latest migrations in master branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved