### PR TITLE
Add additional fields to navbar search

### DIFF
--- a/editor/components/DropdownButtonToggle.tsx
+++ b/editor/components/DropdownButtonToggle.tsx
@@ -1,0 +1,23 @@
+import { forwardRef, HTMLProps } from "react";
+import { Button } from "react-bootstrap";
+
+type CustomToggleProps = HTMLProps<HTMLButtonElement>;
+
+/**
+ * Custom button element dropdown toggle
+ */
+const DropdownButtonToggle = forwardRef<
+  HTMLButtonElement,
+  CustomToggleProps
+>(({ children, onClick }, ref) => (
+    <Button
+      size="sm"
+      ref={ref}
+      onClick={onClick}
+    >
+      {children}
+    </Button>
+));
+
+DropdownButtonToggle.displayName = "DropdownAnchorToggleButton";
+export default DropdownButtonToggle;

--- a/editor/components/NavBarSearch.tsx
+++ b/editor/components/NavBarSearch.tsx
@@ -15,8 +15,11 @@ import { Crash } from "@/types/crashes";
 import { EMSPatientCareRecord } from "@/types/ems";
 import { Location } from "@/types/locations";
 import { useQuery } from "@/utils/graphql";
+import { useLogUserEvent } from "@/utils/userEvents";
 
 const navSearchLocalStorageKey = "navBarSearchField";
+
+const userEventName = "navbar_search";
 
 /**
  * Types that can be used in the search field config
@@ -94,6 +97,7 @@ export default function NavBarSearch() {
   );
   const [searchValue, setSearchValue] = useState("");
   const [searchClicked, setSearchClicked] = useState(false);
+  const logUserEvent = useLogUserEvent();
 
   const router = useRouter();
 
@@ -139,6 +143,7 @@ export default function NavBarSearch() {
   const onSearch = (e: React.ChangeEvent<HTMLFormElement>) => {
     e.preventDefault();
     setSearchClicked(true);
+    logUserEvent(`${userEventName}_${searchField.key}`);
   };
 
   const onSelectSearchField = (field: AnySearchField) => {

--- a/editor/components/NavBarSearch.tsx
+++ b/editor/components/NavBarSearch.tsx
@@ -2,82 +2,232 @@ import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import Spinner from "react-bootstrap/Spinner";
 import Button from "react-bootstrap/Button";
+import Dropdown from "react-bootstrap/Dropdown";
 import Form from "react-bootstrap/Form";
 import InputGroup from "react-bootstrap/InputGroup";
-import { FaMagnifyingGlass } from "react-icons/fa6";
+import { FaCarBurst, FaMagnifyingGlass } from "react-icons/fa6";
 import { CRASH_NAV_SEARCH } from "@/queries/crash";
 import { Crash } from "@/types/crashes";
+import { Location } from "@/types/locations";
 import { useQuery } from "@/utils/graphql";
+import DropdownButtonToggle from "@/components/DropdownButtonToggle";
+import AlignedLabel from "@/components/AlignedLabel";
+import { LuAmbulance, LuChevronDown, LuMapPin } from "react-icons/lu";
+import { EMSPatientCareRecord } from "@/types/ems";
+import { gql } from "graphql-request";
+
+const CRASH_SEARCH = gql`
+  query CrashNavigationSearch($searchValue: String!) {
+    record_locator: crashes(
+      where: {
+        record_locator: { _eq: $searchValue }
+        is_deleted: { _eq: false }
+      }
+    ) {
+      id
+      record_locator
+    }
+  }
+`;
+
+const CASE_SEARCH = gql`
+  query CrashNavigationSearch($searchValue: String!) {
+    case_id: crashes(
+      where: { case_id: { _eq: $searchValue }, is_deleted: { _eq: false } }
+    ) {
+      id
+      record_locator
+    }
+  }
+`;
+
+const LOCATION_SEARCH = gql`
+  query LocationNavigationSearch($searchValue: String!) {
+    location_id: locations(
+      where: { location_id: { _eq: $searchValue }, is_deleted: { _eq: false } }
+    ) {
+      location_id
+    }
+  }
+`;
+
+const EMS_INCIDENT_SEARCH = gql`
+  query EMSNavigationSearch($searchValue: String!) {
+    incident_number: ems__incidents(
+      where: {
+        incident_number: { _eq: $searchValue }
+        is_deleted: { _eq: false }
+      }
+      limit: 1
+    ) {
+      incident_number
+    }
+  }
+`;
 
 const navSearchLocalStorageKey = "navBarSearchField";
 
 /**
+ * Types that can be used in the search field config
+ */
+type SearchableTypes = Crash | Location | EMSPatientCareRecord;
+
+/**
+ * The serach field config
+ */
+type SearchField<T extends SearchableTypes = SearchableTypes> = {
+  key: string;
+  label: string | React.ReactNode;
+  query: string;
+  getUrl: (record: T) => string;
+};
+
+/**
+ * This union lets us pass Search<some-type> around in state and handlers
+ */
+type AnySearchField =
+  | SearchField<Crash>
+  | SearchField<Location>
+  | SearchField<EMSPatientCareRecord>;
+
+const SEARCH_FIELDS = [
+  {
+    key: "case_id",
+    label: (
+      <AlignedLabel>
+        <FaCarBurst className="me-2" />
+        <span>Case ID</span>
+      </AlignedLabel>
+    ),
+    query: CASE_SEARCH,
+    getUrl: (record: Crash) => `/crashes/${record.case_id}`,
+  },
+  {
+    key: "record_locator",
+    label: (
+      <AlignedLabel>
+        <FaCarBurst className="me-2" />
+        <span>Crash ID</span>
+      </AlignedLabel>
+    ),
+    query: CRASH_SEARCH,
+    getUrl: (record: Crash) => `/crashes/${record.record_locator}`,
+  },
+  {
+    key: "incident_number",
+    label: (
+      <AlignedLabel>
+        <LuAmbulance className="me-2" />
+        <span>EMS Incident #</span>
+      </AlignedLabel>
+    ),
+    query: EMS_INCIDENT_SEARCH,
+    getUrl: (record: EMSPatientCareRecord) => `/ems/${record.incident_number}`,
+  },
+  {
+    key: "location_id",
+    label: (
+      <AlignedLabel>
+        <LuMapPin className="me-2" />
+        <span>Location ID</span>
+      </AlignedLabel>
+    ),
+    query: LOCATION_SEARCH,
+    getUrl: (record: Location) => `/locations/${record.location_id}`,
+  },
+] satisfies AnySearchField[];
+
+const getValidSearchField = (val: string | null): AnySearchField => {
+  if (!val) {
+    return SEARCH_FIELDS[0];
+  }
+  const foundSearchField = SEARCH_FIELDS.find(
+    (searchField) => searchField.key === val
+  );
+  return foundSearchField || SEARCH_FIELDS[0];
+};
+
+/**e
  * Allows users to search for and route to a crash by
  * typing in its crash id or case id
  */
 export default function NavBarSearch() {
-  const [searchField, setSearchField] = useState<"case_id" | "record_locator">(
-    localStorage.getItem(navSearchLocalStorageKey) === "record_locator"
-      ? "record_locator"
-      : "case_id"
+  const stored = localStorage.getItem(navSearchLocalStorageKey);
+  const [searchField, setSearchField] = useState<AnySearchField>(
+    getValidSearchField(stored)
   );
   const [searchValue, setSearchValue] = useState("");
   const [searchClicked, setSearchClicked] = useState(false);
 
   const router = useRouter();
 
-  const { data, isLoading } = useQuery<Crash>({
-    // only will fetch data once search button has been clicked
-    query: searchClicked ? CRASH_NAV_SEARCH : null,
-    variables: { searchValue: searchValue },
-    typename: searchField,
-    // override default config so second search wont navigate to previous crash
-    options: {
-      keepPreviousData: false,
-    },
+  const { data, isLoading } = useQuery<SearchableTypes>({
+    query: searchClicked ? searchField.query : null,
+    variables: { searchValue },
+    typename: searchField.key,
+    options: { keepPreviousData: false },
   });
 
-  // if data has been fetched or search button clicked check if data is valid
-  // and route to page
   useEffect(() => {
-    if (searchClicked) {
-      if (data?.length === 1) {
-        const recordLocator = data?.[0].record_locator;
-        router.push(`/crashes/${recordLocator}`);
-        setSearchValue("");
-        setSearchClicked(false);
-      }
+    if (searchClicked && data?.length === 1) {
+      // we pass our to get URL as an any, because we know that getUrl
+      // the query are from the same type
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      router.push(searchField.getUrl(data[0] as any));
+      setSearchValue("");
+      setSearchClicked(false);
     }
-  }, [searchClicked, data, router]);
+  }, [searchClicked, data, router, searchField]);
 
   useEffect(() => {
-    localStorage.setItem(navSearchLocalStorageKey, searchField);
+    localStorage.setItem(navSearchLocalStorageKey, searchField.key);
   }, [searchField]);
 
-  const onSearch = (e: React.FormEvent<HTMLFormElement>) => {
+  const onSearch = (e: React.ChangeEvent<HTMLFormElement>) => {
     e.preventDefault();
     setSearchClicked(true);
   };
 
-  const onSwitchSearchField = () => {
-    setSearchField(
-      searchField === "record_locator" ? "case_id" : "record_locator"
-    );
+  const onSelectSearchField = (field: AnySearchField) => {
+    setSearchField(field);
+    setSearchClicked(false);
   };
 
-  // if length is zero that means data was fetched and returned nothing
   const isSearchInvalid = data?.length === 0;
-
-  const searchError =
-    searchField === "case_id" ? "Case ID not found" : "Crash ID not found";
+  const searchError = `${searchField.label} not found`;
 
   return (
     <Form onSubmit={onSearch}>
       <Form.Group className="me-4">
         <InputGroup hasValidation>
-          <Button onClick={onSwitchSearchField} size="sm">
-            {searchField === "record_locator" ? "Crash ID" : "Case ID"}
-          </Button>
+          <Dropdown as={InputGroup.Text} className="p-0">
+            <Dropdown.Toggle
+              as={DropdownButtonToggle}
+              id="nav-search-field-toggle"
+              className="input-group-text"
+            >
+              <AlignedLabel>
+                <span className="me-2">{searchField.label}</span>
+                <LuChevronDown />
+              </AlignedLabel>
+            </Dropdown.Toggle>
+            <Dropdown.Menu>
+              {SEARCH_FIELDS.map((searchFieldOption) => (
+                <Dropdown.Item
+                  key={searchFieldOption.key}
+                  active={searchFieldOption.key === searchField.key}
+                  className={
+                    searchFieldOption.key === searchField.key
+                      ? "text-white"
+                      : "text-primary"
+                  }
+                  onClick={() => onSelectSearchField(searchFieldOption)}
+                >
+                  {searchFieldOption.label}
+                </Dropdown.Item>
+              ))}
+            </Dropdown.Menu>
+          </Dropdown>
           <Form.Control
             size="sm"
             placeholder="Search..."

--- a/editor/components/NavBarSearch.tsx
+++ b/editor/components/NavBarSearch.tsx
@@ -6,64 +6,16 @@ import Dropdown from "react-bootstrap/Dropdown";
 import Form from "react-bootstrap/Form";
 import InputGroup from "react-bootstrap/InputGroup";
 import { FaCarBurst, FaMagnifyingGlass } from "react-icons/fa6";
-import { CRASH_NAV_SEARCH } from "@/queries/crash";
-import { Crash } from "@/types/crashes";
-import { Location } from "@/types/locations";
-import { useQuery } from "@/utils/graphql";
+import { LuAmbulance, LuChevronDown, LuMapPin } from "react-icons/lu";
 import DropdownButtonToggle from "@/components/DropdownButtonToggle";
 import AlignedLabel from "@/components/AlignedLabel";
-import { LuAmbulance, LuChevronDown, LuMapPin } from "react-icons/lu";
+import { CRASH_NAV_SEARCH, CASE_NAV_SEARCH } from "@/queries/crash";
+import { LOCATION_NAV_SEARCH } from "@/queries/location";
+import { EMS_INCIDENT_NAV_SEARCH } from "@/queries/ems";
+import { Crash } from "@/types/crashes";
 import { EMSPatientCareRecord } from "@/types/ems";
-import { gql } from "graphql-request";
-
-const CRASH_SEARCH = gql`
-  query CrashNavigationSearch($searchValue: String!) {
-    record_locator: crashes(
-      where: {
-        record_locator: { _eq: $searchValue }
-        is_deleted: { _eq: false }
-      }
-    ) {
-      id
-      record_locator
-    }
-  }
-`;
-
-const CASE_SEARCH = gql`
-  query CrashNavigationSearch($searchValue: String!) {
-    case_id: crashes(
-      where: { case_id: { _eq: $searchValue }, is_deleted: { _eq: false } }
-    ) {
-      id
-      record_locator
-    }
-  }
-`;
-
-const LOCATION_SEARCH = gql`
-  query LocationNavigationSearch($searchValue: String!) {
-    location_id: locations(
-      where: { location_id: { _eq: $searchValue }, is_deleted: { _eq: false } }
-    ) {
-      location_id
-    }
-  }
-`;
-
-const EMS_INCIDENT_SEARCH = gql`
-  query EMSNavigationSearch($searchValue: String!) {
-    incident_number: ems__incidents(
-      where: {
-        incident_number: { _eq: $searchValue }
-        is_deleted: { _eq: false }
-      }
-      limit: 1
-    ) {
-      incident_number
-    }
-  }
-`;
+import { Location } from "@/types/locations";
+import { useQuery } from "@/utils/graphql";
 
 const navSearchLocalStorageKey = "navBarSearchField";
 
@@ -99,7 +51,7 @@ const SEARCH_FIELDS = [
         <span>Case ID</span>
       </AlignedLabel>
     ),
-    query: CASE_SEARCH,
+    query: CASE_NAV_SEARCH,
     getUrl: (record: Crash) => `/crashes/${record.case_id}`,
   },
   {
@@ -110,7 +62,7 @@ const SEARCH_FIELDS = [
         <span>Crash ID</span>
       </AlignedLabel>
     ),
-    query: CRASH_SEARCH,
+    query: CRASH_NAV_SEARCH,
     getUrl: (record: Crash) => `/crashes/${record.record_locator}`,
   },
   {
@@ -121,7 +73,7 @@ const SEARCH_FIELDS = [
         <span>EMS Incident #</span>
       </AlignedLabel>
     ),
-    query: EMS_INCIDENT_SEARCH,
+    query: EMS_INCIDENT_NAV_SEARCH,
     getUrl: (record: EMSPatientCareRecord) => `/ems/${record.incident_number}`,
   },
   {
@@ -132,7 +84,7 @@ const SEARCH_FIELDS = [
         <span>Location ID</span>
       </AlignedLabel>
     ),
-    query: LOCATION_SEARCH,
+    query: LOCATION_NAV_SEARCH,
     getUrl: (record: Location) => `/locations/${record.location_id}`,
   },
 ] satisfies AnySearchField[];

--- a/editor/components/NavBarSearch.tsx
+++ b/editor/components/NavBarSearch.tsx
@@ -27,7 +27,7 @@ const userEventName = "navbar_search";
 type SearchableTypes = Crash | Location | EMSPatientCareRecord;
 
 /**
- * The serach field config
+ * The search field config
  */
 type SearchField<T extends SearchableTypes = SearchableTypes> = {
   key: string;
@@ -73,7 +73,7 @@ const SEARCH_FIELDS = [
 
 /**
  * Find a search field config from an input key - it's a safe way to handle an
- * abritrary key string from local storage
+ * arbitrary key string from local storage
  * @param val
  * @returns
  */
@@ -87,9 +87,9 @@ const getValidSearchField = (key: string | null): AnySearchField => {
   return foundSearchField || SEARCH_FIELDS[0];
 };
 
-/**e
- * Allows users to search for and route to a crash by
- * typing in its crash id or case id
+/**
+ * Allows users to search for and route to various record types
+ * by typing in an ID
  */
 export default function NavBarSearch() {
   const [searchField, setSearchField] = useState<AnySearchField>(
@@ -111,8 +111,7 @@ export default function NavBarSearch() {
   useEffect(() => {
     if (searchClicked && data?.length === 1) {
       // we are casting our matchedRecord to bypass TS headaches. we have to
-      // trust that are queries are returning the objects we think they are
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      // trust that our queries are returning the objects we think they are
       const matchedRecord = data[0] as Crash & Location & EMSPatientCareRecord;
       const route = searchField.getUrl(matchedRecord);
       router.push(route);

--- a/editor/components/NavBarSearch.tsx
+++ b/editor/components/NavBarSearch.tsx
@@ -5,8 +5,7 @@ import Button from "react-bootstrap/Button";
 import Dropdown from "react-bootstrap/Dropdown";
 import Form from "react-bootstrap/Form";
 import InputGroup from "react-bootstrap/InputGroup";
-import { FaCarBurst, FaMagnifyingGlass } from "react-icons/fa6";
-import { LuAmbulance, LuChevronDown, LuMapPin } from "react-icons/lu";
+import { LuChevronDown, LuSearch } from "react-icons/lu";
 import DropdownButtonToggle from "@/components/DropdownButtonToggle";
 import AlignedLabel from "@/components/AlignedLabel";
 import { CRASH_NAV_SEARCH, CASE_NAV_SEARCH } from "@/queries/crash";
@@ -29,7 +28,7 @@ type SearchableTypes = Crash | Location | EMSPatientCareRecord;
  */
 type SearchField<T extends SearchableTypes = SearchableTypes> = {
   key: string;
-  label: string | React.ReactNode;
+  label: string;
   query: string;
   getUrl: (record: T) => string;
 };
@@ -45,56 +44,42 @@ type AnySearchField =
 const SEARCH_FIELDS = [
   {
     key: "case_id",
-    label: (
-      <AlignedLabel>
-        <FaCarBurst className="me-2" />
-        <span>Case ID</span>
-      </AlignedLabel>
-    ),
+    label: "Case ID",
     query: CASE_NAV_SEARCH,
-    getUrl: (record: Crash) => `/crashes/${record.case_id}`,
+    getUrl: (record: Crash) => `/crashes/${record.record_locator}`,
   },
   {
     key: "record_locator",
-    label: (
-      <AlignedLabel>
-        <FaCarBurst className="me-2" />
-        <span>Crash ID</span>
-      </AlignedLabel>
-    ),
+    label: "Crash ID",
     query: CRASH_NAV_SEARCH,
     getUrl: (record: Crash) => `/crashes/${record.record_locator}`,
   },
   {
     key: "incident_number",
-    label: (
-      <AlignedLabel>
-        <LuAmbulance className="me-2" />
-        <span>EMS Incident #</span>
-      </AlignedLabel>
-    ),
+    label: "EMS Incident #",
     query: EMS_INCIDENT_NAV_SEARCH,
     getUrl: (record: EMSPatientCareRecord) => `/ems/${record.incident_number}`,
   },
   {
     key: "location_id",
-    label: (
-      <AlignedLabel>
-        <LuMapPin className="me-2" />
-        <span>Location ID</span>
-      </AlignedLabel>
-    ),
+    label: "Location ID",
     query: LOCATION_NAV_SEARCH,
     getUrl: (record: Location) => `/locations/${record.location_id}`,
   },
 ] satisfies AnySearchField[];
 
-const getValidSearchField = (val: string | null): AnySearchField => {
-  if (!val) {
+/**
+ * Find a search field config from an input key - it's a safe way to handle an
+ * abritrary key string from local storage
+ * @param val
+ * @returns
+ */
+const getValidSearchField = (key: string | null): AnySearchField => {
+  if (!key) {
     return SEARCH_FIELDS[0];
   }
   const foundSearchField = SEARCH_FIELDS.find(
-    (searchField) => searchField.key === val
+    (searchField) => searchField.key === key
   );
   return foundSearchField || SEARCH_FIELDS[0];
 };
@@ -104,9 +89,8 @@ const getValidSearchField = (val: string | null): AnySearchField => {
  * typing in its crash id or case id
  */
 export default function NavBarSearch() {
-  const stored = localStorage.getItem(navSearchLocalStorageKey);
   const [searchField, setSearchField] = useState<AnySearchField>(
-    getValidSearchField(stored)
+    getValidSearchField(null)
   );
   const [searchValue, setSearchValue] = useState("");
   const [searchClicked, setSearchClicked] = useState(false);
@@ -122,15 +106,32 @@ export default function NavBarSearch() {
 
   useEffect(() => {
     if (searchClicked && data?.length === 1) {
-      // we pass our to get URL as an any, because we know that getUrl
-      // the query are from the same type
+      // we are casting our matchedRecord to bypass TS headaches. we have to
+      // trust that are queries are returning the objects we think they are
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      router.push(searchField.getUrl(data[0] as any));
+      const matchedRecord = data[0] as Crash & Location & EMSPatientCareRecord;
+      const route = searchField.getUrl(matchedRecord);
+      router.push(route);
       setSearchValue("");
       setSearchClicked(false);
     }
   }, [searchClicked, data, router, searchField]);
 
+  /**
+   * On init, check local storage for search key and use it
+   */
+  useEffect(() => {
+    const searchKeyFromLocalStorage = localStorage.getItem(
+      navSearchLocalStorageKey
+    );
+    if (searchKeyFromLocalStorage) {
+      setSearchField(getValidSearchField(searchKeyFromLocalStorage));
+    }
+  }, []);
+
+  /**
+   * Keep the selected search field key in sync w/ local storage
+   */
   useEffect(() => {
     localStorage.setItem(navSearchLocalStorageKey, searchField.key);
   }, [searchField]);
@@ -195,7 +196,7 @@ export default function NavBarSearch() {
             {searchError}
           </Form.Control.Feedback>
           <Button type="submit" size="sm" disabled={!searchValue}>
-            {!isLoading ? <FaMagnifyingGlass /> : <Spinner size="sm" />}
+            {!isLoading ? <LuSearch className="fs-5" /> : <Spinner size="sm" />}
           </Button>
         </InputGroup>
       </Form.Group>

--- a/editor/queries/crash.ts
+++ b/editor/queries/crash.ts
@@ -315,6 +315,9 @@ export const GET_CRASH = gql`
   }
 `;
 
+/**
+ * Record locator search used by the navbar search component
+ */
 export const CRASH_NAV_SEARCH = gql`
   query CrashNavigationSearch($searchValue: String!) {
     record_locator: crashes(
@@ -326,6 +329,14 @@ export const CRASH_NAV_SEARCH = gql`
       id
       record_locator
     }
+  }
+`;
+
+/**
+ * Case ID search used by the navbar search component
+ */
+export const CASE_NAV_SEARCH = gql`
+  query CrashNavigationSearch($searchValue: String!) {
     case_id: crashes(
       where: { case_id: { _eq: $searchValue }, is_deleted: { _eq: false } }
     ) {

--- a/editor/queries/ems.ts
+++ b/editor/queries/ems.ts
@@ -191,3 +191,20 @@ export const UPDATE_EMS_PCR = gql`
     }
   }
 `;
+
+/**
+ * Incident # search used by the navbar search component
+ */
+export const EMS_INCIDENT_NAV_SEARCH = gql`
+  query EMSNavigationSearch($searchValue: String!) {
+    incident_number: ems__incidents(
+      where: {
+        incident_number: { _eq: $searchValue }
+        is_deleted: { _eq: false }
+      }
+      limit: 1
+    ) {
+      incident_number
+    }
+  }
+`;

--- a/editor/queries/location.ts
+++ b/editor/queries/location.ts
@@ -34,3 +34,16 @@ export const GET_LOCATION = gql`
     }
   }
 `;
+
+/**
+ * Location ID search used by the navbar search component
+ */
+export const LOCATION_NAV_SEARCH = gql`
+  query LocationNavigationSearch($searchValue: String!) {
+    location_id: locations(
+      where: { location_id: { _eq: $searchValue }, is_deleted: { _eq: false } }
+    ) {
+      location_id
+    }
+  }
+`;


### PR DESCRIPTION
## Associated issues

* https://github.com/cityofaustin/atd-data-tech/issues/27749

Here's a little enhancement that came from me getting tired of pasting location IDs and incident numbers into my browser's address bar.

## Testing

**URL to test:** [Netlify](https://deploy-preview-2014--atd-vze-staging.netlify.app/)

1. Test out the updated nav search by search by crash ID, case ID, location ID, and EMS incident number.
2. Refresh your page and confirm that the search field you previously selected remains set when the page reloads.
3. Connect to the staging DB RR, or local, and observe the user events you've created

```sql
select * from user_events where event_name like 'navbar_search%';
```

---

#### Ship list

- [ ] Check migrations for any conflicts with latest migrations in `main` branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved
