### PR TITLE
WSOD when viewing a deleted crash

### DIFF
--- a/atd-vze/src/queries/crashes.js
+++ b/atd-vze/src/queries/crashes.js
@@ -2,7 +2,11 @@ import { gql } from "apollo-boost";
 
 export const GET_CRASH = gql`
   query CrashDetails($crashId: String!) {
-    crashes(where: { record_locator: { _eq: $crashId } }) {
+    crashes(
+      where: {
+        _and: { record_locator: { _eq: $crashId }, is_deleted: { _eq: false } }
+      }
+    ) {
       id
       record_locator
       updated_at
@@ -50,7 +54,6 @@ export const GET_CRASH = gql`
       location_id
       is_temp_record
       in_austin_full_purpose
-      is_deleted
       crash_injury_metrics_view {
         vz_fatality_count
         sus_serious_injry_count

--- a/atd-vze/src/queries/crashes.js
+++ b/atd-vze/src/queries/crashes.js
@@ -50,6 +50,7 @@ export const GET_CRASH = gql`
       location_id
       is_temp_record
       in_austin_full_purpose
+      is_deleted
       crash_injury_metrics_view {
         vz_fatality_count
         sus_serious_injry_count

--- a/atd-vze/src/views/Crashes/Crash.js
+++ b/atd-vze/src/views/Crashes/Crash.js
@@ -93,12 +93,9 @@ function Crash(props) {
     setEditField("");
   };
 
-  // If crash doesnt exist or has been soft deleted, the 404 page should render
-  const isValidCrash = crashData?.crashes?.[0]?.is_deleted === false;
-
   const crashRecord = {
-    // Need to construct empty objects if crash is invalid
-    crash: (isValidCrash && crashData?.crashes?.[0]) || {
+    // Need to construct empty objects if crash doesnt exist
+    crash: crashData?.crashes?.[0] || {
       crash_injury_metrics_view: {},
       crashes_list_view: {},
     },
@@ -130,7 +127,7 @@ function Crash(props) {
   const hasLocation = crashRecord?.crash["location_id"];
   const hasCoordinates = !!latitude && !!longitude;
 
-  return !isValidCrash ? (
+  return !crashData.crashes[0] ? (
     <Page404 />
   ) : (
     <div className="animated fadeIn">

--- a/atd-vze/src/views/Crashes/Crash.js
+++ b/atd-vze/src/views/Crashes/Crash.js
@@ -93,12 +93,17 @@ function Crash(props) {
     setEditField("");
   };
 
+  // If crash doesnt exist or has been soft deleted, the 404 page should render
+  const isValidCrash = crashData?.crashes?.[0]?.is_deleted === false;
+
   const crashRecord = {
-    crash: crashData?.crashes?.[0] || {
+    // Need to construct empty objects if crash is invalid
+    crash: (isValidCrash && crashData?.crashes?.[0]) || {
       crash_injury_metrics_view: {},
       crashes_list_view: {},
     },
   };
+
   const crashPk = crashRecord?.crash?.id;
 
   const {
@@ -125,7 +130,7 @@ function Crash(props) {
   const hasLocation = crashRecord?.crash["location_id"];
   const hasCoordinates = !!latitude && !!longitude;
 
-  return !crashData.crashes[0] ? (
+  return !isValidCrash ? (
     <Page404 />
   ) : (
     <div className="animated fadeIn">


### PR DESCRIPTION
## Associated issues
Closes https://github.com/cityofaustin/atd-data-tech/issues/18789

## Testing
**URL to test:** <!-- VZ URL or Netlify -->
[Netlify](https://deploy-preview-1531--atd-vze-staging.netlify.app/#/create_crash_record)

**Steps to test:**
1. Go to the create crash record page, create a temp crash and route to its crash details page.
2. Now delete that temp record (this is a soft delete in the db) and go back to that same URL, instead of a WSOD you should get the 404 page.
3. Now type in a random crash id that doesnt exist at all, you should also get a WSOD.


---
#### Ship list
- [ ] Check migrations for any conflicts with latest migrations in master branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved