### PR TITLE
Fixes Viewer accessibility issues

### DIFF
--- a/viewer/src/Components/Widgets/SummaryWidget.js
+++ b/viewer/src/Components/Widgets/SummaryWidget.js
@@ -109,10 +109,10 @@ const SummaryWidget = ({
             />
           </span>
           <div className="d-flex flex-column widget-header-text">
-            <span className="mb-0">
+            <span className="mb-0 h5">
               {text} {infoPopover}
             </span>
-            <span className="text-muted">{`in ${currentYear}`}</span>
+            <span className="text-muted h5">{`in ${currentYear}`}</span>
           </div>
         </div>
       </CardBody>

--- a/viewer/src/Components/Widgets/SummaryWidget.js
+++ b/viewer/src/Components/Widgets/SummaryWidget.js
@@ -56,22 +56,10 @@ const SummaryWidget = ({
       bottom: 1px;
     }
 
-    .widget-header-text > h3 {
+    .widget-header-text > span {
       font-size: 1.2em;
     }
   `;
-
-  const renderIcon = () => (
-    <span className="fa-layers fa-3x fa-fw widget-icon">
-      <FontAwesomeIcon icon={faCircle} color={backgroundColor} />
-      <FontAwesomeIcon
-        icon={icon}
-        inverse
-        transform="shrink-6"
-        color={colors.white}
-      />
-    </span>
-  );
 
   const renderFooterBasedOnChange = (currentYearTotal, lastYearTotal) => {
     const icon =
@@ -111,12 +99,20 @@ const SummaryWidget = ({
           </Col>
         </Row>
         <div className="text-left d-flex flex-row">
-          {renderIcon()}
+          <span className="fa-layers fa-3x fa-fw widget-icon">
+            <FontAwesomeIcon icon={faCircle} color={backgroundColor} />
+            <FontAwesomeIcon
+              icon={icon}
+              inverse
+              transform="shrink-6"
+              color={colors.white}
+            />
+          </span>
           <div className="d-flex flex-column widget-header-text">
-            <h3 className="h5 mb-0">
+            <span className="mb-0">
               {text} {infoPopover}
-            </h3>
-            <h3 className="h5 text-muted">{`in ${currentYear}`}</h3>
+            </span>
+            <span className="text-muted">{`in ${currentYear}`}</span>
           </div>
         </div>
       </CardBody>

--- a/viewer/src/views/map/MapControls.js
+++ b/viewer/src/views/map/MapControls.js
@@ -6,14 +6,14 @@ const StyledMapNav = styled.div`
   .nav-buttons {
     position: absolute;
     top: 0px;
-    right: 0px;
+    right: 30px;
     padding: 10px;
   }
 
   .geolocate-button {
     position: absolute;
     top: 68px;
-    right: 0px;
+    right: 30px;
     padding: 10px;
   }
 `;

--- a/viewer/src/views/nav/Header.js
+++ b/viewer/src/views/nav/Header.js
@@ -142,7 +142,6 @@ const Header = () => {
                       >
                         <Button
                           className={`nav-button inactive-nav-button mx-xs-0 mx-lg-2`}
-                          active={currentPath === config.url}
                           style={{ pointerEvents: "none" }}
                         >
                           {config.icon}

--- a/viewer/src/views/nav/Header.js
+++ b/viewer/src/views/nav/Header.js
@@ -48,7 +48,12 @@ const Header = () => {
       margin-right: 5px;
       :hover {
         background: ${colors.info};
+        color: ${colors.white};
       }
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      letter-spacing: normal;
     }
 
     .sidedrawer-toggle {
@@ -138,15 +143,15 @@ const Header = () => {
                       <NavLink
                         tag={A}
                         href={config.url}
-                        className="pr-0 pl-2 mr-0 ml-2"
+                        className="pr-0 pl-2 mr-0 ml-2 "
+                        style={{ color: "#fff" }}
                       >
-                        <Button
-                          className={`nav-button inactive-nav-button mx-xs-0 mx-lg-2`}
-                          style={{ pointerEvents: "none" }}
+                        <span
+                          className={`btn nav-button inactive-nav-button mx-xs-0 mx-lg-2`}
                         >
                           {config.icon}
                           <span className="pl-2">{config.title}</span>
-                        </Button>
+                        </span>
                       </NavLink>
                     </NavItem>
                   )

--- a/viewer/src/views/nav/Header.js
+++ b/viewer/src/views/nav/Header.js
@@ -4,7 +4,7 @@ import { A, usePath } from "hookrouter";
 
 import { Container, Navbar, Button, Nav, NavItem, NavLink } from "reactstrap";
 import styled from "styled-components";
-import { navConfig, trackPageEvent } from "../../constants/nav";
+import { navConfig } from "../../constants/nav";
 import { responsive } from "../../constants/responsive";
 import { colors } from "../../constants/colors";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -142,8 +142,8 @@ const Header = () => {
                       >
                         <Button
                           className={`nav-button inactive-nav-button mx-xs-0 mx-lg-2`}
-                          onClick={() => trackPageEvent(config.eventKey)}
                           active={currentPath === config.url}
+                          style={{ pointerEvents: "none" }}
                         >
                           {config.icon}
                           <span className="pl-2">{config.title}</span>

--- a/viewer/src/views/nav/SideDrawerContent.js
+++ b/viewer/src/views/nav/SideDrawerContent.js
@@ -35,6 +35,9 @@ const SideDrawerContent = ({ type }) => {
   return (
     <div className="side-menu">
       <StyledDrawerHeader>
+        <h1 className="sr-only">
+          Vision Zero Map -- Help Austin reach zero traffic deaths
+        </h1>
         <img
           className="vz-logo"
           src={LOGO_URL}

--- a/viewer/src/views/nav/SideMapControl.js
+++ b/viewer/src/views/nav/SideMapControl.js
@@ -336,13 +336,15 @@ const SideMapControl = ({ type }) => {
 
   return (
     <StyledCard>
-      <h2 className="h4 card-title">
+      <span className="h4 card-title" style={{ display: "block" }}>
         Traffic Crashes{" "}
         <InfoPopover config={popoverConfig.map.trafficCrashes} />
-      </h2>
+      </span>
       <Card className="p-3 card-body">
         <Label className="section-title">
-          <h3 className="h5">Filters</h3>
+          <span className="h5" style={{ display: "block" }}>
+            Filters
+          </span>
         </Label>
         {/* Create a button group for each group of mapFilters */}
         {Object.entries(mapFiltersConfig).map(([group, groupParameters], i) => (

--- a/viewer/src/views/nav/SideMapControl.js
+++ b/viewer/src/views/nav/SideMapControl.js
@@ -336,10 +336,10 @@ const SideMapControl = ({ type }) => {
 
   return (
     <StyledCard>
-      <h3 className="h4 card-title">
+      <h2 className="h4 card-title">
         Traffic Crashes{" "}
         <InfoPopover config={popoverConfig.map.trafficCrashes} />
-      </h3>
+      </h2>
       <Card className="p-3 card-body">
         <Label className="section-title">
           <h3 className="h5">Filters</h3>


### PR DESCRIPTION
## Associated issues

https://github.com/cityofaustin/atd-data-tech/issues/13454

I looked at addressing the AA level issues, that is the target goal we need to meet by late April. 
The AAA issues do not seem too difficult to address, changing some color contrast and making buttons bigger.

I attempted a fix for "Interactive element does not meet minimum size nor spacing" and left comments about it in the code. The gist is we have nested interactive elements and I disabled the inner button, but that means we lost the mouseover hover effect. I can try another solution if we want that effect back. 

There are a few issues on the map page ("Empty headings" and "Text not included in an ARIA landmark" plus one that I see using the chrome extension, but not on the siteimprove site) that are related to the links on the mapbox map in the lower right. I checked the map on our traffic cameras site, which is running a later version of the mapbox package, and those issues have been fixed. I did not try updating the mapbox package, but I can go down that road if we want. 

## Testing

**URL to test:** <!-- VZ URL or Netlify -->

https://deploy-preview-1980--atd-vzv-staging.netlify.app/viewer/

**Steps to test:**

Visit the deploy preview and compare the summary cards to whats in production. I changed them from `h3`s to `spans`

I installed the site improve chrome extension and ran it on the deploy preview:

<img width="500"  alt="Screenshot 2026-03-06 at 10 50 07 AM" src="https://github.com/user-attachments/assets/a492b826-bd9d-46c3-b8e7-bac192cb8199" />


---

#### Ship list

- [ ] Check migrations for any conflicts with latest migrations in `main` branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved
