### PR TITLE
check if data length over 0

### DIFF
--- a/editor/app/crashes/[record_locator]/page.tsx
+++ b/editor/app/crashes/[record_locator]/page.tsx
@@ -74,7 +74,7 @@ export default function CrashDetailsPage({
 
   // Set document title based on loaded crash data
   useDocumentTitle(
-    data
+    data && data.length > 0
       ? `${data[0].record_locator} - ${formatAddresses(data[0])}`
       : "Vision Zero Editor",
     true // exclude the suffix

--- a/editor/app/locations/[location_id]/page.tsx
+++ b/editor/app/locations/[location_id]/page.tsx
@@ -71,7 +71,7 @@ export default function LocationDetailsPage({
 
   // Set document title based on loaded location data
   useDocumentTitle(
-    data
+    data && data.length > 0
       ? `${data[0].location_id} - ${data[0].description}`
       : "Vision Zero Editor",
     true // exclude the suffix


### PR DESCRIPTION
## Associated issues
Fixes a bug caught in testing where data length can be zero which wasnt being accounted for when trying to get the page title, so we need to check for that

See https://visionzero-staging.austinmobility.io/editor/crashes/20672575asdf

## Testing

**URL to test:** <!-- VZ URL or Netlify -->
https://deploy-preview-1852--atd-vze-staging.netlify.app/editor/crashes/20874690asdf

**Steps to test:**
1. Go to this [URL](https://deploy-preview-1852--atd-vze-staging.netlify.app/editor/crashes/20874690asdf) and make sure you get a 404 page

---

#### Ship list

- [ ] Check migrations for any conflicts with latest migrations in `main` branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved
