### PR TITLE
Fix column order in units_cris_insert_rows()

### DIFF
--- a/database/migrations/default/1726766736889_patch-units_cris_insert_rows/down.sql
+++ b/database/migrations/default/1726766736889_patch-units_cris_insert_rows/down.sql
@@ -69,16 +69,10 @@ BEGIN
         new.veh_damage_direction_of_force2_id,
         new.veh_damage_severity1_id,
         new.veh_damage_severity2_id,
-        new.veh_hnr_fl,
         new.veh_make_id,
+        new.veh_hnr_fl,
         new.veh_mod_id,
         new.veh_mod_year,
         new.veh_trvl_dir_id,
         new.vin
     );
-    -- insert new (editable) vz record (only record ID)
-    INSERT INTO public.units_edits (id) values (new.id);
-
-    RETURN NULL;
-END;
-$function$;

--- a/database/migrations/default/1726766736889_patch-units_cris_insert_rows/down.sql
+++ b/database/migrations/default/1726766736889_patch-units_cris_insert_rows/down.sql
@@ -1,0 +1,84 @@
+--revert to migrations/default/1725990797742_veh_hnr_fl - which is bugged out!
+CREATE OR REPLACE FUNCTION public.units_cris_insert_rows()
+ RETURNS trigger
+ LANGUAGE plpgsql
+AS $function$
+BEGIN
+    -- insert new combined / official record
+    INSERT INTO public.units (
+        autonomous_unit_id,
+        contrib_factr_1_id,
+        contrib_factr_2_id,
+        contrib_factr_3_id,
+        contrib_factr_p1_id,
+        contrib_factr_p2_id,
+        crash_pk,
+        created_by,
+        cris_crash_id,
+        e_scooter_id,
+        first_harm_evt_inv_id,
+        id,
+        is_deleted,
+        pbcat_pedalcyclist_id,
+        pbcat_pedestrian_id,
+        pedalcyclist_action_id,
+        pedestrian_action_id,
+        rpt_autonomous_level_engaged_id,
+        unit_desc_id,
+        unit_nbr,
+        updated_by,
+        veh_body_styl_id,
+        veh_damage_description1_id,
+        veh_damage_description2_id,
+        veh_damage_direction_of_force1_id,
+        veh_damage_direction_of_force2_id,
+        veh_damage_severity1_id,
+        veh_damage_severity2_id,
+        veh_hnr_fl,
+        veh_make_id,
+        veh_mod_id,
+        veh_mod_year,
+        veh_trvl_dir_id,
+        vin
+    ) values (
+        new.autonomous_unit_id,
+        new.contrib_factr_1_id,
+        new.contrib_factr_2_id,
+        new.contrib_factr_3_id,
+        new.contrib_factr_p1_id,
+        new.contrib_factr_p2_id,
+        new.crash_pk,
+        new.created_by,
+        new.cris_crash_id,
+        new.e_scooter_id,
+        new.first_harm_evt_inv_id,
+        new.id,
+        new.is_deleted,
+        new.pbcat_pedalcyclist_id,
+        new.pbcat_pedestrian_id,
+        new.pedalcyclist_action_id,
+        new.pedestrian_action_id,
+        new.rpt_autonomous_level_engaged_id,
+        new.unit_desc_id,
+        new.unit_nbr,
+        new.updated_by,
+        new.veh_body_styl_id,
+        new.veh_damage_description1_id,
+        new.veh_damage_description2_id,
+        new.veh_damage_direction_of_force1_id,
+        new.veh_damage_direction_of_force2_id,
+        new.veh_damage_severity1_id,
+        new.veh_damage_severity2_id,
+        new.veh_hnr_fl,
+        new.veh_make_id,
+        new.veh_mod_id,
+        new.veh_mod_year,
+        new.veh_trvl_dir_id,
+        new.vin
+    );
+    -- insert new (editable) vz record (only record ID)
+    INSERT INTO public.units_edits (id) values (new.id);
+
+    RETURN NULL;
+END;
+$function$;

--- a/database/migrations/default/1726766736889_patch-units_cris_insert_rows/up.sql
+++ b/database/migrations/default/1726766736889_patch-units_cris_insert_rows/up.sql
@@ -1,0 +1,83 @@
+CREATE OR REPLACE FUNCTION public.units_cris_insert_rows()
+ RETURNS trigger
+ LANGUAGE plpgsql
+AS $function$
+BEGIN
+    -- insert new combined / official record
+    INSERT INTO public.units (
+        autonomous_unit_id,
+        contrib_factr_1_id,
+        contrib_factr_2_id,
+        contrib_factr_3_id,
+        contrib_factr_p1_id,
+        contrib_factr_p2_id,
+        crash_pk,
+        created_by,
+        cris_crash_id,
+        e_scooter_id,
+        first_harm_evt_inv_id,
+        id,
+        is_deleted,
+        pbcat_pedalcyclist_id,
+        pbcat_pedestrian_id,
+        pedalcyclist_action_id,
+        pedestrian_action_id,
+        rpt_autonomous_level_engaged_id,
+        unit_desc_id,
+        unit_nbr,
+        updated_by,
+        veh_body_styl_id,
+        veh_damage_description1_id,
+        veh_damage_description2_id,
+        veh_damage_direction_of_force1_id,
+        veh_damage_direction_of_force2_id,
+        veh_damage_severity1_id,
+        veh_damage_severity2_id,
+        veh_hnr_fl,
+        veh_make_id,
+        veh_mod_id,
+        veh_mod_year,
+        veh_trvl_dir_id,
+        vin
+    ) values (
+        new.autonomous_unit_id,
+        new.contrib_factr_1_id,
+        new.contrib_factr_2_id,
+        new.contrib_factr_3_id,
+        new.contrib_factr_p1_id,
+        new.contrib_factr_p2_id,
+        new.crash_pk,
+        new.created_by,
+        new.cris_crash_id,
+        new.e_scooter_id,
+        new.first_harm_evt_inv_id,
+        new.id,
+        new.is_deleted,
+        new.pbcat_pedalcyclist_id,
+        new.pbcat_pedestrian_id,
+        new.pedalcyclist_action_id,
+        new.pedestrian_action_id,
+        new.rpt_autonomous_level_engaged_id,
+        new.unit_desc_id,
+        new.unit_nbr,
+        new.updated_by,
+        new.veh_body_styl_id,
+        new.veh_damage_description1_id,
+        new.veh_damage_description2_id,
+        new.veh_damage_direction_of_force1_id,
+        new.veh_damage_direction_of_force2_id,
+        new.veh_damage_severity1_id,
+        new.veh_damage_severity2_id,
+        new.veh_hnr_fl,
+        new.veh_make_id,
+        new.veh_mod_id,
+        new.veh_mod_year,
+        new.veh_trvl_dir_id,
+        new.vin
+    );
+    -- insert new (editable) vz record (only record ID)
+    INSERT INTO public.units_edits (id) values (new.id);
+
+    RETURN NULL;
+END;
+$function$;


### PR DESCRIPTION
## Associated issues
- https://github.com/cityofaustin/atd-data-tech/issues/19135

I'm not sure how this got through testing—I guess the extracts I tested with didn't have any data in these columns, and I didn't test the Create Crash Record form 😕 

## Testing

1. Start your local stack
2. Use the VZE to create a new crash record
4. Run the cris import:
 ```
docker run -it  --rm --env-file .env --network host -v $PWD:/app cris_import_cris_import ./cris_import.py --csv --s3-download
```

---

#### Ship list

- [ ] Check migrations for any conflicts with latest migrations in `main` branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved
