### PR TITLE
Crashes list: update Injuries filter labels

### DIFF
--- a/editor/configs/crashesListViewTable.ts
+++ b/editor/configs/crashesListViewTable.ts
@@ -54,7 +54,7 @@ const crashesListViewfilterCards: FilterGroup[] = [
 
       {
         id: "suspected_serious_injury_crashes",
-        label: "Suspected serious injury crashes",
+        label: "Suspected serious injuries",
         groupOperator: "_and",
         enabled: false,
         filters: [


### PR DESCRIPTION
## Associated issues

https://github.com/cityofaustin/atd-data-tech/issues/24729

## Testing

**URL to test:**

https://deploy-preview-1864--atd-vze-staging.netlify.app/editor/crashes

**Steps to test:**

Open the filters from the crashes list page and check that "crashes" now is updated as "injuries"


---

#### Ship list

- [ ] Check migrations for any conflicts with latest migrations in `main` branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved
