### PR TITLE
Crash details map: show the address search regardless of edit state

### DIFF
--- a/editor/components/PointMap.tsx
+++ b/editor/components/PointMap.tsx
@@ -142,7 +142,7 @@ export const PointMap = ({
       )}
       {/* add nearmap raster source and style */}
       <MapAerialSourceAndLayer />
-      {isEditing && setMapLatLon && (
+      {setMapLatLon && (
         <MapGeocoderControl
           position="top-left"
           onResult={(latLon: LatLon) => setMapLatLon(latLon)}


### PR DESCRIPTION
## Associated issues
Closes https://github.com/cityofaustin/atd-data-tech/issues/24456

## Testing

**URL to test:** <!-- VZ URL or Netlify -->
Netlify

**Steps to test:**
1. Go to a crash details page, see that you can now search addresses without having to click the Edit button first

---

#### Ship list

- [ ] Check migrations for any conflicts with latest migrations in `main` branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved
