### PR TITLE
Add `drvr_lic_type_id` and `veh_hnr_fl` columns

### DIFF
--- a/atd-vzd/migrations/default/1725990787849_drvr_lic_type_id/down.sql
+++ b/atd-vzd/migrations/default/1725990787849_drvr_lic_type_id/down.sql
@@ -1,0 +1,9 @@
+delete from _column_metadata
+where
+    column_name = 'drvr_lic_type_id'
+    and record_type = 'people';
+
+alter table public.people_cris drop column drvr_lic_type_id;
+alter table public.people_edits drop column drvr_lic_type_id;
+alter table public.people drop column drvr_lic_type_id;
+drop table lookups.drvr_lic_type;

--- a/atd-vzd/migrations/default/1725990787849_drvr_lic_type_id/down.sql
+++ b/atd-vzd/migrations/default/1725990787849_drvr_lic_type_id/down.sql
@@ -3,6 +3,85 @@ where
     column_name = 'drvr_lic_type_id'
     and record_type = 'people';
 
+-- restore to version 1715960011005_cris_insert_triggers
+CREATE OR REPLACE FUNCTION public.people_cris_insert_rows()
+ RETURNS trigger
+ LANGUAGE plpgsql
+AS $function$
+BEGIN
+    -- insert new combined / official record
+    INSERT INTO public.people (
+        created_by,
+        drvr_city_name,
+        drvr_drg_cat_1_id,
+        drvr_zip,
+        id,
+        is_deleted,
+        is_primary_person,
+        prsn_age,
+        prsn_alc_rslt_id,
+        prsn_alc_spec_type_id,
+        prsn_bac_test_rslt,
+        prsn_death_timestamp,
+        prsn_drg_rslt_id,
+        prsn_drg_spec_type_id,
+        prsn_ethnicity_id,
+        prsn_exp_homelessness,
+        prsn_first_name,
+        prsn_gndr_id,
+        prsn_helmet_id,
+        prsn_injry_sev_id,
+        prsn_last_name,
+        prsn_mid_name,
+        prsn_name_sfx,
+        prsn_nbr,
+        prsn_occpnt_pos_id,
+        prsn_rest_id,
+        prsn_taken_by,
+        prsn_taken_to,
+        prsn_type_id,
+        unit_id,
+        updated_by
+    ) values (
+        new.created_by,
+        new.drvr_city_name,
+        new.drvr_drg_cat_1_id,
+        new.drvr_zip,
+        new.id,
+        new.is_deleted,
+        new.is_primary_person,
+        new.prsn_age,
+        new.prsn_alc_rslt_id,
+        new.prsn_alc_spec_type_id,
+        new.prsn_bac_test_rslt,
+        new.prsn_death_timestamp,
+        new.prsn_drg_rslt_id,
+        new.prsn_drg_spec_type_id,
+        new.prsn_ethnicity_id,
+        new.prsn_exp_homelessness,
+        new.prsn_first_name,
+        new.prsn_gndr_id,
+        new.prsn_helmet_id,
+        new.prsn_injry_sev_id,
+        new.prsn_last_name,
+        new.prsn_mid_name,
+        new.prsn_name_sfx,
+        new.prsn_nbr,
+        new.prsn_occpnt_pos_id,
+        new.prsn_rest_id,
+        new.prsn_taken_by,
+        new.prsn_taken_to,
+        new.prsn_type_id,
+        new.unit_id,
+        new.updated_by
+    );
+    -- insert new (editable) vz record (only record ID)
+    INSERT INTO public.people_edits (id) values (new.id);
+
+    RETURN NULL;
+END;
+$function$;
+
 alter table public.people_cris drop column drvr_lic_type_id;
 alter table public.people_edits drop column drvr_lic_type_id;
 alter table public.people drop column drvr_lic_type_id;

--- a/atd-vzd/migrations/default/1725990787849_drvr_lic_type_id/up.sql
+++ b/atd-vzd/migrations/default/1725990787849_drvr_lic_type_id/up.sql
@@ -14,6 +14,8 @@ insert into lookups.drvr_lic_type (id, label) values
 (98, 'OTHER'),
 (99, 'UNKNOWN');
 
+comment on table lookups.drvr_lic_type is 'Lookup table for driver''s license types';
+
 alter table public.people_cris
 add column drvr_lic_type_id integer,
 add constraint people_cris_drvr_lic_type_id_fkey
@@ -31,6 +33,10 @@ add column drvr_lic_type_id integer,
 add constraint people_drvr_lic_type_id_fkey
 foreign key (drvr_lic_type_id)
 references lookups.drvr_lic_type (id);
+
+comment on column public.people_cris.drvr_lic_type_id is 'Driver''s license type';
+comment on column public.people_edits.drvr_lic_type_id is 'Driver''s license type';
+comment on column public.people.drvr_lic_type_id is 'Driver''s license type';
 
 insert into _column_metadata (column_name, record_type, is_imported_from_cris)
 values ('drvr_lic_type_id', 'people', true);

--- a/atd-vzd/migrations/default/1725990787849_drvr_lic_type_id/up.sql
+++ b/atd-vzd/migrations/default/1725990787849_drvr_lic_type_id/up.sql
@@ -40,3 +40,84 @@ comment on column public.people.drvr_lic_type_id is 'Driver''s license type';
 
 insert into _column_metadata (column_name, record_type, is_imported_from_cris)
 values ('drvr_lic_type_id', 'people', true);
+
+CREATE OR REPLACE FUNCTION public.people_cris_insert_rows()
+ RETURNS trigger
+ LANGUAGE plpgsql
+AS $function$
+BEGIN
+    -- insert new combined / official record
+    INSERT INTO public.people (
+        created_by,
+        drvr_city_name,
+        drvr_drg_cat_1_id,
+        drvr_lic_type_id,
+        drvr_zip,
+        id,
+        is_deleted,
+        is_primary_person,
+        prsn_age,
+        prsn_alc_rslt_id,
+        prsn_alc_spec_type_id,
+        prsn_bac_test_rslt,
+        prsn_death_timestamp,
+        prsn_drg_rslt_id,
+        prsn_drg_spec_type_id,
+        prsn_ethnicity_id,
+        prsn_exp_homelessness,
+        prsn_first_name,
+        prsn_gndr_id,
+        prsn_helmet_id,
+        prsn_injry_sev_id,
+        prsn_last_name,
+        prsn_mid_name,
+        prsn_name_sfx,
+        prsn_nbr,
+        prsn_occpnt_pos_id,
+        prsn_rest_id,
+        prsn_taken_by,
+        prsn_taken_to,
+        prsn_type_id,
+        unit_id,
+        updated_by
+    ) values (
+        new.created_by,
+        new.drvr_city_name,
+        new.drvr_drg_cat_1_id,
+        new.drvr_lic_type_id,
+        new.drvr_zip,
+        new.id,
+        new.is_deleted,
+        new.is_primary_person,
+        new.prsn_age,
+        new.prsn_alc_rslt_id,
+        new.prsn_alc_spec_type_id,
+        new.prsn_bac_test_rslt,
+        new.prsn_death_timestamp,
+        new.prsn_drg_rslt_id,
+        new.prsn_drg_spec_type_id,
+        new.prsn_ethnicity_id,
+        new.prsn_exp_homelessness,
+        new.prsn_first_name,
+        new.prsn_gndr_id,
+        new.prsn_helmet_id,
+        new.prsn_injry_sev_id,
+        new.prsn_last_name,
+        new.prsn_mid_name,
+        new.prsn_name_sfx,
+        new.prsn_nbr,
+        new.prsn_occpnt_pos_id,
+        new.prsn_rest_id,
+        new.prsn_taken_by,
+        new.prsn_taken_to,
+        new.prsn_type_id,
+        new.unit_id,
+        new.updated_by
+    );
+    -- insert new (editable) vz record (only record ID)
+    INSERT INTO public.people_edits (id) values (new.id);
+
+    RETURN NULL;
+END;
+$function$;
+

--- a/atd-vzd/migrations/default/1725990787849_drvr_lic_type_id/up.sql
+++ b/atd-vzd/migrations/default/1725990787849_drvr_lic_type_id/up.sql
@@ -1,0 +1,36 @@
+create table lookups.drvr_lic_type (
+    id integer primary key,
+    label text not null unique,
+    source text not null default 'cris'
+);
+
+insert into lookups.drvr_lic_type (id, label) values
+(1, 'ID CARD'),
+(4, 'COMMERCIAL DRIVER LIC.'),
+(8, 'UNLICENSED'),
+(9, 'DRIVER LICENSE'),
+(10, 'OCCUPATIONAL'),
+(95, 'AUTONOMOUS'),
+(98, 'OTHER'),
+(99, 'UNKNOWN');
+
+alter table public.people_cris
+add column drvr_lic_type_id integer,
+add constraint people_cris_drvr_lic_type_id_fkey
+foreign key (drvr_lic_type_id)
+references lookups.drvr_lic_type (id);
+
+alter table public.people_edits
+add column drvr_lic_type_id integer,
+add constraint people_edits_drvr_lic_type_id_fkey
+foreign key (drvr_lic_type_id)
+references lookups.drvr_lic_type (id);
+
+alter table public.people
+add column drvr_lic_type_id integer,
+add constraint people_drvr_lic_type_id_fkey
+foreign key (drvr_lic_type_id)
+references lookups.drvr_lic_type (id);
+
+insert into _column_metadata (column_name, record_type, is_imported_from_cris)
+values ('drvr_lic_type_id', 'people', true);

--- a/atd-vzd/migrations/default/1725990797742_veh_hnr_fl/down.sql
+++ b/atd-vzd/migrations/default/1725990797742_veh_hnr_fl/down.sql
@@ -1,3 +1,86 @@
+-- restore to version 1715960011005_cris_insert_triggers
+CREATE OR REPLACE FUNCTION public.units_cris_insert_rows()
+ RETURNS trigger
+ LANGUAGE plpgsql
+AS $function$
+BEGIN
+    -- insert new combined / official record
+    INSERT INTO public.units (
+        autonomous_unit_id,
+        contrib_factr_1_id,
+        contrib_factr_2_id,
+        contrib_factr_3_id,
+        contrib_factr_p1_id,
+        contrib_factr_p2_id,
+        crash_pk,
+        created_by,
+        cris_crash_id,
+        e_scooter_id,
+        first_harm_evt_inv_id,
+        id,
+        is_deleted,
+        pbcat_pedalcyclist_id,
+        pbcat_pedestrian_id,
+        pedalcyclist_action_id,
+        pedestrian_action_id,
+        rpt_autonomous_level_engaged_id,
+        unit_desc_id,
+        unit_nbr,
+        updated_by,
+        veh_body_styl_id,
+        veh_damage_description1_id,
+        veh_damage_description2_id,
+        veh_damage_direction_of_force1_id,
+        veh_damage_direction_of_force2_id,
+        veh_damage_severity1_id,
+        veh_damage_severity2_id,
+        veh_make_id,
+        veh_mod_id,
+        veh_mod_year,
+        veh_trvl_dir_id,
+        vin
+    ) values (
+        new.autonomous_unit_id,
+        new.contrib_factr_1_id,
+        new.contrib_factr_2_id,
+        new.contrib_factr_3_id,
+        new.contrib_factr_p1_id,
+        new.contrib_factr_p2_id,
+        new.crash_pk,
+        new.created_by,
+        new.cris_crash_id,
+        new.e_scooter_id,
+        new.first_harm_evt_inv_id,
+        new.id,
+        new.is_deleted,
+        new.pbcat_pedalcyclist_id,
+        new.pbcat_pedestrian_id,
+        new.pedalcyclist_action_id,
+        new.pedestrian_action_id,
+        new.rpt_autonomous_level_engaged_id,
+        new.unit_desc_id,
+        new.unit_nbr,
+        new.updated_by,
+        new.veh_body_styl_id,
+        new.veh_damage_description1_id,
+        new.veh_damage_description2_id,
+        new.veh_damage_direction_of_force1_id,
+        new.veh_damage_direction_of_force2_id,
+        new.veh_damage_severity1_id,
+        new.veh_damage_severity2_id,
+        new.veh_make_id,
+        new.veh_mod_id,
+        new.veh_mod_year,
+        new.veh_trvl_dir_id,
+        new.vin
+    );
+    -- insert new (editable) vz record (only record ID)
+    INSERT INTO public.units_edits (id) values (new.id);
+
+    RETURN NULL;
+END;
+$function$;
+
 delete from _column_metadata
 where
     column_name = 'veh_hnr_fl'

--- a/atd-vzd/migrations/default/1725990797742_veh_hnr_fl/down.sql
+++ b/atd-vzd/migrations/default/1725990797742_veh_hnr_fl/down.sql
@@ -1,0 +1,8 @@
+delete from _column_metadata
+where
+    column_name = 'veh_hnr_fl'
+    and record_type = 'units';
+
+alter table units_cris drop column veh_hnr_fl;
+alter table units_edits drop column veh_hnr_fl;
+alter table units drop column veh_hnr_fl;

--- a/atd-vzd/migrations/default/1725990797742_veh_hnr_fl/up.sql
+++ b/atd-vzd/migrations/default/1725990797742_veh_hnr_fl/up.sql
@@ -2,9 +2,93 @@ alter table units_cris add column veh_hnr_fl boolean;
 alter table units_edits add column veh_hnr_fl boolean;
 alter table units add column veh_hnr_fl boolean;
 
-comment on column public.units_cris.veh_hnr_fl is 'If the unit left the scene of the crash, aka, hit-and-run. ';
-comment on column public.units_edits.veh_hnr_fl is 'If the unit left the scene of the crash, aka, hit-and-run. ';
-comment on column public.units.veh_hnr_fl is 'If the unit left the scene of the crash, aka, hit-and-run. ';
+comment on column public.units_cris.veh_hnr_fl is 'If the unit was involved in a hit-and-run crash. This field may indicate that the unit was the victim of a hit and run, or this unit left the scene/committed the hit and run';
+comment on column public.units_edits.veh_hnr_fl is 'If the unit was involved in a hit-and-run crash. This field may indicate that the unit was the victim of a hit and run, or this unit left the scene/committed the hit and run';
+comment on column public.units.veh_hnr_fl is 'If the unit was involved in a hit-and-run crash. This field may indicate that the unit was the victim of a hit and run, or this unit left the scene/committed the hit and run';
 
 insert into _column_metadata (column_name, record_type, is_imported_from_cris)
 values ('veh_hnr_fl', 'units', true);
+
+CREATE OR REPLACE FUNCTION public.units_cris_insert_rows()
+ RETURNS trigger
+ LANGUAGE plpgsql
+AS $function$
+BEGIN
+    -- insert new combined / official record
+    INSERT INTO public.units (
+        autonomous_unit_id,
+        contrib_factr_1_id,
+        contrib_factr_2_id,
+        contrib_factr_3_id,
+        contrib_factr_p1_id,
+        contrib_factr_p2_id,
+        crash_pk,
+        created_by,
+        cris_crash_id,
+        e_scooter_id,
+        first_harm_evt_inv_id,
+        id,
+        is_deleted,
+        pbcat_pedalcyclist_id,
+        pbcat_pedestrian_id,
+        pedalcyclist_action_id,
+        pedestrian_action_id,
+        rpt_autonomous_level_engaged_id,
+        unit_desc_id,
+        unit_nbr,
+        updated_by,
+        veh_body_styl_id,
+        veh_damage_description1_id,
+        veh_damage_description2_id,
+        veh_damage_direction_of_force1_id,
+        veh_damage_direction_of_force2_id,
+        veh_damage_severity1_id,
+        veh_damage_severity2_id,
+        veh_hnr_fl,
+        veh_make_id,
+        veh_mod_id,
+        veh_mod_year,
+        veh_trvl_dir_id,
+        vin
+    ) values (
+        new.autonomous_unit_id,
+        new.contrib_factr_1_id,
+        new.contrib_factr_2_id,
+        new.contrib_factr_3_id,
+        new.contrib_factr_p1_id,
+        new.contrib_factr_p2_id,
+        new.crash_pk,
+        new.created_by,
+        new.cris_crash_id,
+        new.e_scooter_id,
+        new.first_harm_evt_inv_id,
+        new.id,
+        new.is_deleted,
+        new.pbcat_pedalcyclist_id,
+        new.pbcat_pedestrian_id,
+        new.pedalcyclist_action_id,
+        new.pedestrian_action_id,
+        new.rpt_autonomous_level_engaged_id,
+        new.unit_desc_id,
+        new.unit_nbr,
+        new.updated_by,
+        new.veh_body_styl_id,
+        new.veh_damage_description1_id,
+        new.veh_damage_description2_id,
+        new.veh_damage_direction_of_force1_id,
+        new.veh_damage_direction_of_force2_id,
+        new.veh_damage_severity1_id,
+        new.veh_damage_severity2_id,
+        new.veh_make_id,
+        new.veh_hnr_fl,
+        new.veh_mod_id,
+        new.veh_mod_year,
+        new.veh_trvl_dir_id,
+        new.vin
+    );
+    -- insert new (editable) vz record (only record ID)
+    INSERT INTO public.units_edits (id) values (new.id);
+
+    RETURN NULL;
+END;
+$function$;

--- a/atd-vzd/migrations/default/1725990797742_veh_hnr_fl/up.sql
+++ b/atd-vzd/migrations/default/1725990797742_veh_hnr_fl/up.sql
@@ -1,0 +1,6 @@
+alter table units_cris add column veh_hnr_fl boolean;
+alter table units_edits add column veh_hnr_fl boolean;
+alter table units add column veh_hnr_fl boolean;
+
+insert into _column_metadata (column_name, record_type, is_imported_from_cris)
+values ('veh_hnr_fl', 'units', true);

--- a/atd-vzd/migrations/default/1725990797742_veh_hnr_fl/up.sql
+++ b/atd-vzd/migrations/default/1725990797742_veh_hnr_fl/up.sql
@@ -2,5 +2,9 @@ alter table units_cris add column veh_hnr_fl boolean;
 alter table units_edits add column veh_hnr_fl boolean;
 alter table units add column veh_hnr_fl boolean;
 
+comment on column public.units_cris.veh_hnr_fl is 'If the unit left the scene of the crash, aka, hit-and-run. ';
+comment on column public.units_edits.veh_hnr_fl is 'If the unit left the scene of the crash, aka, hit-and-run. ';
+comment on column public.units.veh_hnr_fl is 'If the unit left the scene of the crash, aka, hit-and-run. ';
+
 insert into _column_metadata (column_name, record_type, is_imported_from_cris)
 values ('veh_hnr_fl', 'units', true);


### PR DESCRIPTION
## Associated issues
- https://github.com/cityofaustin/atd-data-tech/issues/18931

## Testing

1. Start your local stack
2. Apply migrations and metadata
3. From your CRIS import directory,  run the import on whatever zips you have laying around (or use `--s3-download` to fetch one from the bucket).

```shell
$ docker run -it  --rm --env-file .env --network host -v $PWD:/app cris_import_cris_import ./cris_import.py --csv --skip-unzip
```

4. To make sure the trigger is working, inspect the data in your DB by setting the `created_at` date in this query to the current date:

```sql
-- compare cris drvr_lic_type_id to unified value
SELECT
    people_cris.drvr_lic_type_id AS cris_drvr_lic_type_id,
    people.drvr_lic_type_id AS unified_drvr_lic_type_id
FROM
    people_cris
    LEFT JOIN people ON people_cris.id = people.id
WHERE
    people_cris.created_at > '2024-09-10';

-- compare cris cris_veh_hnr_fl to unified value
SELECT
    units_cris.veh_hnr_fl AS cris_veh_hnr_fl,
    units.veh_hnr_fl AS unified_veh_hnr_fl
FROM
    units_cris
    LEFT JOIN units ON units_cris.id = units.id
WHERE
    units_cris.created_at > '2024-09-10';


```




---
#### Ship list
- [ ] Check migrations for any conflicts with latest migrations in master branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved