### PR TITLE
Shade the By Time of Day chart current year maximum

### DIFF
--- a/viewer/src/constants/colors.js
+++ b/viewer/src/constants/colors.js
@@ -1,8 +1,12 @@
 export const colors = {
-  intensity1Of5Lowest: "#f3f4ff",
-  intensity2Of5: "#c6c8e1",
-  intensity3Of5: "#9a9cc2",
-  intensity4Of5: "#6d6fa4",
+  intensity0Of7: "#eeeffb",
+  intensity1Of7: "#E4E5F5",
+  intensity2Of7: "#BEC0E3",
+  intensity3Of7: "#9B9DCF",
+  intensity4Of7: "#5C5FA0",
+  intensity5Of7: "#404385",
+  intensity6Of7: "#33377E",
+  intensity7Of7: "#7A7DB9",
   // Use viridis1Of6Highest in place of intensity5Of5Highest (they are the same)
   viridis1Of6Highest: "#404385",
   viridis2Of6: "#2a788d",

--- a/viewer/src/constants/colors.js
+++ b/viewer/src/constants/colors.js
@@ -1,13 +1,12 @@
 export const colors = {
   // Color scale anchored on #404385
-  intensity0Of7: "#eeeffb",
-  intensity1Of7: "#E4E5F5",
-  intensity2Of7: "#BEC0E3",
-  intensity3Of7: "#9B9DCF",
-  intensity4Of7: "#5C5FA0",
-  intensity5Of7: "#404385",
-  intensity6Of7: "#33377E",
-  intensity7Of7: "#7A7DB9",
+  intensity0Of6: "#eeeffb",
+  intensity1Of6: "#E4E5F5",
+  intensity2Of6: "#BEC0E3",
+  intensity3Of6: "#9B9DCF",
+  intensity4Of6: "#5C5FA0",
+  intensity5Of6: "#404385",
+  intensity6Of6: "#33377E",
   // Use viridis1Of6Highest in place of intensity5Of5Highest (they are the same)
   viridis1Of6Highest: "#404385",
   viridis2Of6: "#2a788d",

--- a/viewer/src/constants/colors.js
+++ b/viewer/src/constants/colors.js
@@ -1,4 +1,5 @@
 export const colors = {
+  // Color scale anchored on #404385
   intensity0Of7: "#eeeffb",
   intensity1Of7: "#E4E5F5",
   intensity2Of7: "#BEC0E3",

--- a/viewer/src/constants/time.js
+++ b/viewer/src/constants/time.js
@@ -9,8 +9,11 @@ export const ROLLING_YEARS_OF_DATA = 4;
 export const MONTHS_AGO =
   process.env.REACT_APP_VZV_ENVIRONMENT === "PREVIEW" ? 1 : 2;
 
+// Last date of records that should be referenced in VZV (the last day of the month that is MONTHS_AGO months ago)
+export const dataEndDate = sub(new Date(), { days: 14 });
+
 // Create array of ints of last n years
-export const yearsArray = () => {
+const getYearsArray = () => {
   let years = [];
   let year = parseInt(format(dataEndDate, "yyyy"));
   for (let i = 0; i <= ROLLING_YEARS_OF_DATA; i++) {
@@ -19,6 +22,8 @@ export const yearsArray = () => {
   return years;
 };
 
+export const yearsArray = getYearsArray();
+
 // First date of records that should be referenced in VZV (start of first year in rolling window)
 export const dataStartDate = startOfYear(
   sub(new Date(), {
@@ -26,9 +31,6 @@ export const dataStartDate = startOfYear(
     years: ROLLING_YEARS_OF_DATA,
   })
 );
-
-// Last date of records that should be referenced in VZV (the last day of the month that is MONTHS_AGO months ago)
-export const dataEndDate = sub(new Date(), { days: 14 });
 
 // Summary time data
 export const summaryCurrentYearStartDate = format(

--- a/viewer/src/constants/time.js
+++ b/viewer/src/constants/time.js
@@ -9,7 +9,7 @@ export const ROLLING_YEARS_OF_DATA = 4;
 export const MONTHS_AGO =
   process.env.REACT_APP_VZV_ENVIRONMENT === "PREVIEW" ? 1 : 2;
 
-// Last date of records that should be referenced in VZV (the last day of the month that is MONTHS_AGO months ago)
+// Last date of records that should be referenced in VZV
 export const dataEndDate = sub(new Date(), { days: 14 });
 
 // Create array of ints of last n years

--- a/viewer/src/views/summary/Components/CrashTypeSelector.js
+++ b/viewer/src/views/summary/Components/CrashTypeSelector.js
@@ -7,29 +7,60 @@ import { colors } from "../../../constants/colors";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faHeartbeat, faMedkit } from "@fortawesome/free-solid-svg-icons";
 
-const CrashTypeSelector = ({ setCrashType, componentName }) => {
-  const fatalitiesAndSeriousInjuries = {
+const CRASH_TYPES = {
+  fatalitiesAndSeriousInjuries: {
     name: "fatalitiesAndSeriousInjuries",
     textString: "Fatalities and Serious Injuries",
     queryStringCrash: "(death_cnt > 0 OR sus_serious_injry_cnt > 0)",
     queryStringPerson: "(prsn_injry_sev_id = 4 OR prsn_injry_sev_id = 1)",
-  };
-
-  const fatalities = {
+  },
+  fatalities: {
     name: "fatalities",
     textString: "Fatalities",
     queryStringCrash: "(death_cnt > 0)",
     queryStringPerson: "(prsn_injry_sev_id = 4)",
-  };
-
-  const seriousInjuries = {
+  },
+  seriousInjuries: {
     name: "seriousInjuries",
     textString: "Serious Injuries",
     queryStringCrash: "(sus_serious_injry_cnt > 0)",
     queryStringPerson: "(prsn_injry_sev_id = 1)",
-  };
+  },
+};
 
-  const [activeTab, setActiveTab] = useState(fatalitiesAndSeriousInjuries);
+// Set styles to override Bootstrap default styling
+const StyledButton = styled.div`
+  .crash-type {
+    font-size: 14px;
+    color: ${colors.dark};
+    background: ${colors.buttonBackground} 0% 0% no-repeat padding-box;
+    border-style: none;
+    border-radius: 18px;
+    opacity: 1;
+    margin-right: 2px;
+  }
+`;
+
+const fatalitiesIcon = (
+  <FontAwesomeIcon
+    className="block-icon"
+    icon={faHeartbeat}
+    color={colors.fatalities}
+  />
+);
+
+const seriousInjuriesIcon = (
+  <FontAwesomeIcon
+    className="block-icon"
+    icon={faMedkit}
+    color={colors.seriousInjuries}
+  />
+);
+
+const CrashTypeSelector = ({ setCrashType, componentName }) => {
+  const [activeTab, setActiveTab] = useState(
+    CRASH_TYPES.fatalitiesAndSeriousInjuries
+  );
 
   const toggle = (tab) => {
     if (activeTab.name !== tab.name) {
@@ -41,35 +72,6 @@ const CrashTypeSelector = ({ setCrashType, componentName }) => {
     setCrashType(activeTab);
   }, [setCrashType, activeTab]);
 
-  // Set styles to override Bootstrap default styling
-  const StyledButton = styled.div`
-    .crash-type {
-      font-size: 14px;
-      color: ${colors.dark};
-      background: ${colors.buttonBackground} 0% 0% no-repeat padding-box;
-      border-style: none;
-      border-radius: 18px;
-      opacity: 1;
-      margin-right: 2px;
-    }
-  `;
-
-  const fatalitiesIcon = (
-    <FontAwesomeIcon
-      className="block-icon"
-      icon={faHeartbeat}
-      color={colors.fatalities}
-    />
-  );
-
-  const seriousInjuriesIcon = (
-    <FontAwesomeIcon
-      className="block-icon"
-      icon={faMedkit}
-      color={colors.seriousInjuries}
-    />
-  );
-
   return (
     <StyledButton>
       <Button
@@ -80,7 +82,7 @@ const CrashTypeSelector = ({ setCrashType, componentName }) => {
           "crash-type"
         )}
         onClick={() => {
-          toggle(fatalitiesAndSeriousInjuries);
+          toggle(CRASH_TYPES.fatalitiesAndSeriousInjuries);
         }}
       >
         All
@@ -93,7 +95,7 @@ const CrashTypeSelector = ({ setCrashType, componentName }) => {
           "crash-type"
         )}
         onClick={() => {
-          toggle(fatalities);
+          toggle(CRASH_TYPES.fatalities);
           trackPageEvent("fatal");
         }}
       >
@@ -107,7 +109,7 @@ const CrashTypeSelector = ({ setCrashType, componentName }) => {
           "crash-type"
         )}
         onClick={() => {
-          toggle(seriousInjuries);
+          toggle(CRASH_TYPES.seriousInjuries);
           trackPageEvent("injury");
         }}
       >

--- a/viewer/src/views/summary/Components/CrashTypeSelector.js
+++ b/viewer/src/views/summary/Components/CrashTypeSelector.js
@@ -7,7 +7,7 @@ import { colors } from "../../../constants/colors";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faHeartbeat, faMedkit } from "@fortawesome/free-solid-svg-icons";
 
-const CRASH_TYPES = {
+export const CRASH_TYPES = {
   fatalitiesAndSeriousInjuries: {
     name: "fatalitiesAndSeriousInjuries",
     textString: "Fatalities and Serious Injuries",

--- a/viewer/src/views/summary/CrashesByMode.js
+++ b/viewer/src/views/summary/CrashesByMode.js
@@ -102,7 +102,7 @@ const CrashesByMode = () => {
         let newData = {};
         // Use Promise.all to let all requests resolve before setting chart data by year
         await Promise.all(
-          yearsArray().map(async (year) => {
+          yearsArray.map(async (year) => {
             // If getting data for current year (only including years past January), set end of query to last day of previous month,
             // else if getting data for previous years, set end of query to last day of year
             let endDate =
@@ -128,11 +128,11 @@ const CrashesByMode = () => {
       setChartLegend(chartRef.current.chartInstance.generateLegend());
   }, [chartData, legendColors]);
 
-  const createChartLabels = () => yearsArray().map((year) => `${year}`);
+  const createChartLabels = () => yearsArray.map((year) => `${year}`);
 
   // Tabulate fatalities/injuries by mode fields in data
   const getModeData = (fields) =>
-    yearsArray().map((year) => {
+    yearsArray.map((year) => {
       return chartData[year].reduce((accumulator, record) => {
         const isFatalQuery =
           crashType.name === "fatalities" ||
@@ -179,7 +179,7 @@ const CrashesByMode = () => {
 
   // Get an array of annual totals for the selected crash type
   const getYearTotalsArray = useMemo(() => {
-    const yearTotalsArray = yearsArray().map((year, index) => {
+    const yearTotalsArray = yearsArray.map((year, index) => {
       let currentYearTotal = 0;
       data.datasets &&
         data.datasets.forEach((mode) => {

--- a/viewer/src/views/summary/CrashesByTimeOfDay.js
+++ b/viewer/src/views/summary/CrashesByTimeOfDay.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useMemo } from "react";
 import axios from "axios";
-import { format, parseISO, sub } from "date-fns";
+import { format, parseISO } from "date-fns";
 import clonedeep from "lodash.clonedeep";
 
 import CrashTypeSelector from "./Components/CrashTypeSelector";
@@ -17,14 +17,8 @@ import {
   LinearXAxisTickSeries,
   LinearXAxisTickLabel,
 } from "reaviz";
-import {
-  summaryCurrentYearStartDate,
-  summaryCurrentYearEndDate,
-  yearsArray,
-  dataEndDate,
-} from "../../constants/time";
+import { yearsArray } from "../../constants/time";
 import { crashEndpointUrl } from "./queries/socrataQueries";
-import { getYearsAgoLabel } from "./helpers/helpers";
 import { colors } from "../../constants/colors";
 import ColorSpinner from "../../Components/Spinner/ColorSpinner";
 
@@ -63,8 +57,6 @@ const buildDataArray = () => {
 
 const calculateHourBlockTotals = (records, crashType) => {
   const dataArray = buildDataArray();
-
-  console.log("RECORDZ", records);
   records.forEach((record) => {
     const recordDateTime = parseISO(record.crash_timestamp_ct);
     const recordHour = format(recordDateTime, hourFormat);
@@ -92,20 +84,18 @@ const calculateHourBlockTotals = (records, crashType) => {
 
 /**
  * Generate the query url for the Socrata query based on the active tab and crash type
- * @param {Number} activeTab - The active tab index that corresponds to year option selected
+ * @param {Number | "all_years"} activeYear - The active year selected in the cart. Either a year number of "all_years"
  * @param {Object} crashType - Object containing query and name details (see CrashTypeSelector component)
  * @returns {String} The query url for the Socrata query
  */
-const getFatalitiesByYearsAgoUrl = (activeTab, crashType) => {
-  // subtract years ago (based on activeTab) from current year
-  const yearsAgoDate = format(
-    sub(parseISO(summaryCurrentYearStartDate), { years: activeTab }),
-    "yyyy"
-  );
-  let queryUrl =
-    activeTab === 0
-      ? `${crashEndpointUrl}?$where=${crashType.queryStringCrash} AND crash_timestamp_ct between '${summaryCurrentYearStartDate}T00:00:00' and '${summaryCurrentYearEndDate}T23:59:59'`
-      : `${crashEndpointUrl}?$where=${crashType.queryStringCrash} AND crash_timestamp_ct between '${yearsAgoDate}-01-01T00:00:00' and '${yearsAgoDate}-12-31T23:59:59'`;
+const getFatalitiesByYearsAgoUrl = (activeYear, crashType) => {
+  const queryStartYear =
+    activeYear === "all_years" ? yearsArray[0] : activeYear;
+
+  const queryEndYear =
+    activeYear === "all_years" ? yearsArray.at(-1) : activeYear;
+
+  let queryUrl = `${crashEndpointUrl}?$where=${crashType.queryStringCrash} AND crash_timestamp_ct between '${queryStartYear}-01-01T00:00:00' and '${queryEndYear}-12-31T23:59:59'`;
   return queryUrl;
 };
 
@@ -126,22 +116,22 @@ const formatValue = (d) => {
 };
 
 const CrashesByTimeOfDay = () => {
-  const [activeTab, setActiveTab] = useState(0);
-  const [crashType, setCrashType] = useState([]);
+  const [activeYear, setActiveYear] = useState(yearsArray.at(-1));
+  const [crashType, setCrashType] = useState({});
   const [heatmapData, setHeatmapData] = useState([]);
 
-  const toggle = (tab) => {
-    if (activeTab !== tab) setActiveTab(tab);
+  const toggle = (year) => {
+    if (activeYear !== year) setActiveYear(year);
   };
 
   useEffect(() => {
     if (!crashType.queryStringCrash) return;
 
-    axios.get(getFatalitiesByYearsAgoUrl(activeTab, crashType)).then((res) => {
+    axios.get(getFatalitiesByYearsAgoUrl(activeYear, crashType)).then((res) => {
       const formattedData = calculateHourBlockTotals(res.data, crashType);
       setHeatmapData(formattedData);
     });
-  }, [activeTab, crashType]);
+  }, [activeYear, crashType]);
 
   const maxForLegend = useMemo(
     () => getMaxCrashCount(heatmapData),
@@ -160,6 +150,7 @@ const CrashesByTimeOfDay = () => {
     }
   `;
 
+  console.log("crashType", crashType)
   return (
     <Container className="m-0 p-0">
       <Row>
@@ -185,23 +176,31 @@ const CrashesByTimeOfDay = () => {
           <Row className="text-center">
             <Col className="pb-2">
               <StyledButton>
-                {yearsArray() // Calculate years ago for each year in data window
-                  .map((year) => {
-                    const currentYear = parseInt(format(dataEndDate, "yyyy"));
-                    return currentYear - year;
-                  })
-                  .map((yearsAgo) => (
+                <Button
+                  key="all_years"
+                  className={classnames(
+                    { active: activeYear === "all_years" },
+                    "year-selector"
+                  )}
+                  onClick={() => {
+                    toggle("all_years");
+                  }}
+                >
+                  All
+                </Button>
+                {yearsArray // Calculate years ago for each year in data window
+                  .map((year) => (
                     <Button
-                      key={yearsAgo}
+                      key={year}
                       className={classnames(
-                        { active: activeTab === yearsAgo },
+                        { active: activeYear === year },
                         "year-selector"
                       )}
                       onClick={() => {
-                        toggle(yearsAgo);
+                        toggle(year);
                       }}
                     >
-                      {getYearsAgoLabel(yearsAgo)}
+                      {year}
                     </Button>
                   ))}
               </StyledButton>
@@ -216,20 +215,35 @@ const CrashesByTimeOfDay = () => {
                 series={
                   <HeatmapSeries
                     colorScheme={[
-                      colors.intensity2Of5,
-                      colors.intensity3Of5,
-                      colors.intensity4Of5,
-                      colors.viridis1Of6Highest,
+                      colors.intensity1Of7,
+                      colors.intensity2Of7,
+                      colors.intensity3Of7,
+                      colors.intensity4Of7,
+                      colors.intensity5Of7,
+                      colors.intensity6Of7,
+                      colors.intensity7Of7,
                     ]}
-                    emptyColor={colors.intensity1Of5Lowest}
+                    emptyColor={colors.intensity0Of7}
                     cell={
                       <HeatmapCell
                         tooltip={
                           <ChartTooltip
-                            content={(d) =>
-                              `${d.x} ∙
-                          ${formatValue(d)}`
-                            }
+                            content={(d) => (
+                              <div
+                                // attempt to match react-charts tooltip style
+                                style={{
+                                  backgroundColor: "rgba(10, 10, 10, 0.8)",
+                                  color: "#fff",
+                                  padding: 5,
+                                  borderRadius: 5,
+                                }}
+                              >
+                                <span className="font-weight-bold">{`${d.x}`}</span>
+                                <div>
+                                  <span>{`${formatValue(d)} crash${!d.y || d.y > 1 ? "es" : ""}`}</span>
+                                </div>
+                              </div>
+                            )}
                           />
                         }
                       />
@@ -266,10 +280,7 @@ const CrashesByTimeOfDay = () => {
                     { key: "Min", data: 0 },
                   ]}
                   orientation="horizontal"
-                  colorScheme={[
-                    colors.intensity1Of5Lowest,
-                    colors.viridis1Of6Highest,
-                  ]}
+                  colorScheme={[colors.intensity1Of7, colors.intensity6Of7]}
                 />
               )}
             </Col>

--- a/viewer/src/views/summary/CrashesByTimeOfDay.js
+++ b/viewer/src/views/summary/CrashesByTimeOfDay.js
@@ -22,7 +22,7 @@ import { crashEndpointUrl } from "./queries/socrataQueries";
 import { colors } from "../../constants/colors";
 import ColorSpinner from "../../Components/Spinner/ColorSpinner";
 
-const dayOfWeekArray = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+const dayOfWeekArray = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
 
 // format time at 1AM, 12PM, etc
 const hourFormat = "ha";

--- a/viewer/src/views/summary/CrashesByTimeOfDay.js
+++ b/viewer/src/views/summary/CrashesByTimeOfDay.js
@@ -236,15 +236,14 @@ const CrashesByTimeOfDay = () => {
                 series={
                   <HeatmapSeries
                     colorScheme={[
-                      colors.intensity1Of7,
-                      colors.intensity2Of7,
-                      colors.intensity3Of7,
-                      colors.intensity4Of7,
-                      colors.intensity5Of7,
-                      colors.intensity6Of7,
-                      colors.intensity7Of7,
+                      colors.intensity1Of6,
+                      colors.intensity2Of6,
+                      colors.intensity3Of6,
+                      colors.intensity4Of6,
+                      colors.intensity5Of6,
+                      colors.intensity6Of6,
                     ]}
-                    emptyColor={colors.intensity0Of7}
+                    emptyColor={colors.intensity0Of6}
                     cell={
                       <HeatmapCell
                         tooltip={
@@ -310,7 +309,7 @@ const CrashesByTimeOfDay = () => {
                   { key: "Min", data: 0 },
                 ]}
                 orientation="horizontal"
-                colorScheme={[colors.intensity1Of7, colors.intensity6Of7]}
+                colorScheme={[colors.intensity1Of6, colors.intensity6Of6]}
               />
             )}
           </Col>

--- a/viewer/src/views/summary/CrashesByTimeOfDay.js
+++ b/viewer/src/views/summary/CrashesByTimeOfDay.js
@@ -126,7 +126,6 @@ function getMaxCrashCount(formattedData) {
  * @returns
  */
 const formatCrashCount = (crashCount) => {
-  console.log(crashCount);
   return `${crashCount} crash${!crashCount || crashCount > 1 ? "es" : ""}`;
 };
 

--- a/viewer/src/views/summary/CrashesByTimeOfDay.js
+++ b/viewer/src/views/summary/CrashesByTimeOfDay.js
@@ -130,7 +130,7 @@ const formatCrashCount = (crashCount) => {
 };
 
 const CrashesByTimeOfDay = () => {
-  const [activeYear, setActiveYear] = useState(yearsArray.at(-1));
+  const [activeYear, setActiveYear] = useState("all_years");
   const [crashType, setCrashType] = useState({});
   const [heatmapData, setHeatmapData] = useState([]);
 
@@ -196,18 +196,6 @@ const CrashesByTimeOfDay = () => {
         <Row className="text-center">
           <Col className="pb-2">
             <StyledButton>
-              <Button
-                key="all_years"
-                className={classnames(
-                  { active: activeYear === "all_years" },
-                  "year-selector"
-                )}
-                onClick={() => {
-                  setActiveYear("all_years");
-                }}
-              >
-                All
-              </Button>
               {yearsArray // Calculate years ago for each year in data window
                 .map((year) => (
                   <Button
@@ -223,6 +211,18 @@ const CrashesByTimeOfDay = () => {
                     {year}
                   </Button>
                 ))}
+              <Button
+                key="all_years"
+                className={classnames(
+                  { active: activeYear === "all_years" },
+                  "year-selector"
+                )}
+                onClick={() => {
+                  setActiveYear("all_years");
+                }}
+              >
+                All
+              </Button>
             </StyledButton>
           </Col>
         </Row>

--- a/viewer/src/views/summary/CrashesByTimeOfDay.js
+++ b/viewer/src/views/summary/CrashesByTimeOfDay.js
@@ -3,7 +3,7 @@ import axios from "axios";
 import { format, parseISO } from "date-fns";
 import clonedeep from "lodash.clonedeep";
 
-import CrashTypeSelector from "./Components/CrashTypeSelector";
+import CrashTypeSelector, { CRASH_TYPES } from "./Components/CrashTypeSelector";
 import { Row, Col, Container, Button } from "reactstrap";
 import styled from "styled-components";
 import classnames from "classnames";
@@ -49,12 +49,19 @@ const buildDataArray = () => {
 };
 
 /**
+ * Container to store fetched data by crash type
+ */
+const chartDataStore = Object.keys(CRASH_TYPES).reduce((prev, crashType) => {
+  prev[crashType] = {};
+  return prev;
+}, {});
+
+/**
  * Calculate the figures to populate the heatmap cells
  * @param {*} records - Array of crash records returned from the Socrata query
  * @param {Object} crashType - Object containing query and name details (see CrashTypeSelector component)
  * @returns
  */
-
 const calculateHourBlockTotals = (records, crashType) => {
   const dataArray = buildDataArray();
   records.forEach((record) => {
@@ -120,17 +127,24 @@ const CrashesByTimeOfDay = () => {
   const [crashType, setCrashType] = useState({});
   const [heatmapData, setHeatmapData] = useState([]);
 
-  const toggle = (year) => {
-    if (activeYear !== year) setActiveYear(year);
-  };
-
   useEffect(() => {
     if (!crashType.queryStringCrash) return;
 
-    axios.get(getFatalitiesByYearsAgoUrl(activeYear, crashType)).then((res) => {
-      const formattedData = calculateHourBlockTotals(res.data, crashType);
-      setHeatmapData(formattedData);
-    });
+    if (!chartDataStore[crashType.name][activeYear]) {
+      // we have not fetched this data yet, so do that
+      setHeatmapData([]);
+      axios
+        .get(getFatalitiesByYearsAgoUrl(activeYear, crashType))
+        .then((res) => {
+          const formattedData = calculateHourBlockTotals(res.data, crashType);
+          // save fetched data for re-use
+          chartDataStore[crashType.name][activeYear] = formattedData;
+          setHeatmapData(formattedData);
+        });
+    } else {
+      // we already fetched this data
+      setHeatmapData(chartDataStore[crashType.name][activeYear]);
+    }
   }, [activeYear, crashType]);
 
   const maxForLegend = useMemo(
@@ -150,7 +164,6 @@ const CrashesByTimeOfDay = () => {
     }
   `;
 
-  console.log("crashType", crashType)
   return (
     <Container className="m-0 p-0">
       <Row>
@@ -171,43 +184,44 @@ const CrashesByTimeOfDay = () => {
           <hr />
         </Col>
       </Row>
-      {!!heatmapData.length > 0 ? (
-        <div>
-          <Row className="text-center">
-            <Col className="pb-2">
-              <StyledButton>
-                <Button
-                  key="all_years"
-                  className={classnames(
-                    { active: activeYear === "all_years" },
-                    "year-selector"
-                  )}
-                  onClick={() => {
-                    toggle("all_years");
-                  }}
-                >
-                  All
-                </Button>
-                {yearsArray // Calculate years ago for each year in data window
-                  .map((year) => (
-                    <Button
-                      key={year}
-                      className={classnames(
-                        { active: activeYear === year },
-                        "year-selector"
-                      )}
-                      onClick={() => {
-                        toggle(year);
-                      }}
-                    >
-                      {year}
-                    </Button>
-                  ))}
-              </StyledButton>
-            </Col>
-          </Row>
-          <Row className="h-auto">
-            <Col id="demographics-heatmap">
+
+      <div>
+        <Row className="text-center">
+          <Col className="pb-2">
+            <StyledButton>
+              <Button
+                key="all_years"
+                className={classnames(
+                  { active: activeYear === "all_years" },
+                  "year-selector"
+                )}
+                onClick={() => {
+                  setActiveYear("all_years");
+                }}
+              >
+                All
+              </Button>
+              {yearsArray // Calculate years ago for each year in data window
+                .map((year) => (
+                  <Button
+                    key={year}
+                    className={classnames(
+                      { active: activeYear === year },
+                      "year-selector"
+                    )}
+                    onClick={() => {
+                      setActiveYear(year);
+                    }}
+                  >
+                    {year}
+                  </Button>
+                ))}
+            </StyledButton>
+          </Col>
+        </Row>
+        <Row className="h-auto">
+          <Col id="demographics-heatmap">
+            {!!heatmapData.length > 0 ? (
               <Heatmap
                 height={267}
                 margins={[0, 0, 0, 15]}
@@ -269,28 +283,28 @@ const CrashesByTimeOfDay = () => {
                   />
                 }
               />
-            </Col>
-          </Row>
-          <Row>
-            <Col className="py-2">
-              {!!maxForLegend && (
-                <SequentialLegend
-                  data={[
-                    { key: "Max", data: maxForLegend },
-                    { key: "Min", data: 0 },
-                  ]}
-                  orientation="horizontal"
-                  colorScheme={[colors.intensity1Of7, colors.intensity6Of7]}
-                />
-              )}
-            </Col>
-          </Row>
-        </div>
-      ) : (
-        <h1>
-          <ColorSpinner />
-        </h1>
-      )}
+            ) : (
+              <h1>
+                <ColorSpinner />
+              </h1>
+            )}
+          </Col>
+        </Row>
+        <Row>
+          <Col className="py-2">
+            {!!maxForLegend && (
+              <SequentialLegend
+                data={[
+                  { key: "Max", data: maxForLegend },
+                  { key: "Min", data: 0 },
+                ]}
+                orientation="horizontal"
+                colorScheme={[colors.intensity1Of7, colors.intensity6Of7]}
+              />
+            )}
+          </Col>
+        </Row>
+      </div>
     </Container>
   );
 };

--- a/viewer/src/views/summary/CrashesByTimeOfDay.js
+++ b/viewer/src/views/summary/CrashesByTimeOfDay.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useState, useEffect } from "react";
+import React, { useCallback, useState, useEffect, useMemo } from "react";
 import axios from "axios";
 import { format, parseISO, sub } from "date-fns";
 import clonedeep from "lodash.clonedeep";
@@ -21,7 +21,6 @@ import {
   summaryCurrentYearStartDate,
   summaryCurrentYearEndDate,
   yearsArray,
-  dataStartDate,
   dataEndDate,
 } from "../../constants/time";
 import { crashEndpointUrl } from "./queries/socrataQueries";
@@ -31,8 +30,11 @@ import ColorSpinner from "../../Components/Spinner/ColorSpinner";
 
 const dayOfWeekArray = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
 
+// format time at 1AM, 12PM, etc
+const hourFormat = "ha";
+
 const hourBlockArray = [...Array(24).keys()].map((hour) =>
-  format(new Date().setHours(hour), "hha")
+  format(new Date().setHours(hour), hourFormat)
 );
 
 /**
@@ -62,9 +64,10 @@ const buildDataArray = () => {
 const calculateHourBlockTotals = (records, crashType) => {
   const dataArray = buildDataArray();
 
+  console.log("RECORDZ", records);
   records.forEach((record) => {
     const recordDateTime = parseISO(record.crash_timestamp_ct);
-    const recordHour = format(recordDateTime, "hha");
+    const recordHour = format(recordDateTime, hourFormat);
     const recordDay = format(recordDateTime, "E");
 
     const hourData = dataArray.find((hour) => hour.key === recordHour).data;
@@ -95,7 +98,10 @@ const calculateHourBlockTotals = (records, crashType) => {
  */
 const getFatalitiesByYearsAgoUrl = (activeTab, crashType) => {
   // subtract years ago (based on activeTab) from current year
-  const yearsAgoDate = format(sub(parseISO(summaryCurrentYearStartDate), { years: activeTab }), "yyyy");
+  const yearsAgoDate = format(
+    sub(parseISO(summaryCurrentYearStartDate), { years: activeTab }),
+    "yyyy"
+  );
   let queryUrl =
     activeTab === 0
       ? `${crashEndpointUrl}?$where=${crashType.queryStringCrash} AND crash_timestamp_ct between '${summaryCurrentYearStartDate}T00:00:00' and '${summaryCurrentYearEndDate}T23:59:59'`
@@ -103,14 +109,26 @@ const getFatalitiesByYearsAgoUrl = (activeTab, crashType) => {
   return queryUrl;
 };
 
+function getMaxCrashCount(formattedData) {
+  let max = 0;
+  for (const hour of formattedData) {
+    for (const day of hour.data) {
+      if (day.data === null) continue;
+      if (day.data > max) max = day.data;
+    }
+  }
+  return max;
+}
+
+const formatValue = (d) => {
+  const value = d.data.value ? d.data.value : 0;
+  return value;
+};
+
 const CrashesByTimeOfDay = () => {
   const [activeTab, setActiveTab] = useState(0);
   const [crashType, setCrashType] = useState([]);
   const [heatmapData, setHeatmapData] = useState([]);
-  const [heatmapDataWithPlaceholder, setHeatmapDataWithPlaceholder] = useState(
-    []
-  );
-  const [maxForLegend, setMaxForLegend] = useState(null);
 
   const toggle = (tab) => {
     if (activeTab !== tab) setActiveTab(tab);
@@ -125,71 +143,10 @@ const CrashesByTimeOfDay = () => {
     });
   }, [activeTab, crashType]);
 
-  // Query to find maximum day total per crash type
-  useEffect(() => {
-    if (maxForLegend) return;
-
-    const maxQuery = `
-    SELECT date_extract_dow(crash_timestamp_ct) as day, date_extract_hh(crash_timestamp_ct) as hour, date_extract_y(crash_timestamp_ct) as year, SUM(death_cnt) as death, SUM(sus_serious_injry_cnt) as serious, serious + death as all 
-    WHERE crash_timestamp_ct BETWEEN '${format(
-      dataStartDate,
-      "yyyy-MM-dd"
-    )}' and '${summaryCurrentYearEndDate}' 
-    GROUP BY day, hour, year 
-    ORDER BY year 
-    |> 
-    SELECT max(death) as fatalities, max(serious) as seriousInjuries, max(all) as fatalitiesAndSeriousInjuries
-    `;
-
-    axios
-      .get(crashEndpointUrl + `?$query=` + encodeURIComponent(maxQuery))
-      .then((res) => {
-        setMaxForLegend(res.data[0]);
-      });
-  }, [maxForLegend, crashType]);
-
-  // When crashType changes, add a placeholder column containing max values to weight each year consistently
-  useEffect(() => {
-    const lastRecordInHeatmapData = heatmapData[heatmapData.length - 1];
-    const isPlaceholderArraySet =
-      lastRecordInHeatmapData && lastRecordInHeatmapData.key === "";
-
-    if (!maxForLegend || heatmapData.length === 0 || isPlaceholderArraySet)
-      return;
-
-    const placeholderArray = heatmapData[0].data.map((data, i) => ({
-      key: dayOfWeekArray[i],
-      data: maxForLegend[crashType.name],
-      // Add this metadata to find which cells to hide in the callback ref below
-      metadata: { isPlaceholder: true },
-    }));
-
-    const placeholderObjForChartWeighting = {
-      key: "",
-      data: placeholderArray,
-    };
-
-    const updatedWeightingData = [
-      ...heatmapData,
-      placeholderObjForChartWeighting,
-    ];
-
-    setHeatmapDataWithPlaceholder(updatedWeightingData);
-  }, [maxForLegend, heatmapData, crashType]);
-
-  // Hide placeholder cells with a callback ref
-  const heatmapCellRef = useCallback((node) => {
-    // Look for the isPlaceholder metadata that we placed there to identify the cells to hide
-    if (node?.props?.data?.metadata?.isPlaceholder) {
-      // Update the cell's style to hide it and its tooltip
-      node.rect.current.style.visibility = "hidden";
-    }
-  }, []);
-
-  const formatValue = (d) => {
-    const value = d.data.value ? d.data.value : 0;
-    return value;
-  };
+  const maxForLegend = useMemo(
+    () => getMaxCrashCount(heatmapData),
+    [heatmapData]
+  );
 
   // Set styles to override Bootstrap default styling
   const StyledButton = styled.div`
@@ -223,7 +180,7 @@ const CrashesByTimeOfDay = () => {
           <hr />
         </Col>
       </Row>
-      {!!heatmapDataWithPlaceholder.length > 0 ? (
+      {!!heatmapData.length > 0 ? (
         <div>
           <Row className="text-center">
             <Col className="pb-2">
@@ -251,23 +208,25 @@ const CrashesByTimeOfDay = () => {
             </Col>
           </Row>
           <Row className="h-auto">
-            <Col id="demographics-heatmap" className="pl-4">
+            <Col id="demographics-heatmap">
               <Heatmap
                 height={267}
-                data={heatmapDataWithPlaceholder}
+                margins={[0, 0, 0, 15]}
+                data={heatmapData}
                 series={
                   <HeatmapSeries
-                    colorScheme={[
-                      colors.intensity2Of5,
-                      colors.intensity3Of5,
-                      colors.intensity4Of5,
-                      colors.viridis1Of6Highest,
-                    ]}
+                  colorScheme={[
+                    "#dadaeb","#9e9ac8", "#6a51a3", "#3f007d"
+                  ]}
+                    // colorScheme={[
+                    //   colors.intensity2Of5,
+                    //   colors.intensity3Of5,
+                    //   colors.intensity4Of5,
+                    //   colors.viridis1Of6Highest,
+                    // ]}   
                     emptyColor={colors.intensity1Of5Lowest}
                     cell={
                       <HeatmapCell
-                        // This ref is needed to hide placeholder cells
-                        ref={heatmapCellRef}
                         tooltip={
                           <ChartTooltip
                             content={(d) =>
@@ -306,7 +265,7 @@ const CrashesByTimeOfDay = () => {
               {!!maxForLegend && (
                 <SequentialLegend
                   data={[
-                    { key: "Max", data: maxForLegend[crashType.name] },
+                    { key: "Max", data: maxForLegend },
                     { key: "Min", data: 0 },
                   ]}
                   orientation="horizontal"

--- a/viewer/src/views/summary/CrashesByTimeOfDay.js
+++ b/viewer/src/views/summary/CrashesByTimeOfDay.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useState, useEffect, useMemo } from "react";
+import React, { useState, useEffect, useMemo } from "react";
 import axios from "axios";
 import { format, parseISO, sub } from "date-fns";
 import clonedeep from "lodash.clonedeep";
@@ -215,15 +215,12 @@ const CrashesByTimeOfDay = () => {
                 data={heatmapData}
                 series={
                   <HeatmapSeries
-                  colorScheme={[
-                    "#dadaeb","#9e9ac8", "#6a51a3", "#3f007d"
-                  ]}
-                    // colorScheme={[
-                    //   colors.intensity2Of5,
-                    //   colors.intensity3Of5,
-                    //   colors.intensity4Of5,
-                    //   colors.viridis1Of6Highest,
-                    // ]}   
+                    colorScheme={[
+                      colors.intensity2Of5,
+                      colors.intensity3Of5,
+                      colors.intensity4Of5,
+                      colors.viridis1Of6Highest,
+                    ]}
                     emptyColor={colors.intensity1Of5Lowest}
                     cell={
                       <HeatmapCell

--- a/viewer/src/views/summary/CrashesByTimeOfDay.js
+++ b/viewer/src/views/summary/CrashesByTimeOfDay.js
@@ -91,7 +91,7 @@ const calculateHourBlockTotals = (records, crashType) => {
 
 /**
  * Generate the query url for the Socrata query based on the active tab and crash type
- * @param {Number | "all_years"} activeYear - The active year selected in the cart. Either a year number of "all_years"
+ * @param {Number | "all_years"} activeYear - The active year selected in the chart. Either a year number or "all_years"
  * @param {Object} crashType - Object containing query and name details (see CrashTypeSelector component)
  * @returns {String} The query url for the Socrata query
  */
@@ -106,6 +106,9 @@ const getFatalitiesByYearsAgoUrl = (activeYear, crashType) => {
   return queryUrl;
 };
 
+/**
+ * Find the maximum number of crashes that occurs in a single hour block
+ */
 function getMaxCrashCount(formattedData) {
   let max = 0;
   for (const hour of formattedData) {
@@ -117,9 +120,14 @@ function getMaxCrashCount(formattedData) {
   return max;
 }
 
-const formatValue = (d) => {
-  const value = d.data.value ? d.data.value : 0;
-  return value;
+/**
+ * Format the crash count like "0 crashes" or "1 crash", etc
+ * @param {Integer} crashCount
+ * @returns
+ */
+const formatCrashCount = (crashCount) => {
+  console.log(crashCount);
+  return `${crashCount} crash${!crashCount || crashCount > 1 ? "es" : ""}`;
 };
 
 const CrashesByTimeOfDay = () => {
@@ -242,7 +250,7 @@ const CrashesByTimeOfDay = () => {
                       <HeatmapCell
                         tooltip={
                           <ChartTooltip
-                            content={(d) => (
+                            content={({ y: crashCount, x: label }) => (
                               <div
                                 // attempt to match react-charts tooltip style
                                 style={{
@@ -252,9 +260,13 @@ const CrashesByTimeOfDay = () => {
                                   borderRadius: 5,
                                 }}
                               >
-                                <span className="font-weight-bold">{`${d.x}`}</span>
+                                <span className="font-weight-bold">
+                                  {label}
+                                </span>
                                 <div>
-                                  <span>{`${formatValue(d)} crash${!d.y || d.y > 1 ? "es" : ""}`}</span>
+                                  <span>
+                                    {formatCrashCount(crashCount || 0)}
+                                  </span>
                                 </div>
                               </div>
                             )}

--- a/viewer/src/views/summary/PeopleByDemographics.js
+++ b/viewer/src/views/summary/PeopleByDemographics.js
@@ -179,7 +179,7 @@ const PeopleByDemographics = () => {
       } = chartConfigs[dataKey];
       const isTarget = categoryType === "target";
       const isRange = categoryType === "range";
-      const years = yearsArray();
+      const years = yearsArray;
       const currentYear = years[years.length - 1];
 
       const formattedTypes = {};
@@ -262,7 +262,7 @@ const PeopleByDemographics = () => {
       );
 
       const data = {
-        labels: yearsArray(),
+        labels: yearsArray,
         datasets: config.labelCategories.map((category, i) => ({
           label: config.labelCategories[i],
           data: demoData[configName][crashType.name][category],

--- a/viewer/src/views/summary/helpers/helpers.js
+++ b/viewer/src/views/summary/helpers/helpers.js
@@ -68,7 +68,3 @@ export const getSummaryYearsOfLifeLost = (data, prevYear, currentYear) => {
     { [prevYear]: 0, [currentYear]: 0 }
   ); // start with a count at 0 years
 };
-
-export const getYearsAgoLabel = (yearsAgo) => {
-  return format(sub(dataEndDate, { years: yearsAgo }), "yyyy");
-};

--- a/viewer/src/views/summary/helpers/helpers.js
+++ b/viewer/src/views/summary/helpers/helpers.js
@@ -1,7 +1,4 @@
-import { sub, format } from "date-fns";
-
 import { lifespanYears } from "../../../constants/calc";
-import { dataEndDate } from "../../../constants/time";
 // Helpers to handle Socrata responses for Summary view components
 
 const calcFieldTotalsFromRecords = (data, prevYear, currentYear, field) =>


### PR DESCRIPTION
## Associated issues

* https://github.com/cityofaustin/atd-data-tech/issues/27729

## Testing

**URL to test:** [Netlify](https://deploy-preview-2012--atd-vzv-staging.netlify.app/)

**Steps to test:**

1. Scroll to the time of day chart and test all of the year selector buttons by serious/fatal/both injury types.
2. Hover over the chart cells and see that the tooltip styles are improved, although they don't render very smoothly :/ 
3. Obseve that the chart's Y axis labels (Sun, Mon, etc) are not clipped on their left or right edge
4. Test out the other charts, esp Demographic, Travel mode, and Year & Month

---

#### Ship list

- [ ] Check migrations for any conflicts with latest migrations in `main` branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved
