### PR TITLE
EMS list: change default search field to incident number

### DIFF
--- a/editor/configs/emsListViewTable.ts
+++ b/editor/configs/emsListViewTable.ts
@@ -250,13 +250,13 @@ export const emsListViewQueryConfig: QueryConfig = {
   searchFilter: {
     id: "search",
     value: "",
-    column: "incident_location_address",
+    column: "incident_number",
     operator: "_ilike",
     wildcard: true,
   },
   searchFields: [
-    { label: "Incident address", value: "incident_location_address" },
     { label: "Incident number", value: "incident_number" },
+    { label: "Incident address", value: "incident_location_address" },
     { label: "APD Case IDs", value: "unparsed_apd_incident_numbers" },
   ],
   dateFilter: {


### PR DESCRIPTION
## Associated issues
Closes https://github.com/issues/assigned?issue=cityofaustin%7Catd-data-tech%7C23370

## Testing

**URL to test:** <!-- VZ URL or Netlify -->
Netlify

**Steps to test:**
On the EMS list page, see that Incident number is now the default field to search by. Test searching by incident number

---

#### Ship list

- [ ] Check migrations for any conflicts with latest migrations in `main` branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved
