### PR TITLE
Fix the link labeled "website" on the Vision Zero Viewer

### DIFF
--- a/viewer/src/views/summary/Summary.js
+++ b/viewer/src/views/summary/Summary.js
@@ -86,7 +86,7 @@ const Summary = () => {
                     initiatives, visit Austin Transportation's Vision Zero
                     Program{" "}
                     <a
-                      href="https://austintexas.gov/page/programs-and-initiatives"
+                      href="https://www.austintexas.gov/department/vision-zero"
                       target="_blank"
                       rel="noopener noreferrer"
                     >


### PR DESCRIPTION
## Associated issues
https://github.com/cityofaustin/atd-data-tech/issues/23473

<img width="4024" height="2294" alt="Screenshot 2025-07-16 at 2 29 36 PM" src="https://github.com/user-attachments/assets/16911794-57bd-42f5-b776-da481fde08d8" />

## Testing


**URL to test:** https://deploy-preview-1816--atd-vzv-staging.netlify.app/

**Steps to test:**
- Go to the "Summary" page (as opposed to the map). 
- Click on the first hyperlink in the grey alert banner with the text "website"
- It should open a new tab at: https://www.austintexas.gov/department/vision-zero

---

#### Ship list

- [ ] Check migrations for any conflicts with latest migrations in `main` branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved
