### PR TITLE
Add global crash search

### DIFF
--- a/atd-vze/src/Components/CrashNavigationSearchForm.js
+++ b/atd-vze/src/Components/CrashNavigationSearchForm.js
@@ -3,7 +3,7 @@ import { useHistory } from "react-router-dom";
 import { Form, Input, InputGroup, InputGroupAddon, Button } from "reactstrap";
 
 // captures any non-number except the `t` and `T` (for temp crashes)
-const CRASH_ID_EXCLUDE_CHARACTERS_REGEX = /[^(0-9tT)]*/;
+const CRASH_ID_EXCLUDE_CHARACTERS_REGEX = /[^\dtT]*/g;
 
 const CrashNavigationSearchForm = () => {
   const [crashSearchId, setCrashSearchId] = useState("");

--- a/atd-vze/src/Components/CrashNavigationSearchForm.js
+++ b/atd-vze/src/Components/CrashNavigationSearchForm.js
@@ -1,0 +1,46 @@
+import React, { useState } from "react";
+import { useHistory } from "react-router-dom";
+import { Form, Input, InputGroup, InputGroupAddon, Button } from "reactstrap";
+
+// captures any non-number except the `t` and `T` (for temp crashes)
+const CRASH_ID_EXCLUDE_CHARACTERS_REGEX = /[^(0-9tT)]*/;
+
+const CrashNavigationSearchForm = () => {
+  const [crashSearchId, setCrashSearchId] = useState("");
+  let history = useHistory();
+
+  return (
+    <Form className="mr-2" onSubmit={e => e.preventDefault()}>
+      <InputGroup>
+        <Input
+          size="sm"
+          type="text"
+          name="crash-navigation-search"
+          placeholder={"Go to crash..."}
+          value={crashSearchId}
+          onChange={e =>
+            setCrashSearchId(
+              e.target.value.replace(CRASH_ID_EXCLUDE_CHARACTERS_REGEX, "")
+            )
+          }
+        />
+        <InputGroupAddon addonType="append">
+          <Button
+            type="submit"
+            color="secondary"
+            disabled={!crashSearchId}
+            size="sm"
+            onClick={() => {
+              history.push(`/crashes/${crashSearchId}`);
+              setCrashSearchId("");
+            }}
+          >
+            <i className="fa fa-arrow-right" />
+          </Button>
+        </InputGroupAddon>
+      </InputGroup>
+    </Form>
+  );
+};
+
+export default CrashNavigationSearchForm;

--- a/atd-vze/src/containers/DefaultLayout/DefaultHeader.js
+++ b/atd-vze/src/containers/DefaultLayout/DefaultHeader.js
@@ -93,6 +93,7 @@ const DefaultHeader = props => {
                 alt="admin@bootstrapmaster.com"
               />
             </DropdownToggle>
+            {/* Account section */}
             <DropdownMenu right>
               <DropdownItem header tag="div" className="text-center">
                 <strong>Account</strong>
@@ -103,7 +104,7 @@ const DefaultHeader = props => {
               <DropdownItem onClick={logout}>
                 <i className="fa fa-lock" /> Log Out
               </DropdownItem>
-
+              {/* Support section */}
               <DropdownItem header tag="div" className="text-center">
                 <strong>Support</strong>
               </DropdownItem>

--- a/atd-vze/src/containers/DefaultLayout/DefaultHeader.js
+++ b/atd-vze/src/containers/DefaultLayout/DefaultHeader.js
@@ -1,5 +1,5 @@
-import React, { useState } from "react";
-import { NavLink, useHistory } from "react-router-dom";
+import React from "react";
+import { NavLink } from "react-router-dom";
 import { useAuth0 } from "../../auth/authContext";
 import Can from "../../auth/Can";
 import {
@@ -10,15 +10,11 @@ import {
   Nav,
   NavItem,
   Alert,
-  Form,
-  Input,
-  InputGroup,
-  InputGroupAddon,
-  Button,
 } from "reactstrap";
 import PropTypes from "prop-types";
 
 import { AppHeader, AppNavbarBrand, AppSidebarToggler } from "@coreui/react";
+import CrashNavigationSearchForm from "../../Components/CrashNavigationSearchForm";
 import logo from "../../assets/img/brand/visionzerotext.png";
 
 const propTypes = {
@@ -48,41 +44,6 @@ const EnvAlertBanner = () => {
       This is a <span style={{ fontWeight: "bold" }}>{env}</span> environment
       for testing purposes.
     </Alert>
-  );
-};
-
-const GlobalSearch = () => {
-  const [crashSearchId, setCrashSearchId] = useState("");
-  let history = useHistory();
-
-  return (
-    <Form className="mr-2" onSubmit={e => e.preventDefault()}>
-      <InputGroup>
-        <Input
-          size="sm"
-          type="text"
-          name="crash-navigation-search"
-          placeholder={"Go to crash..."}
-          value={crashSearchId}
-          onChange={e => setCrashSearchId(e.target.value.replace(/\W/g, ""))}
-        />
-
-        <InputGroupAddon addonType="append">
-          <Button
-            type="submit"
-            color="secondary"
-            disabled={!crashSearchId}
-            size="sm"
-            onClick={() => {
-              history.push(`/crashes/${crashSearchId}`);
-              setCrashSearchId("");
-            }}
-          >
-            <i className="fa fa-arrow-right" />
-          </Button>
-        </InputGroupAddon>
-      </InputGroup>
-    </Form>
   );
 };
 
@@ -126,7 +87,7 @@ const DefaultHeader = props => {
         </Nav>
 
         <Nav className="ml-auto" navbar>
-          <GlobalSearch />
+          <CrashNavigationSearchForm />
           <UncontrolledDropdown nav direction="down">
             <DropdownToggle nav>
               <img

--- a/atd-vze/src/containers/DefaultLayout/DefaultHeader.js
+++ b/atd-vze/src/containers/DefaultLayout/DefaultHeader.js
@@ -1,5 +1,5 @@
-import React from "react";
-import { NavLink } from "react-router-dom";
+import React, { useState } from "react";
+import { NavLink, useHistory } from "react-router-dom";
 import { useAuth0 } from "../../auth/authContext";
 import Can from "../../auth/Can";
 import {
@@ -10,6 +10,11 @@ import {
   Nav,
   NavItem,
   Alert,
+  Form,
+  Input,
+  InputGroup,
+  InputGroupAddon,
+  Button,
 } from "reactstrap";
 import PropTypes from "prop-types";
 
@@ -43,6 +48,38 @@ const EnvAlertBanner = () => {
       This is a <span style={{ fontWeight: "bold" }}>{env}</span> environment
       for testing purposes.
     </Alert>
+  );
+};
+
+const GlobalSearch = () => {
+  const [crashSearchId, setCrashSearchId] = useState(null);
+  let history = useHistory();
+
+  return (
+    <Form className="mr-2" onSubmit={e => e.preventDefault()}>
+      <InputGroup>
+        <Input
+          size="sm"
+          type="text"
+          name="crash-navigation-search"
+          placeholder={"Go to crash..."}
+          value={crashSearchId}
+          onChange={e => setCrashSearchId(e.target.value.replace(/\W/g, ""))}
+        />
+
+        <InputGroupAddon addonType="append">
+          <Button
+            type="submit"
+            color="secondary"
+            disabled={!crashSearchId}
+            size="sm"
+            onClick={() => history.push(`/crashes/${crashSearchId}`)}
+          >
+            <i className="fa fa-arrow-right" />
+          </Button>
+        </InputGroupAddon>
+      </InputGroup>
+    </Form>
   );
 };
 
@@ -84,7 +121,9 @@ const DefaultHeader = props => {
             )}
           />
         </Nav>
+
         <Nav className="ml-auto" navbar>
+          <GlobalSearch />
           <UncontrolledDropdown nav direction="down">
             <DropdownToggle nav>
               <img
@@ -103,13 +142,7 @@ const DefaultHeader = props => {
               <DropdownItem onClick={logout}>
                 <i className="fa fa-lock" /> Log Out
               </DropdownItem>
-            </DropdownMenu>
-          </UncontrolledDropdown>
-          <UncontrolledDropdown nav direction="down">
-            <DropdownToggle nav>
-              <i className="fa fa-question-circle fa-2x" />
-            </DropdownToggle>
-            <DropdownMenu right>
+
               <DropdownItem header tag="div" className="text-center">
                 <strong>Support</strong>
               </DropdownItem>

--- a/atd-vze/src/containers/DefaultLayout/DefaultHeader.js
+++ b/atd-vze/src/containers/DefaultLayout/DefaultHeader.js
@@ -51,7 +51,6 @@ const DefaultHeader = props => {
   const { logout, getRoles } = useAuth0();
   // eslint-disable-next-line
   const { children, ...attributes } = props;
-
   return (
     <div className="sticky-top">
       <EnvAlertBanner />
@@ -66,7 +65,6 @@ const DefaultHeader = props => {
           }}
         />
         <AppSidebarToggler className="d-md-down-none" display="lg" />
-
         <Nav className="d-md-down-none" navbar>
           <NavItem className="px-3">
             <NavLink to="/dashboard" className="nav-link">
@@ -85,7 +83,6 @@ const DefaultHeader = props => {
             )}
           />
         </Nav>
-
         <Nav className="ml-auto" navbar>
           <CrashNavigationSearchForm />
           <UncontrolledDropdown nav direction="down">

--- a/atd-vze/src/containers/DefaultLayout/DefaultHeader.js
+++ b/atd-vze/src/containers/DefaultLayout/DefaultHeader.js
@@ -52,7 +52,7 @@ const EnvAlertBanner = () => {
 };
 
 const GlobalSearch = () => {
-  const [crashSearchId, setCrashSearchId] = useState(null);
+  const [crashSearchId, setCrashSearchId] = useState("");
   let history = useHistory();
 
   return (
@@ -73,7 +73,10 @@ const GlobalSearch = () => {
             color="secondary"
             disabled={!crashSearchId}
             size="sm"
-            onClick={() => history.push(`/crashes/${crashSearchId}`)}
+            onClick={() => {
+              history.push(`/crashes/${crashSearchId}`);
+              setCrashSearchId("");
+            }}
           >
             <i className="fa fa-arrow-right" />
           </Button>

--- a/atd-vze/src/containers/DefaultLayout/DefaultHeader.js
+++ b/atd-vze/src/containers/DefaultLayout/DefaultHeader.js
@@ -109,7 +109,7 @@ const DefaultHeader = props => {
                 <strong>Support</strong>
               </DropdownItem>
               <DropdownItem
-                href="https://atd.knack.com/dts#new-service-request/?view_249_vars=%7B%22field_398%22%3A%22Bug%20Report%20%E2%80%94%20Something%20is%20not%20working%22%2C%22field_399%22%3A%22Vision%20Zero%20(Editor)%22%7D"
+                href="https://atd.knack.com/dts#new-service-request/?view_249_vars=%7B%22field_398%22%3A%22Bug%20Report%20%E2%80%94%20Something%20is%20not%20working%22%2C%22field_399%22%3A%22Vision%20Zero%20Editor%22%7D"
                 target="_blank"
                 rel="noreferrer"
               >
@@ -117,7 +117,7 @@ const DefaultHeader = props => {
                 <i className="fa fa-external-link" />
               </DropdownItem>
               <DropdownItem
-                href="https://atd.knack.com/dts#new-service-request/?view_249_vars=%7B%22field_398%22%3A%22Feature%20or%20Enhancement%20%E2%80%94%20An%20application%20I%20use%20could%20be%20improved%22%2C%22field_399%22%3A%22Vision%20Zero%20(Editor)%22%7D"
+                href="https://atd.knack.com/dts#new-service-request/?view_249_vars=%7B%22field_398%22%3A%22Feature%20or%20Enhancement%20%E2%80%94%20An%20application%20I%20use%20could%20be%20improved%22%2C%22field_399%22%3A%22Vision%20Zero%20Editor%22%7D"
                 target="_blank"
                 rel="noreferrer"
               >

--- a/atd-vze/src/containers/DefaultLayout/DefaultHeader.js
+++ b/atd-vze/src/containers/DefaultLayout/DefaultHeader.js
@@ -85,7 +85,7 @@ const DefaultHeader = props => {
         </Nav>
         <Nav className="ml-auto" navbar>
           <CrashNavigationSearchForm />
-          <UncontrolledDropdown nav direction="down">
+          <UncontrolledDropdown nav direction="down" className="mr-2">
             <DropdownToggle nav>
               <img
                 src={"./assets/img/avatars/1.png"}

--- a/atd-vze/src/views/Crashes/CrashDiagram.js
+++ b/atd-vze/src/views/Crashes/CrashDiagram.js
@@ -169,7 +169,7 @@ const CrashDiagram = ({ crashId, isCr3Stored, isTempRecord }) => {
               <p>
                 For additional assistance, you can
                 <a
-                  href="https://atd.knack.com/dts#new-service-request/?view_249_vars=%7B%22field_398%22%3A%22Bug%20Report%20%E2%80%94%20Something%20is%20not%20working%22%2C%22field_399%22%3A%22Vision%20Zero%20(Editor)%22%7D"
+                  href="https://atd.knack.com/dts#new-service-request/?view_249_vars=%7B%22field_398%22%3A%22Bug%20Report%20%E2%80%94%20Something%20is%20not%20working%22%2C%22field_399%22%3A%22Vision%20Zero%20Editor%22%7D"
                   target="_blank"
                   rel="noopener noreferrer"
                 >


### PR DESCRIPTION
## Associated issues

- https://github.com/cityofaustin/atd-data-tech/issues/19034

## Testing

**URL to test:** [Deploy preview](https://deploy-preview-1549--atd-vze-staging.netlify.app/#/crashes)

1. Try using the new search form with a valid crash ID (`20339647`), a temporary crash ID (`T338978`), and a crash ID that doesn't exist (`12345`)
2. Confirm that the `404` page renders when you search for a crash that doesn't exist
3. Confirm that you cannot enter any non-digit characters except `T` and `t` into the search form
4. Confirm that you can use the `enter` key to submit the search form
5. Confirm that search input is cleared after the form is submitted
6. Check out the new combined account/support menu in the top-right—it should work normally

---
#### Ship list
- [ ] Check migrations for any conflicts with latest migrations in master branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved