### PR TITLE
Ability to copy address and record IDs on detail pages

### DIFF
--- a/editor/app/crashes/page.tsx
+++ b/editor/app/crashes/page.tsx
@@ -4,12 +4,12 @@ import Button from "react-bootstrap/Button";
 import UserEventsLogger from "@/components/UserEventsLogger";
 import AlignedLabel from "@/components/AlignedLabel";
 import CreateCrashRecordModal from "@/components/CreateCrashRecordModal";
-import { FaCirclePlus } from "react-icons/fa6";
 import { crashesListViewColumns } from "@/configs/crashesListViewColumns";
 import { crashesListViewQueryConfig } from "@/configs/crashesListViewTable";
 import PermissionsRequired from "@/components/PermissionsRequired";
 import TableWrapper from "@/components/TableWrapper";
 import { useDocumentTitle } from "@/utils/documentTitle";
+import { LuCirclePlus } from "react-icons/lu";
 
 const localStorageKey = "crashesListViewQueryConfig";
 
@@ -38,7 +38,7 @@ export default function Crashes() {
               onClick={() => setShowNewUserModal(true)}
             >
               <AlignedLabel>
-                <FaCirclePlus className="me-2" />
+                <LuCirclePlus className="me-2" />
                 <span>Create</span>
               </AlignedLabel>
             </Button>

--- a/editor/app/ems/page.tsx
+++ b/editor/app/ems/page.tsx
@@ -5,9 +5,9 @@ import { emsListViewColumns } from "@/configs/emsColumns";
 import TableWrapper from "@/components/TableWrapper";
 import UserEventsLogger from "@/components/UserEventsLogger";
 import { emsListViewQueryConfig } from "@/configs/emsListViewTable";
-import { FaCircleInfo } from "react-icons/fa6";
 import { useDocumentTitle } from "@/utils/documentTitle";
 import { Filter } from "@/types/queryBuilder";
+import { LuInfo } from "react-icons/lu";
 
 const localStorageKey = "emsListQueryConfig";
 
@@ -33,7 +33,7 @@ export default function EMS() {
         </div>
         <div className="fw-light text-secondary mb-2">
           <AlignedLabel>
-            <FaCircleInfo className="me-2" />
+            <LuInfo className="me-2" />
             <span>
               EMS analysis is currently in beta. Data may be inaccurate or change
               significantly as we continue to refine the system.

--- a/editor/app/locations/[location_id]/page.tsx
+++ b/editor/app/locations/[location_id]/page.tsx
@@ -16,7 +16,7 @@ import { locationCardColumns } from "@/configs/locationDataCard";
 import { locationCrashesColumns } from "@/configs/locationCrashesColumns";
 import { locationCrashesQueryConfig } from "@/configs/locationCrashesTable";
 import AlignedLabel from "@/components/AlignedLabel";
-import { FaCircleInfo } from "react-icons/fa6";
+import { LuInfo } from "react-icons/lu";
 import NotesCard from "@/components/NotesCard";
 import {
   INSERT_LOCATION_NOTE,
@@ -115,7 +115,7 @@ export default function LocationDetailsPage({
               <Card.Title>Crashes</Card.Title>
               <Card.Subtitle className="fw-light text-secondary">
                 <AlignedLabel>
-                  <FaCircleInfo className="me-2" />
+                  <LuInfo className="me-2 text-secondary" />
                   <span>
                     The data in this table is refreshed on an hourly basis
                   </span>

--- a/editor/app/upload-non-cr3/page.tsx
+++ b/editor/app/upload-non-cr3/page.tsx
@@ -97,7 +97,7 @@ export default function UploadNonCr3() {
 
   return (
     <div className="h-100 d-flex flex-column">
-      <div className="fs-3 fw-bold">Upload Non-CR3 records</div>
+      <div className="fs-3 fw-bold mb-3">Upload Non-CR3 records</div>
 
       {!data && (
         <Row>

--- a/editor/app/upload-non-cr3/page.tsx
+++ b/editor/app/upload-non-cr3/page.tsx
@@ -19,11 +19,11 @@ import {
   NonCr3ValidationError,
 } from "@/types/nonCr3";
 import {
-  FaFileCsv,
-  FaCircleCheck,
-  FaCircleInfo,
-  FaTriangleExclamation,
-} from "react-icons/fa6";
+  LuCircleCheck,
+  LuFileSpreadsheet,
+  LuInfo,
+  LuTriangleAlert,
+} from "react-icons/lu";
 import { useDocumentTitle } from "@/utils/documentTitle";
 
 const MAX_ERRORS_TO_DISPLAY = 50;
@@ -130,7 +130,7 @@ export default function UploadNonCr3() {
               download="non_cr3_template.csv"
               className="text-decoration-none ms-3 text-nowrap d-flex align-items-center"
             >
-              <FaFileCsv className="me-2" />
+              <LuFileSpreadsheet className="me-2" />
               Download CSV template
             </Link>
           </Col>
@@ -142,7 +142,7 @@ export default function UploadNonCr3() {
             <Col>
               <Alert variant="info">
                 <AlignedLabel>
-                  <FaCircleInfo className="me-2" />
+                  <LuInfo className="me-2" />
                   {`${data.length.toLocaleString()} records will be imported`}
                 </AlignedLabel>
               </Alert>
@@ -181,7 +181,7 @@ export default function UploadNonCr3() {
           {success && (
             <Alert variant="success">
               <AlignedLabel>
-                <FaCircleCheck className="me-2" />
+                <LuCircleCheck className="me-2" />
                 <span>Records successfully imported</span>
               </AlignedLabel>
             </Alert>
@@ -189,7 +189,7 @@ export default function UploadNonCr3() {
           {validationErrors && (
             <Alert variant="danger" className="d-flex justify-content-between">
               <AlignedLabel>
-                <FaTriangleExclamation className="me-2" />
+                <LuTriangleAlert className="me-2" />
                 <span>
                   Your file is invalid — please correct the below errors and try
                   again
@@ -200,7 +200,7 @@ export default function UploadNonCr3() {
           {uploadError && (
             <Alert variant="danger" className="d-flex justify-content-between">
               <AlignedLabel>
-                <FaTriangleExclamation className="me-2" />
+                <LuTriangleAlert className="me-2" />
                 <span>
                   There was an error uploading your file - please try again.
                 </span>

--- a/editor/app/users/page.tsx
+++ b/editor/app/users/page.tsx
@@ -42,7 +42,7 @@ export default function Users() {
     // only display the copied button state for a moment
     navigator.clipboard.writeText(userEmails).then(() => {
       setCopyUserEmailsClicked(true);
-      const copiedStateTime = 1000;
+      const copiedStateTime = 2000;
       setTimeout(() => setCopyUserEmailsClicked(false), copiedStateTime);
     });
   }, [users]);

--- a/editor/app/users/page.tsx
+++ b/editor/app/users/page.tsx
@@ -5,7 +5,6 @@ import Alert from "react-bootstrap/Alert";
 import Button from "react-bootstrap/Button";
 import Spinner from "react-bootstrap/Spinner";
 import Table from "react-bootstrap/Table";
-import { FaUserPlus, FaCopy, FaCheck } from "react-icons/fa6";
 import AlignedLabel from "@/components/AlignedLabel";
 import PermissionsRequired from "@/components/PermissionsRequired";
 import UserModal from "@/components/UserModal";
@@ -13,6 +12,7 @@ import { useUsersInfinite } from "@/utils/users";
 import { User } from "@/types/users";
 import { formatRoleName } from "@/utils/auth";
 import { useDocumentTitle } from "@/utils/documentTitle";
+import { LuCheck, LuCopy, LuUserPlus } from "react-icons/lu";
 
 const allowedCreateUserRoles = ["vz-admin"];
 
@@ -75,7 +75,7 @@ export default function Users() {
                     disabled={isValidating}
                   >
                     <AlignedLabel>
-                      <FaUserPlus className="me-2" />
+                      <LuUserPlus className="me-2" />
                       <span>Add user</span>
                     </AlignedLabel>
                   </Button>
@@ -83,15 +83,16 @@ export default function Users() {
                 <Button
                   onClick={handleCopyUserEmails}
                   disabled={isValidating || copyUserEmailsClicked}
+                  variant="outline-primary"
                 >
                   {copyUserEmailsClicked ? (
                     <AlignedLabel>
-                      <FaCheck className="me-2" />
+                      <LuCheck className="me-2" />
                       <span>Copied</span>
                     </AlignedLabel>
                   ) : (
                     <AlignedLabel>
-                      <FaCopy className="me-2" />
+                      <LuCopy className="me-2" />
                       <span>Copy user emails</span>
                     </AlignedLabel>
                   )}

--- a/editor/components/AppBreadCrumb.tsx
+++ b/editor/components/AppBreadCrumb.tsx
@@ -1,7 +1,6 @@
 import { useMemo, Fragment } from "react";
 import { usePathname } from "next/navigation";
 import Link from "next/link";
-import Col from "react-bootstrap/Col";
 import { routes } from "@/configs/routes";
 import CopyValueButton from "@/components/CopyValueButton";
 

--- a/editor/components/AppBreadCrumb.tsx
+++ b/editor/components/AppBreadCrumb.tsx
@@ -73,12 +73,10 @@ export default function AppBreadCrumb() {
             );
           } else {
             return (
-              <>
-                <span key={crumb.label} className="text-secondary me-2">
-                  {crumb.label}
-                </span>
+              <Fragment key={crumb.label}>
+                <span className="text-secondary me-2">{crumb.label}</span>
                 <CopyValueButton tooltipLabel="Copy" value={crumb.label} />
-              </>
+              </Fragment>
             );
           }
         })}

--- a/editor/components/AppBreadCrumb.tsx
+++ b/editor/components/AppBreadCrumb.tsx
@@ -3,6 +3,7 @@ import { usePathname } from "next/navigation";
 import Link from "next/link";
 import Col from "react-bootstrap/Col";
 import { routes } from "@/configs/routes";
+import CopyValueButton from "@/components/CopyValueButton";
 
 interface Crumb {
   path: string;
@@ -54,33 +55,34 @@ export default function AppBreadCrumb() {
   }
 
   return (
-    <div className="pb-2">
-      <Col>
-        {isDetailsPage &&
-          crumbs?.map((crumb, i) => {
-            if (i < crumbs.length - 1) {
-              return (
-                <Fragment key={crumb.label}>
-                  <span>
-                    <Link
-                      className="text-decoration-none"
-                      href={`/${crumb.path}`}
-                    >
-                      {crumb.label}
-                    </Link>
-                  </span>
-                  <span className="mx-2 fw-light text-secondary">{"/"}</span>
-                </Fragment>
-              );
-            } else {
-              return (
-                <span key={crumb.label} className="text-secondary">
+    <div className="pb-2 d-flex align-items-center">
+      {isDetailsPage &&
+        crumbs?.map((crumb, i) => {
+          if (i < crumbs.length - 1) {
+            return (
+              <Fragment key={crumb.label}>
+                <span>
+                  <Link
+                    className="text-decoration-none"
+                    href={`/${crumb.path}`}
+                  >
+                    {crumb.label}
+                  </Link>
+                </span>
+                <span className="mx-2 fw-light text-secondary">{"/"}</span>
+              </Fragment>
+            );
+          } else {
+            return (
+              <>
+                <span key={crumb.label} className="text-secondary me-2">
                   {crumb.label}
                 </span>
-              );
-            }
-          })}
-      </Col>
+                <CopyValueButton tooltipLabel="Copy" value={crumb.label} />
+              </>
+            );
+          }
+        })}
     </div>
   );
 }

--- a/editor/components/CopyValueButton.tsx
+++ b/editor/components/CopyValueButton.tsx
@@ -21,7 +21,7 @@ export default function CopyValueButton({
   const handleCopyValue = () => {
     navigator.clipboard.writeText(String(value)).then(() => {
       setIsCopyClicked(true);
-      const copiedStateTime = 1000;
+      const copiedStateTime = 2000;
       setTimeout(() => setIsCopyClicked(false), copiedStateTime);
     });
   };

--- a/editor/components/CopyValueButton.tsx
+++ b/editor/components/CopyValueButton.tsx
@@ -10,7 +10,7 @@ interface CopyValueButtonProps {
 }
 
 /**
- * Compent provides a button UI to copy an aribtrary value to the clipboard
+ * Component that provides an animated button UI to copy an aribtrary value to the clipboard
  */
 export default function CopyValueButton({
   value,

--- a/editor/components/CopyValueButton.tsx
+++ b/editor/components/CopyValueButton.tsx
@@ -37,7 +37,7 @@ export default function CopyValueButton({
     >
       <Button
         onClick={handleCopyValue}
-        className="d-flex align-items-baseline edit-address-button mt-1 px-1"
+        className="d-flex align-items-baseline edit-address-button my-1 px-1"
       >
         {!isCopyClicked && <LuCopy className="text-muted" />}
         {isCopyClicked && <LuCheck className="text-success" />}

--- a/editor/components/CopyValueButton.tsx
+++ b/editor/components/CopyValueButton.tsx
@@ -1,0 +1,47 @@
+import { useState } from "react";
+import { Button, OverlayTrigger, Tooltip } from "react-bootstrap";
+import { LuCheck, LuCopy } from "react-icons/lu";
+
+interface CopyValueButtonProps {
+  /* The value to be copied */
+  value: unknown;
+  /* The label to display in the button tooltip on hover */
+  tooltipLabel: string;
+}
+
+/**
+ * Compent provides a button UI to copy an aribtrary value to the clipboard
+ */
+export default function CopyValueButton({
+  value,
+  tooltipLabel,
+}: CopyValueButtonProps) {
+  const [isCopyClicked, setIsCopyClicked] = useState(false);
+
+  const handleCopyValue = () => {
+    navigator.clipboard.writeText(String(value)).then(() => {
+      setIsCopyClicked(true);
+      const copiedStateTime = 1000;
+      setTimeout(() => setIsCopyClicked(false), copiedStateTime);
+    });
+  };
+
+  return (
+    <OverlayTrigger
+      placement="top"
+      overlay={
+        <Tooltip id="copy-address-tooltip" hidden={isCopyClicked}>
+          {tooltipLabel}
+        </Tooltip>
+      }
+    >
+      <Button
+        onClick={handleCopyValue}
+        className="d-flex align-items-baseline edit-address-button mt-1 px-1"
+      >
+        {!isCopyClicked && <LuCopy className="text-muted" />}
+        {isCopyClicked && <LuCheck className="text-success" />}
+      </Button>
+    </OverlayTrigger>
+  );
+}

--- a/editor/components/CrashHeader.tsx
+++ b/editor/components/CrashHeader.tsx
@@ -1,12 +1,12 @@
 import { useState } from "react";
-import { Button, OverlayTrigger, Tooltip } from "react-bootstrap";
+import { Button, Col, Row } from "react-bootstrap";
 import { useAuth0 } from "@auth0/auth0-react";
 import { Crash } from "@/types/crashes";
 import CrashInjuryIndicators from "@/components/CrashInjuryIndicators";
-import { LuCheck, LuCopy, LuSquarePen } from "react-icons/lu";
+import { LuSquarePen } from "react-icons/lu";
 import EditCrashAddressModal from "@/components/EditCrashAddressModal";
 import { hasRole } from "@/utils/auth";
-import AlignedLabel from "@/components/AlignedLabel";
+import CopyValueButton from "@/components/CopyValueButton";
 
 interface CrashHeaderProps {
   crash: Crash;
@@ -18,20 +18,10 @@ interface CrashHeaderProps {
  */
 export default function CrashHeader({ crash, refetch }: CrashHeaderProps) {
   const [showEditAddressModal, setShowEditAddressModal] = useState(false);
-  const [isCopyAddressClicked, setIsCopyAddressClicked] = useState(false);
 
   const onSaveCallback = () => {
     setShowEditAddressModal(false);
     refetch();
-  };
-
-  const handleCopyAddress = () => {
-    // only display the copied button state for a moment
-    navigator.clipboard.writeText(crash.address_display || "").then(() => {
-      setIsCopyAddressClicked(true);
-      const copiedStateTime = 1000;
-      setTimeout(() => setIsCopyAddressClicked(false), copiedStateTime);
-    });
   };
 
   const { user } = useAuth0();
@@ -39,8 +29,8 @@ export default function CrashHeader({ crash, refetch }: CrashHeaderProps) {
   const isReadOnlyUser = user && hasRole(["readonly"], user);
 
   return (
-    <div className="d-flex justify-content-between mb-3">
-      <div className="d-flex align-items-center">
+    <Row className="d-flex justify-content-between align-items-center mb-3">
+      <Col className="d-flex align-items-center">
         {isReadOnlyUser ? (
           <span className="fs-3 fw-bold text-uppercase">
             {crash.address_display}
@@ -50,27 +40,21 @@ export default function CrashHeader({ crash, refetch }: CrashHeaderProps) {
             onClick={() => setShowEditAddressModal(true)}
             className="d-flex align-items-baseline edit-address-button"
           >
-            <span className="fs-3 fw-bold text-uppercase me-2">
+            <span className="fs-3 fw-bold text-uppercase me-2 text-nowrap">
               {crash.address_display}
             </span>
             <LuSquarePen className="text-muted" />
           </Button>
         )}
-        <OverlayTrigger
-          placement="top"
-          overlay={<Tooltip id="copy-address-tooltip" hidden={isCopyAddressClicked}>Copy address</Tooltip>}
-        >
-          <Button
-            onClick={handleCopyAddress}
-            className="d-flex align-items-baseline edit-address-button mt-1 px-1"
-          >
-            {!isCopyAddressClicked && <LuCopy className="text-muted" />}
-            {isCopyAddressClicked && <LuCheck className="text-success" />}
-          </Button>
-        </OverlayTrigger>
-      </div>
+        <CopyValueButton
+          tooltipLabel="Copy address"
+          value={String(crash.address_display || "")}
+        />
+      </Col>
       {crash.crash_injury_metrics_view && (
-        <CrashInjuryIndicators injuries={crash.crash_injury_metrics_view} />
+        <Col xs="auto">
+          <CrashInjuryIndicators injuries={crash.crash_injury_metrics_view} />
+        </Col>
       )}
       <EditCrashAddressModal
         crashId={crash.id}
@@ -79,6 +63,6 @@ export default function CrashHeader({ crash, refetch }: CrashHeaderProps) {
         onSaveCallback={onSaveCallback}
         crash={crash}
       ></EditCrashAddressModal>
-    </div>
+    </Row>
   );
 }

--- a/editor/components/CrashHeader.tsx
+++ b/editor/components/CrashHeader.tsx
@@ -32,7 +32,7 @@ export default function CrashHeader({ crash, refetch }: CrashHeaderProps) {
     <Row className="d-flex justify-content-between align-items-center mb-3">
       <Col className="d-flex align-items-center">
         {isReadOnlyUser ? (
-          <span className="fs-3 fw-bold text-uppercase">
+          <span className="fs-3 fw-bold text-uppercase me-2">
             {crash.address_display}
           </span>
         ) : (

--- a/editor/components/CrashHeader.tsx
+++ b/editor/components/CrashHeader.tsx
@@ -1,11 +1,12 @@
 import { useState } from "react";
-import { Button } from "react-bootstrap";
+import { Button, OverlayTrigger, Tooltip } from "react-bootstrap";
 import { useAuth0 } from "@auth0/auth0-react";
 import { Crash } from "@/types/crashes";
 import CrashInjuryIndicators from "@/components/CrashInjuryIndicators";
-import { LuSquarePen } from "react-icons/lu";
+import { LuCheck, LuCopy, LuSquarePen } from "react-icons/lu";
 import EditCrashAddressModal from "@/components/EditCrashAddressModal";
 import { hasRole } from "@/utils/auth";
+import AlignedLabel from "@/components/AlignedLabel";
 
 interface CrashHeaderProps {
   crash: Crash;
@@ -17,10 +18,20 @@ interface CrashHeaderProps {
  */
 export default function CrashHeader({ crash, refetch }: CrashHeaderProps) {
   const [showEditAddressModal, setShowEditAddressModal] = useState(false);
+  const [isCopyAddressClicked, setIsCopyAddressClicked] = useState(false);
 
   const onSaveCallback = () => {
     setShowEditAddressModal(false);
     refetch();
+  };
+
+  const handleCopyAddress = () => {
+    // only display the copied button state for a moment
+    navigator.clipboard.writeText(crash.address_display || "").then(() => {
+      setIsCopyAddressClicked(true);
+      const copiedStateTime = 1000;
+      setTimeout(() => setIsCopyAddressClicked(false), copiedStateTime);
+    });
   };
 
   const { user } = useAuth0();
@@ -29,21 +40,35 @@ export default function CrashHeader({ crash, refetch }: CrashHeaderProps) {
 
   return (
     <div className="d-flex justify-content-between mb-3">
-      {isReadOnlyUser ? (
-        <span className="fs-3 fw-bold text-uppercase">
-          {crash.address_display}
-        </span>
-      ) : (
-        <Button
-          onClick={() => setShowEditAddressModal(true)}
-          className="d-flex align-items-baseline edit-address-button"
-        >
-          <span className="fs-3 fw-bold text-uppercase me-2">
+      <div className="d-flex align-items-center">
+        {isReadOnlyUser ? (
+          <span className="fs-3 fw-bold text-uppercase">
             {crash.address_display}
           </span>
-          <LuSquarePen className="text-muted" />
-        </Button>
-      )}
+        ) : (
+          <Button
+            onClick={() => setShowEditAddressModal(true)}
+            className="d-flex align-items-baseline edit-address-button"
+          >
+            <span className="fs-3 fw-bold text-uppercase me-2">
+              {crash.address_display}
+            </span>
+            <LuSquarePen className="text-muted" />
+          </Button>
+        )}
+        <OverlayTrigger
+          placement="top"
+          overlay={<Tooltip id="copy-address-tooltip" hidden={isCopyAddressClicked}>Copy address</Tooltip>}
+        >
+          <Button
+            onClick={handleCopyAddress}
+            className="d-flex align-items-baseline edit-address-button mt-1 px-1"
+          >
+            {!isCopyAddressClicked && <LuCopy className="text-muted" />}
+            {isCopyAddressClicked && <LuCheck className="text-success" />}
+          </Button>
+        </OverlayTrigger>
+      </div>
       {crash.crash_injury_metrics_view && (
         <CrashInjuryIndicators injuries={crash.crash_injury_metrics_view} />
       )}

--- a/editor/components/CrashHeader.tsx
+++ b/editor/components/CrashHeader.tsx
@@ -38,7 +38,7 @@ export default function CrashHeader({ crash, refetch }: CrashHeaderProps) {
         ) : (
           <Button
             onClick={() => setShowEditAddressModal(true)}
-            className="d-flex align-items-baseline edit-address-button"
+            className="d-flex align-items-center edit-address-button"
           >
             <span className="fs-3 fw-bold text-uppercase me-2 text-nowrap">
               {crash.address_display}

--- a/editor/components/EMSCardHeader.tsx
+++ b/editor/components/EMSCardHeader.tsx
@@ -1,5 +1,5 @@
 import Badge from "react-bootstrap/Badge";
-import { FaCircleInfo } from "react-icons/fa6";
+import { LuInfo } from "react-icons/lu";
 
 export default function EMSCardHeader() {
   return (
@@ -12,7 +12,7 @@ export default function EMSCardHeader() {
       </div>
       <div className="fw-light text-secondary">
         <span className="d-flex align-items-center">
-          <FaCircleInfo className="me-2" style={{ minWidth: "1rem" }} />
+          <LuInfo className="me-2" style={{ minWidth: "1rem" }} />
           <span>
             EMS analysis is currently in beta. Data may be inaccurate or change
             significantly as we continue to refine the system.

--- a/editor/components/EnvironmentBadge.tsx
+++ b/editor/components/EnvironmentBadge.tsx
@@ -1,6 +1,6 @@
 import Alert from "react-bootstrap/Alert";
-import { FaCircleInfo } from "react-icons/fa6";
 import AlignedLabel from "./AlignedLabel";
+import { LuInfo } from "react-icons/lu";
 
 /**
  * Banner that displays environment information when not in production
@@ -15,11 +15,7 @@ export default function EnvironmentBadge() {
   return (
     <Alert variant={isLocal ? "warning" : "info"} className="my-auto py-0">
       <AlignedLabel>
-        {isLocal ? (
-          <FaCircleInfo className="me-2" />
-        ) : (
-          <FaCircleInfo className="me-2" />
-        )}
+        <LuInfo className="me-2" />
         <span className="text-capitalize">{`${environment} environment`}</span>
       </AlignedLabel>
     </Alert>

--- a/editor/components/TableExportModal.tsx
+++ b/editor/components/TableExportModal.tsx
@@ -7,7 +7,7 @@ import { useQuery } from "@/utils/graphql";
 import { useLogUserEvent } from "@/utils/userEvents";
 import { unparse } from "papaparse";
 import AlignedLabel from "./AlignedLabel";
-import { FaCircleInfo, FaDownload } from "react-icons/fa6";
+import { LuDownload, LuInfo } from "react-icons/lu";
 import { formatFileTimestamp } from "@/utils/formatters";
 import { getRecordValue } from "@/utils/formHelpers";
 import { ColDataCardDef } from "@/types/types";
@@ -147,7 +147,7 @@ export default function TableExportModal<T extends Record<string, unknown>>({
           variant="info"
           className="d-flex justify-content-between align-items-center"
         >
-          <FaCircleInfo className="me-3 fs-4" />
+          <LuInfo className="me-3 fs-4" />
           <div>
             You are about to download{" "}
             <span className="fw-bold">{`${totalRecordCount.toLocaleString()} `}</span>
@@ -173,7 +173,7 @@ export default function TableExportModal<T extends Record<string, unknown>>({
             onClick={onClose}
           >
             <AlignedLabel>
-              <FaDownload className="me-2" />
+              <LuDownload className="me-2" />
               Download
             </AlignedLabel>
           </Button>

--- a/editor/components/TablePaginationControls.tsx
+++ b/editor/components/TablePaginationControls.tsx
@@ -6,7 +6,8 @@ import ButtonToolbar from "react-bootstrap/ButtonToolbar";
 import OverlayTrigger from "react-bootstrap/OverlayTrigger";
 import Spinner from "react-bootstrap/Spinner";
 import Tooltip from "react-bootstrap/Tooltip";
-import { FaAngleLeft, FaAngleRight, FaDownload } from "react-icons/fa6";
+import { FaAngleLeft, FaAngleRight } from "react-icons/fa6";
+import { LuDownload } from "react-icons/lu";
 import AlignedLabel from "./AlignedLabel";
 import TableColumnVisibilityMenu from "@/components/TableColumnVisibilityMenu";
 import TablePageSizeSelector from "@/components/TablePageSizeSelector";
@@ -173,7 +174,7 @@ export default function TablePaginationControls({
             title="Download results"
           >
             <AlignedLabel>
-              <FaDownload />
+              <LuDownload className="fs-5" />
             </AlignedLabel>
           </Button>
         </OverlayTrigger>


### PR DESCRIPTION
## Associated issues

* https://github.com/cityofaustin/atd-data-tech/issues/27389
* https://github.com/cityofaustin/atd-data-tech/issues/27390

<img width="837" height="426" alt="Screenshot 2026-03-16 at 5 20 34 PM" src="https://github.com/user-attachments/assets/e078c0aa-a798-44a1-8161-bd76eebf3b2a" />

## Testing

**URL to test:** [Netlify](https://deploy-preview-1987--atd-vze-staging.netlify.app/editor)

**Steps to test:**

1. Navigate to any crash details page and test out the button to copy the crash address. Now use the button in the page breadcrumb to copy the crash ID.
2. Navigate to the EMS, Fatality, and Location details page and test out the copy button in the breadcrumb on each page.

---

#### Ship list

- [ ] Check migrations for any conflicts with latest migrations in `main` branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved
