### PR TITLE
Drop leading `_` from image handler names

### DIFF
--- a/api/server.py
+++ b/api/server.py
@@ -26,14 +26,14 @@ from werkzeug.local import LocalProxy
 
 
 from utils.images import (
-    _upsert_person_image,
-    _delete_person_image,
-    _get_person_image_url,
-    _transfer_person_image,
+    copy_person_image as copy_person_image_handler,
+    delete_crash_diagram_image,
+    delete_person_image,
+    get_crash_diagram_image_url,
+    get_person_image_url,
+    upsert_crash_diagram_image,
+    upsert_person_image,
     validate_file_size,
-    _get_crash_diagram_image_url,
-    _upsert_crash_diagram_image,
-    _delete_crash_diagram_image,
 )
 
 
@@ -417,7 +417,7 @@ def download_crash_report(record_locator):
 # No role requirement - all authenticated users can GET
 def get_person_image(person_id):
     """Retrieves a person image URL"""
-    return _get_person_image_url(person_id, s3)
+    return get_person_image_url(person_id, s3)
 
 
 @app.route("/images/person/<int:person_id>", methods=["DELETE", "PUT"])
@@ -428,9 +428,9 @@ def get_person_image(person_id):
 def modify_person_image(person_id):
     """Upserts or deletes a person image"""
     if request.method == "PUT":
-        return _upsert_person_image(person_id, s3)
+        return upsert_person_image(person_id, s3)
     elif request.method == "DELETE":
-        return _delete_person_image(person_id, s3)
+        return delete_person_image(person_id, s3)
     return jsonify(message="Bad Request"), 400
 
 @app.route(
@@ -441,7 +441,7 @@ def modify_person_image(person_id):
 @requires_auth
 def copy_person_image(source_person_id, target_person_id):
     """Copy a person image from one person record to another"""
-    return _transfer_person_image(source_person_id, target_person_id, s3)
+    return copy_person_image_handler(source_person_id, target_person_id, s3)
 
 
 @app.route("/images/crash_diagram/<record_locator>", methods=["GET"])
@@ -449,7 +449,7 @@ def copy_person_image(source_person_id, target_person_id):
 @requires_auth
 def get_crash_diagram_image(record_locator):
     """Retrieves a crash diagram image URL"""
-    return _get_crash_diagram_image_url(record_locator, s3)
+    return get_crash_diagram_image_url(record_locator, s3)
 
 
 @app.route("/images/crash_diagram/<record_locator>", methods=["DELETE", "PUT"])
@@ -460,9 +460,9 @@ def get_crash_diagram_image(record_locator):
 def modify_crash_diagram_image(record_locator):
     """Upserts or deletes a crash diagram image"""
     if request.method == "PUT":
-        return _upsert_crash_diagram_image(record_locator, s3)
+        return upsert_crash_diagram_image(record_locator, s3)
     elif request.method == "DELETE":
-        return _delete_crash_diagram_image(record_locator, s3)
+        return delete_crash_diagram_image(record_locator, s3)
     return jsonify(message="Bad Request"), 400
 
 

--- a/api/utils/images.py
+++ b/api/utils/images.py
@@ -273,7 +273,7 @@ def get_presigned_url(s3_object_key, s3, expires_in=3600):
     )
 
 
-def _handle_image_upload(person_id, file, s3):
+def handle_image_upload(person_id, file, s3):
     """Uploads a person image to S3 after validating and removing EXIF data"""
     img_without_exif, img_format, ext = validate_and_process_image(file)
 
@@ -468,3 +468,4 @@ _get_crash_diagram_metadata = get_crash_diagram_metadata
 _get_crash_diagram_image_url = get_crash_diagram_image_url
 _upsert_crash_diagram_image = upsert_crash_diagram_image
 _delete_crash_diagram_image = delete_crash_diagram_image
+_handle_image_upload = handle_image_upload

--- a/api/utils/images.py
+++ b/api/utils/images.py
@@ -89,7 +89,7 @@ def strip_exif(img):
     return img_without_exif
 
 
-def _get_person_image_metadata(person_id):
+def get_person_image_metadata(person_id):
     """Get the person record image metadata for a given person record ID"""
     res = make_hasura_request(
         query=GET_PERSON_IMAGE_METADATA_FULL, variables={"person_id": person_id}
@@ -102,9 +102,9 @@ def _get_person_image_metadata(person_id):
     )
 
 
-def _get_person_image_url(person_id, s3):
+def get_person_image_url(person_id, s3):
     """Get a presigned S3 download URL for the given person record ID"""
-    image_obj_key, _, _ = _get_person_image_metadata(person_id)
+    image_obj_key, _, _ = get_person_image_metadata(person_id)
 
     if not image_obj_key:
         return jsonify(error=f"No image found for person ID: {person_id}"), 404
@@ -113,7 +113,7 @@ def _get_person_image_url(person_id, s3):
     return jsonify(url=url)
 
 
-def _upsert_person_image(person_id, s3):
+def upsert_person_image(person_id, s3):
     """Handle a person image upsert.
 
     If the person record does not have any image metadata in the DB, the image is
@@ -133,7 +133,7 @@ def _upsert_person_image(person_id, s3):
     has_file = "file" in request.files
     image_source = request.form.get("image_source")
     image_original_obj_key, image_original_filename, image_original_source = (
-        _get_person_image_metadata(person_id)
+        get_person_image_metadata(person_id)
     )
     is_new = not image_original_obj_key
 
@@ -287,14 +287,14 @@ def _handle_image_upload(person_id, file, s3):
     return new_image_obj_key
 
 
-def _transfer_person_image(source_person_id, target_person_id, s3):
-    """Transfer an image from one person record to another.
+def copy_person_image(source_person_id, target_person_id, s3):
+    """Copy a person image from one record to another.
 
     Copies the S3 object to a new key for the target person and updates the
     target person's image metadata in the database.
     """
     source_obj_key, source_original_filename, source_image_source = (
-        _get_person_image_metadata(source_person_id)
+        get_person_image_metadata(source_person_id)
     )
 
     if not source_obj_key:
@@ -334,9 +334,9 @@ def _transfer_person_image(source_person_id, target_person_id, s3):
     return jsonify(success=True), 200
 
 
-def _delete_person_image(person_id, s3):
+def delete_person_image(person_id, s3):
     """Delete an image from S3 and nullify its metadata in the db"""
-    image_obj_key, _, _ = _get_person_image_metadata(person_id)
+    image_obj_key, _, _ = get_person_image_metadata(person_id)
 
     if not image_obj_key:
         abort(404, description=f"No image found for person ID: {person_id}")
@@ -364,7 +364,7 @@ def _delete_person_image(person_id, s3):
         abort(500, description="Delete failed")
 
 
-def _get_crash_diagram_metadata(record_locator):
+def get_crash_diagram_metadata(record_locator):
     """Get the crash record diagram metadata for a given crash ID"""
     res = make_hasura_request(
         query=GET_CRASH_DIAGRAM_METADATA, variables={"record_locator": record_locator}
@@ -375,9 +375,9 @@ def _get_crash_diagram_metadata(record_locator):
     return None
 
 
-def _get_crash_diagram_image_url(record_locator, s3):
+def get_crash_diagram_image_url(record_locator, s3):
     """Get a presigned S3 download URL for the given crash record_locator"""
-    diagram_obj_key = _get_crash_diagram_metadata(record_locator)
+    diagram_obj_key = get_crash_diagram_metadata(record_locator)
 
     if not diagram_obj_key:
         return (
@@ -389,13 +389,13 @@ def _get_crash_diagram_image_url(record_locator, s3):
     return jsonify(url=url)
 
 
-def _upsert_crash_diagram_image(record_locator, s3):
+def upsert_crash_diagram_image(record_locator, s3):
     """Handle a crash diagram image upsert"""
     if "file" not in request.files:
         return jsonify(error="Image file is required"), 400
 
     file = request.files["file"]
-    diagram_original_obj_key = _get_crash_diagram_metadata(record_locator)
+    diagram_original_obj_key = get_crash_diagram_metadata(record_locator)
 
     # Process and upload the image
     img_without_exif, img_format, ext = validate_and_process_image(file)
@@ -429,9 +429,9 @@ def _upsert_crash_diagram_image(record_locator, s3):
     return jsonify(success=True), 200
 
 
-def _delete_crash_diagram_image(record_locator, s3):
+def delete_crash_diagram_image(record_locator, s3):
     """Delete a crash diagram from S3 and clear metadata in the db"""
-    diagram_obj_key = _get_crash_diagram_metadata(record_locator)
+    diagram_obj_key = get_crash_diagram_metadata(record_locator)
 
     if not diagram_obj_key:
         abort(404, description=f"No crash diagram found for crash ID: {record_locator}")
@@ -456,3 +456,15 @@ def _delete_crash_diagram_image(record_locator, s3):
     except Exception as e:
         current_app.logger.exception(str(e))
         abort(500, description="Delete failed")
+
+
+# Temporary compatibility aliases (remove after downstream imports are updated)
+_get_person_image_metadata = get_person_image_metadata
+_get_person_image_url = get_person_image_url
+_upsert_person_image = upsert_person_image
+_delete_person_image = delete_person_image
+_transfer_person_image = copy_person_image
+_get_crash_diagram_metadata = get_crash_diagram_metadata
+_get_crash_diagram_image_url = get_crash_diagram_image_url
+_upsert_crash_diagram_image = upsert_crash_diagram_image
+_delete_crash_diagram_image = delete_crash_diagram_image

--- a/api/utils/images.py
+++ b/api/utils/images.py
@@ -456,16 +456,3 @@ def delete_crash_diagram_image(record_locator, s3):
     except Exception as e:
         current_app.logger.exception(str(e))
         abort(500, description="Delete failed")
-
-
-# Temporary compatibility aliases (remove after downstream imports are updated)
-_get_person_image_metadata = get_person_image_metadata
-_get_person_image_url = get_person_image_url
-_upsert_person_image = upsert_person_image
-_delete_person_image = delete_person_image
-_transfer_person_image = copy_person_image
-_get_crash_diagram_metadata = get_crash_diagram_metadata
-_get_crash_diagram_image_url = get_crash_diagram_image_url
-_upsert_crash_diagram_image = upsert_crash_diagram_image
-_delete_crash_diagram_image = delete_crash_diagram_image
-_handle_image_upload = handle_image_upload


### PR DESCRIPTION
## Associated issues

* https://github.com/cityofaustin/atd-data-tech/issues/27703

## Summary

- Rename public image helpers in `utils/images.py` to conventional names (`get_person_image_url`, `upsert_person_image`, `copy_person_image`, etc.) and update server imports. 
- Import `copy_person_image` as `copy_person_image_handler` to avoid shadowing the Flask route. 
- Add temporary underscore aliases for backward compatibility with any external imports.

## Testing


**URL to test:** <!-- VZ URL or Netlify -->
Local

**Run the tests:**
```
cd api
pytest tests/test_person_images.py tests/test_diagram_images.py
```

**Run the API locally:**
- Upload, view, and delete a person image on the fatality details page
- Upload, view, and delete a crash diagram image on a temp record

---

#### Ship list

- [ ] Check migrations for any conflicts with latest migrations in `main` branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved
