### PR TITLE
Move victim name to the right of people table

### DIFF
--- a/atd-vze/src/views/Crashes/VictimNameField.js
+++ b/atd-vze/src/views/Crashes/VictimNameField.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { Button, Input, Form, Row, Col, Label } from "reactstrap";
+import { Button, Input, Row, Col, Label } from "reactstrap";
 
 // This component should be role-restricted to users with Admin or IT Supervisor permissions
 // Role check currently happens in the shouldRenderVictimName function of personDataMap
@@ -40,7 +40,7 @@ const VictimNameField = ({
   return (
     <td>
       {isEditing && (
-        <Form>
+        <Col>
           <Row>
             {Object.keys(nameFieldConfig.subfields).map(field => {
               return (
@@ -89,7 +89,7 @@ const VictimNameField = ({
             </Col>
             <Col />
           </Row>
-        </Form>
+        </Col>
       )}
 
       {!isEditing && (

--- a/atd-vze/src/views/Crashes/VictimNameField.js
+++ b/atd-vze/src/views/Crashes/VictimNameField.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { Button, Input, Row, Col, Label } from "reactstrap";
+import { Button, Input, Row, Col, Label, Form } from "reactstrap";
 
 // This component should be role-restricted to users with Admin or IT Supervisor permissions
 // Role check currently happens in the shouldRenderVictimName function of personDataMap
@@ -40,56 +40,58 @@ const VictimNameField = ({
   return (
     <td>
       {isEditing && (
-        <Col>
-          <Row>
-            {Object.keys(nameFieldConfig.subfields).map(field => {
-              return (
-                <Col key={`$field-${field}${personId}`} className={"m-1 p-0"}>
-                  <Label className={"text-muted m-0 p-0"}>
-                    {nameFieldConfig.subfields[field].label}
-                  </Label>
-                  <Input
-                    defaultValue={row[field]}
-                    onChange={e => handleInputChange(e, field)}
-                    // Make input render in uppercase
-                    style={{ textTransform: "uppercase" }}
-                  ></Input>
-                </Col>
-              );
-            })}
-          </Row>
-          <Row>
-            <Col className={"mx-1 p-0"}>
-              <Button
-                type="submit"
-                block
-                color="primary"
-                size="sm"
-                style={{ minWidth: "50px" }}
-                className="btn-pill mt-2 mr-1"
-                onClick={e =>
-                  handleSubmit(e, mutationVariable, mutation, refetch)
-                }
-              >
-                <i className="fa fa-check edit-toggle" />
-              </Button>
-            </Col>
-            <Col className={"m-0 p-0"}>
-              <Button
-                type="cancel"
-                block
-                color="danger"
-                size="sm"
-                className="btn-pill mt-2"
-                style={{ minWidth: "50px" }}
-                onClick={e => handleCancelClick(e)}
-              >
-                <i className="fa fa-times edit-toggle"></i>
-              </Button>
-            </Col>
-            <Col />
-          </Row>
-        </Col>
+        <Form>
+          <Col>
+            <Row>
+              {Object.keys(nameFieldConfig.subfields).map(field => {
+                return (
+                  <Col key={`$field-${field}${personId}`} className={"m-1 p-0"}>
+                    <Label className={"text-muted m-0 p-0"}>
+                      {nameFieldConfig.subfields[field].label}
+                    </Label>
+                    <Input
+                      defaultValue={row[field]}
+                      onChange={e => handleInputChange(e, field)}
+                      // Make input render in uppercase
+                      style={{ textTransform: "uppercase" }}
+                    ></Input>
+                  </Col>
+                );
+              })}
+            </Row>
+            <Row>
+              <Col className={"mx-1 p-0"}>
+                <Button
+                  type="submit"
+                  block
+                  color="primary"
+                  size="sm"
+                  style={{ minWidth: "50px" }}
+                  className="btn-pill mt-2 mr-1"
+                  onClick={e =>
+                    handleSubmit(e, mutationVariable, mutation, refetch)
+                  }
+                >
+                  <i className="fa fa-check edit-toggle" />
+                </Button>
+              </Col>
+              <Col className={"m-0 p-0"}>
+                <Button
+                  type="cancel"
+                  block
+                  color="danger"
+                  size="sm"
+                  className="btn-pill mt-2"
+                  style={{ minWidth: "50px" }}
+                  onClick={e => handleCancelClick(e)}
+                >
+                  <i className="fa fa-times edit-toggle"></i>
+                </Button>
+              </Col>
+              <Col />
+            </Row>
+          </Col>
+        </Form>
       )}
 
       {!isEditing && (

--- a/atd-vze/src/views/Crashes/peopleDataMap.js
+++ b/atd-vze/src/views/Crashes/peopleDataMap.js
@@ -44,24 +44,6 @@ export const primaryPersonDataMap = [
         badge: true,
         badgeColor: getInjurySeverityColor,
       },
-      victim_name: {
-        label: "Victim Name",
-        editable: true,
-        format: "text",
-        mutationVariableKey: "personId",
-        shouldRender: shouldRenderVictimName,
-        subfields: {
-          prsn_first_name: {
-            label: "First",
-          },
-          prsn_mid_name: {
-            label: "Middle",
-          },
-          prsn_last_name: {
-            label: "Last",
-          },
-        },
-      },
       prsn_type: {
         label: "Type",
         editable: false,
@@ -105,6 +87,24 @@ export const primaryPersonDataMap = [
         format: "boolean",
         mutationVariableKey: "personId",
       },
+      victim_name: {
+        label: "Victim Name",
+        editable: true,
+        format: "text",
+        mutationVariableKey: "personId",
+        shouldRender: shouldRenderVictimName,
+        subfields: {
+          prsn_first_name: {
+            label: "First",
+          },
+          prsn_mid_name: {
+            label: "Middle",
+          },
+          prsn_last_name: {
+            label: "Last",
+          },
+        },
+      },
     },
   },
 ];
@@ -129,24 +129,6 @@ export const personDataMap = [
         mutationVariableKey: "personId",
         badge: true,
         badgeColor: getInjurySeverityColor,
-      },
-      victim_name: {
-        label: "Victim Name",
-        editable: true,
-        format: "text",
-        mutationVariableKey: "personId",
-        shouldRender: shouldRenderVictimName,
-        subfields: {
-          prsn_first_name: {
-            label: "First",
-          },
-          prsn_mid_name: {
-            label: "Middle",
-          },
-          prsn_last_name: {
-            label: "Last",
-          },
-        },
       },
       prsn_type: {
         label: "Type",
@@ -182,6 +164,24 @@ export const personDataMap = [
         editable: true,
         format: "boolean",
         mutationVariableKey: "personId",
+      },
+      victim_name: {
+        label: "Victim Name",
+        editable: true,
+        format: "text",
+        mutationVariableKey: "personId",
+        shouldRender: shouldRenderVictimName,
+        subfields: {
+          prsn_first_name: {
+            label: "First",
+          },
+          prsn_mid_name: {
+            label: "Middle",
+          },
+          prsn_last_name: {
+            label: "Last",
+          },
+        },
       },
     },
   },


### PR DESCRIPTION
## Associated issues
Closes https://github.com/cityofaustin/atd-data-tech/issues/18816

## Testing
**URL to test:** <!-- VZ URL or Netlify -->
[Netlify](https://deploy-preview-1532--atd-vze-staging.netlify.app/)

**Steps to test:**
1. For people with fatal injuries, see that the victim name column is now to the far right of the table. Check this for primary and non primary people.


---
#### Ship list
- [ ] Check migrations for any conflicts with latest migrations in master branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved