### PR TITLE
Paginate overlapping map pop-ups on table maps

### DIFF
--- a/editor/components/FatalitiesMapPopupContent.tsx
+++ b/editor/components/FatalitiesMapPopupContent.tsx
@@ -10,13 +10,16 @@ export default function FatalitiesMapPopupContent({
   properties,
 }: FatalitiesMapPopupContentProps) {
   return (
-    <div className="h-100 m-1 px-1" style={{ minWidth: "125px" }}>
+    <div className="h-100 m-1 px-1">
       <div className="fw-bold fs-6 pb-2 border-bottom">
         {properties?.address_display}
       </div>
       <div className="d-flex justify-content-between pt-2">
         <span className="fw-bold">Crash ID</span>
-        <Link href={`/fatalities/${properties?.record_locator}`} prefetch={false}>
+        <Link
+          href={`/fatalities/${properties?.record_locator}`}
+          prefetch={false}
+        >
           {properties?.record_locator}
         </Link>
       </div>
@@ -28,9 +31,7 @@ export default function FatalitiesMapPopupContent({
       </div>
       <div className="d-flex justify-content-between">
         <span className="fw-bold">YTD Fatal Crash</span>
-        <span className="text-muted">
-          {properties?.ytd_fatal_crash}
-        </span>
+        <span className="text-muted">{properties?.ytd_fatal_crash}</span>
       </div>
     </div>
   );

--- a/editor/components/LocationsTableMapPopupContent.tsx
+++ b/editor/components/LocationsTableMapPopupContent.tsx
@@ -6,7 +6,7 @@ export default function LocationTableMapPopupContent({
   properties,
 }: TableMapPopupContentProps) {
   return (
-    <div className="h-100 m-1 px-1" style={{ minWidth: "125px" }}>
+    <div className="h-100 m-1 px-1">
       <div className="fw-bold fs-6 pb-2 border-bottom">
         {properties?.address_display}
       </div>

--- a/editor/components/PopupWrapper.tsx
+++ b/editor/components/PopupWrapper.tsx
@@ -1,7 +1,9 @@
 import { useState } from "react";
 import { Popup } from "react-map-gl";
+import { Button } from "react-bootstrap";
 import { TableMapPopupContentProps } from "./TableMapPopupContent";
 import { GeoJsonProperties } from "geojson";
+import { LuSquareArrowLeft, LuSquareArrowRight } from "react-icons/lu";
 
 interface PopupWrapperProps {
   latitude: number;
@@ -19,27 +21,25 @@ export default function PopupWrapper({
   PopupContent,
   onClose,
 }: PopupWrapperProps) {
-  const selectedFeaturesLength = selectedFeatures.length
-  console.log(selectedFeaturesLength)
+  const selectedFeaturesLength = selectedFeatures.length;
+  console.log(selectedFeaturesLength);
   const [activeFeature, setActiveFeature] = useState(0);
 
   const handleNext = () => {
-    if (activeFeature === selectedFeaturesLength -1) {
-      setActiveFeature(0)
+    if (activeFeature === selectedFeaturesLength - 1) {
+      setActiveFeature(0);
+    } else {
+      setActiveFeature(activeFeature + 1);
     }
-    else {
-      setActiveFeature(activeFeature+1)
-    }
-  }
+  };
 
   const handlePrevious = () => {
     if (activeFeature === 0) {
-      setActiveFeature(selectedFeaturesLength-1)
+      setActiveFeature(selectedFeaturesLength - 1);
+    } else {
+      setActiveFeature(activeFeature - 1);
     }
-    else { 
-      setActiveFeature(activeFeature -1)
-    }
-  }
+  };
 
   if (selectedFeaturesLength > 1) {
     return (
@@ -50,9 +50,18 @@ export default function PopupWrapper({
         closeOnClick={false}
         onClose={onClose}
       >
-        <PopupContent properties={selectedFeatures[activeFeature].properties} />
-        <hr></hr>
-        {activeFeature + 1}/{selectedFeaturesLength}
+        <PopupContent properties={selectedFeatures[activeFeature]?.properties} />
+        <div className="d-flex align-items-center">
+          <Button className="border-0" variant="link" onClick={handlePrevious}>
+            <LuSquareArrowLeft className="text-muted" />
+          </Button>{" "}
+          <span>
+            {activeFeature + 1}/{selectedFeaturesLength}
+          </span>
+          <Button className="border-0" variant="link" onClick={handleNext}>
+            <LuSquareArrowRight className="text-muted" />
+          </Button>{" "}
+        </div>
       </Popup>
     );
   }

--- a/editor/components/PopupWrapper.tsx
+++ b/editor/components/PopupWrapper.tsx
@@ -25,21 +25,15 @@ export default function PopupWrapper({
   console.log(selectedFeaturesLength);
   const [activeFeature, setActiveFeature] = useState(0);
 
-  const handleNext = () => {
-    if (activeFeature === selectedFeaturesLength - 1) {
-      setActiveFeature(0);
-    } else {
-      setActiveFeature(activeFeature + 1);
-    }
-  };
+  const handleNext = () =>
+    activeFeature === selectedFeaturesLength - 1
+      ? setActiveFeature(0)
+      : setActiveFeature(activeFeature + 1);
 
-  const handlePrevious = () => {
-    if (activeFeature === 0) {
-      setActiveFeature(selectedFeaturesLength - 1);
-    } else {
-      setActiveFeature(activeFeature - 1);
-    }
-  };
+  const handlePrevious = () =>
+    activeFeature === 0
+      ? setActiveFeature(selectedFeaturesLength - 1)
+      : setActiveFeature(activeFeature - 1);
 
   if (selectedFeaturesLength > 1) {
     return (
@@ -50,8 +44,10 @@ export default function PopupWrapper({
         closeOnClick={false}
         onClose={onClose}
       >
-        <PopupContent properties={selectedFeatures[activeFeature]?.properties} />
-        <div className="d-flex align-items-center">
+        <PopupContent
+          properties={selectedFeatures[activeFeature]?.properties}
+        />
+        <div className="d-flex align-items-center justify-content-between">
           <Button className="border-0" variant="link" onClick={handlePrevious}>
             <LuSquareArrowLeft className="text-muted" />
           </Button>{" "}
@@ -65,6 +61,8 @@ export default function PopupWrapper({
       </Popup>
     );
   }
+
+  /** Only one popup, display with no navigation */
   return (
     <Popup
       latitude={latitude}

--- a/editor/components/PopupWrapper.tsx
+++ b/editor/components/PopupWrapper.tsx
@@ -1,10 +1,10 @@
 import { useEffect, useState } from "react";
 import { Popup } from "react-map-gl";
 import { Button } from "react-bootstrap";
-import { TableMapPopupContentProps } from "./TableMapPopupContent";
 import { GeoJsonProperties } from "geojson";
-import { LuSquareArrowLeft, LuSquareArrowRight } from "react-icons/lu";
-import { COLORS } from "@/utils/constants";
+import { LuArrowLeft, LuArrowRight } from "react-icons/lu";
+import { TableMapPopupContentProps } from "./TableMapPopupContent";
+import AlignedLabel from "@/components/AlignedLabel";
 
 interface PopupWrapperProps {
   latitude: number;
@@ -51,20 +51,30 @@ export default function PopupWrapper({
         properties={selectedFeatures[activeFeatureIndex]?.properties}
       />
       {selectedFeaturesLength > 1 && (
-        <div className="d-flex align-items-center justify-content-between border-top m-2">
+        <div className="d-flex align-items-center justify-content-between border-top pt-2 mx-2">
           <Button
-            className="border-0 px-0"
-            variant="link"
+            size="sm"
+            className="px-0 me-2 px-1"
+            variant="outline-primary"
             onClick={handlePrevious}
           >
-            <LuSquareArrowLeft color={COLORS.primary} />
-          </Button>{" "}
-          <span>
-            {activeFeatureIndex + 1}/{selectedFeaturesLength}
+            <AlignedLabel>
+              <LuArrowLeft className="fs-6" />
+            </AlignedLabel>
+          </Button>
+          <span className="text-primary">
+            {activeFeatureIndex + 1} of {selectedFeaturesLength}
           </span>
-          <Button className="border-0 px-0" variant="link" onClick={handleNext}>
-            <LuSquareArrowRight color={COLORS.primary} />
-          </Button>{" "}
+          <Button
+            size="sm"
+            className=" px-0 px-1"
+            variant="outline-primary"
+            onClick={handleNext}
+          >
+            <AlignedLabel>
+              <LuArrowRight className="fs-6" />
+            </AlignedLabel>
+          </Button>
         </div>
       )}
     </Popup>

--- a/editor/components/PopupWrapper.tsx
+++ b/editor/components/PopupWrapper.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { Popup } from "react-map-gl";
 import { TableMapPopupContentProps } from "./TableMapPopupContent";
 import { GeoJsonProperties } from "geojson";
@@ -14,9 +15,47 @@ export default function PopupWrapper({
   latitude,
   longitude,
   featureProperties,
+  selectedFeatures,
   PopupContent,
   onClose,
 }: PopupWrapperProps) {
+  const selectedFeaturesLength = selectedFeatures.length
+  console.log(selectedFeaturesLength)
+  const [activeFeature, setActiveFeature] = useState(0);
+
+  const handleNext = () => {
+    if (activeFeature === selectedFeaturesLength -1) {
+      setActiveFeature(0)
+    }
+    else {
+      setActiveFeature(activeFeature+1)
+    }
+  }
+
+  const handlePrevious = () => {
+    if (activeFeature === 0) {
+      setActiveFeature(selectedFeaturesLength-1)
+    }
+    else { 
+      setActiveFeature(activeFeature -1)
+    }
+  }
+
+  if (selectedFeaturesLength > 1) {
+    return (
+      <Popup
+        latitude={latitude}
+        longitude={longitude}
+        // The popup won't render after multiple map feature click without this prop being false :/
+        closeOnClick={false}
+        onClose={onClose}
+      >
+        <PopupContent properties={selectedFeatures[activeFeature].properties} />
+        <hr></hr>
+        {activeFeature + 1}/{selectedFeaturesLength}
+      </Popup>
+    );
+  }
   return (
     <Popup
       latitude={latitude}

--- a/editor/components/PopupWrapper.tsx
+++ b/editor/components/PopupWrapper.tsx
@@ -8,7 +8,7 @@ import { LuSquareArrowLeft, LuSquareArrowRight } from "react-icons/lu";
 interface PopupWrapperProps {
   latitude: number;
   longitude: number;
-  featureProperties: GeoJsonProperties;
+  selectedFeatures: GeoJsonProperties[];
   PopupContent: React.ComponentType<TableMapPopupContentProps>;
   onClose: () => void;
 }
@@ -16,12 +16,11 @@ interface PopupWrapperProps {
 export default function PopupWrapper({
   latitude,
   longitude,
-  featureProperties,
   selectedFeatures,
   PopupContent,
   onClose,
 }: PopupWrapperProps) {
-  const selectedFeaturesLength = selectedFeatures.length;
+  const selectedFeaturesLength = selectedFeatures?.length;
   console.log(selectedFeaturesLength);
   const [activeFeature, setActiveFeature] = useState(0);
 
@@ -71,7 +70,7 @@ export default function PopupWrapper({
       closeOnClick={false}
       onClose={onClose}
     >
-      <PopupContent properties={featureProperties} />
+      <PopupContent properties={selectedFeatures[0]?.properties} />
     </Popup>
   );
 }

--- a/editor/components/PopupWrapper.tsx
+++ b/editor/components/PopupWrapper.tsx
@@ -46,15 +46,19 @@ export default function PopupWrapper({
         <PopupContent
           properties={selectedFeatures[activeFeature]?.properties}
         />
-        <div className="d-flex align-items-center justify-content-between">
-          <Button className="border-0" variant="link" onClick={handlePrevious}>
-            <LuSquareArrowLeft className="text-muted" />
+        <div className="d-flex align-items-center justify-content-between border-top m-2">
+          <Button
+            className="border-0 px-0"
+            variant="link"
+            onClick={handlePrevious}
+          >
+            <LuSquareArrowLeft color="#1276d1" />
           </Button>{" "}
           <span>
             {activeFeature + 1}/{selectedFeaturesLength}
           </span>
-          <Button className="border-0" variant="link" onClick={handleNext}>
-            <LuSquareArrowRight className="text-muted" />
+          <Button className="border-0 px-0" variant="link" onClick={handleNext}>
+            <LuSquareArrowRight color="#1276d1" />
           </Button>{" "}
         </div>
       </Popup>

--- a/editor/components/PopupWrapper.tsx
+++ b/editor/components/PopupWrapper.tsx
@@ -46,6 +46,7 @@ export default function PopupWrapper({
       // The popup won't render after multiple map feature click without this prop being false :/
       closeOnClick={false}
       onClose={onClose}
+      style={{ width: "235px" }}
     >
       <PopupContent
         properties={selectedFeatures[activeFeatureIndex]?.properties}

--- a/editor/components/PopupWrapper.tsx
+++ b/editor/components/PopupWrapper.tsx
@@ -1,9 +1,10 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Popup } from "react-map-gl";
 import { Button } from "react-bootstrap";
 import { TableMapPopupContentProps } from "./TableMapPopupContent";
 import { GeoJsonProperties } from "geojson";
 import { LuSquareArrowLeft, LuSquareArrowRight } from "react-icons/lu";
+import { COLORS } from "@/utils/constants";
 
 interface PopupWrapperProps {
   latitude: number;
@@ -21,18 +22,22 @@ export default function PopupWrapper({
   onClose,
 }: PopupWrapperProps) {
   const selectedFeaturesLength = selectedFeatures?.length;
-  console.log(selectedFeaturesLength);
-  const [activeFeature, setActiveFeature] = useState(0);
+  const [activeFeatureIndex, setActiveFeatureIndex] = useState(0);
 
   const handleNext = () =>
-    activeFeature === selectedFeaturesLength - 1
-      ? setActiveFeature(0)
-      : setActiveFeature(activeFeature + 1);
+    activeFeatureIndex === selectedFeaturesLength - 1
+      ? setActiveFeatureIndex(0)
+      : setActiveFeatureIndex(activeFeatureIndex + 1);
 
   const handlePrevious = () =>
-    activeFeature === 0
-      ? setActiveFeature(selectedFeaturesLength - 1)
-      : setActiveFeature(activeFeature - 1);
+    activeFeatureIndex === 0
+      ? setActiveFeatureIndex(selectedFeaturesLength - 1)
+      : setActiveFeatureIndex(activeFeatureIndex - 1);
+
+  // reset popup active feature to first element if viewing new array of popups
+  useEffect(() => {
+    setActiveFeatureIndex(0);
+  }, [selectedFeatures]);
 
   if (selectedFeaturesLength > 1) {
     return (
@@ -44,7 +49,7 @@ export default function PopupWrapper({
         onClose={onClose}
       >
         <PopupContent
-          properties={selectedFeatures[activeFeature]?.properties}
+          properties={selectedFeatures[activeFeatureIndex]?.properties}
         />
         <div className="d-flex align-items-center justify-content-between border-top m-2">
           <Button
@@ -52,13 +57,13 @@ export default function PopupWrapper({
             variant="link"
             onClick={handlePrevious}
           >
-            <LuSquareArrowLeft color="#1276d1" />
+            <LuSquareArrowLeft color={COLORS.primary} />
           </Button>{" "}
           <span>
-            {activeFeature + 1}/{selectedFeaturesLength}
+            {activeFeatureIndex + 1}/{selectedFeaturesLength}
           </span>
           <Button className="border-0 px-0" variant="link" onClick={handleNext}>
-            <LuSquareArrowRight color="#1276d1" />
+            <LuSquareArrowRight color={COLORS.primary} />
           </Button>{" "}
         </div>
       </Popup>

--- a/editor/components/PopupWrapper.tsx
+++ b/editor/components/PopupWrapper.tsx
@@ -39,18 +39,18 @@ export default function PopupWrapper({
     setActiveFeatureIndex(0);
   }, [selectedFeatures]);
 
-  if (selectedFeaturesLength > 1) {
-    return (
-      <Popup
-        latitude={latitude}
-        longitude={longitude}
-        // The popup won't render after multiple map feature click without this prop being false :/
-        closeOnClick={false}
-        onClose={onClose}
-      >
-        <PopupContent
-          properties={selectedFeatures[activeFeatureIndex]?.properties}
-        />
+  return (
+    <Popup
+      latitude={latitude}
+      longitude={longitude}
+      // The popup won't render after multiple map feature click without this prop being false :/
+      closeOnClick={false}
+      onClose={onClose}
+    >
+      <PopupContent
+        properties={selectedFeatures[activeFeatureIndex]?.properties}
+      />
+      {selectedFeaturesLength > 1 && (
         <div className="d-flex align-items-center justify-content-between border-top m-2">
           <Button
             className="border-0 px-0"
@@ -66,20 +66,7 @@ export default function PopupWrapper({
             <LuSquareArrowRight color={COLORS.primary} />
           </Button>{" "}
         </div>
-      </Popup>
-    );
-  }
-
-  /** Only one popup, display with no navigation */
-  return (
-    <Popup
-      latitude={latitude}
-      longitude={longitude}
-      // The popup won't render after multiple map feature click without this prop being false :/
-      closeOnClick={false}
-      onClose={onClose}
-    >
-      <PopupContent properties={selectedFeatures[0]?.properties} />
+      )}
     </Popup>
   );
 }

--- a/editor/components/TableMap.tsx
+++ b/editor/components/TableMap.tsx
@@ -81,10 +81,9 @@ export const TableMap = ({ mapRef, geojson, mapConfig }: TableMapProps) => {
     }
   }, [geojsonBounds, mapRef]);
 
-  const [selectedFeature, setSelectedFeature] = useState<GeoJSONFeature | null>(
-    null
-  );
-  const [selectedFeatures, setSelectedFeatures] = useState<GeoJSONFeature[]|null>(null)
+  const [selectedFeatures, setSelectedFeatures] = useState<
+    GeoJSONFeature[] | null
+  >(null);
   const [cursor, setCursor] = useState("grab");
 
   const onMouseEnter = useCallback(() => {
@@ -117,11 +116,9 @@ export const TableMap = ({ mapRef, geojson, mapConfig }: TableMapProps) => {
       onClick={(e) => {
         e.originalEvent.stopPropagation();
         if (e.features?.length) {
-          setSelectedFeatures(e.features)
-          setSelectedFeature(e.features[0]);
+          setSelectedFeatures(e.features);
         } else {
-          setSelectedFeature(null);
-          setSelectedFeatures(null)
+          setSelectedFeatures(null);
         }
       }}
       // conditionally include props from mapConfig
@@ -143,12 +140,11 @@ export const TableMap = ({ mapRef, geojson, mapConfig }: TableMapProps) => {
       />
       {selectedFeatures && selectedFeatures.length > 0 && (
         <PopupWrapper
-          longitude={selectedFeature?.properties?.longitude}
-          latitude={selectedFeature?.properties?.latitude}
-          // featureProperties={selectedFeature.properties}
+          longitude={selectedFeatures[0]?.properties?.longitude}
+          latitude={selectedFeatures[0]?.properties?.latitude}
           selectedFeatures={selectedFeatures}
           PopupContent={PopupComponent}
-          onClose={() => setSelectedFeature(null)}
+          onClose={() => setSelectedFeatures(null)}
         />
       )}
     </MapGL>

--- a/editor/components/TableMap.tsx
+++ b/editor/components/TableMap.tsx
@@ -141,11 +141,11 @@ export const TableMap = ({ mapRef, geojson, mapConfig }: TableMapProps) => {
         setBasemapType={setBasemapType}
         controlId="tableMap"
       />
-      {selectedFeature && (
+      {selectedFeatures && selectedFeatures.length > 0 && (
         <PopupWrapper
           longitude={selectedFeature?.properties?.longitude}
           latitude={selectedFeature?.properties?.latitude}
-          featureProperties={selectedFeature.properties}
+          // featureProperties={selectedFeature.properties}
           selectedFeatures={selectedFeatures}
           PopupContent={PopupComponent}
           onClose={() => setSelectedFeature(null)}

--- a/editor/components/TableMap.tsx
+++ b/editor/components/TableMap.tsx
@@ -84,6 +84,7 @@ export const TableMap = ({ mapRef, geojson, mapConfig }: TableMapProps) => {
   const [selectedFeature, setSelectedFeature] = useState<GeoJSONFeature | null>(
     null
   );
+  const [selectedFeatures, setSelectedFeatures] = useState<GeoJSONFeature[]|null>(null)
   const [cursor, setCursor] = useState("grab");
 
   const onMouseEnter = useCallback(() => {
@@ -116,9 +117,11 @@ export const TableMap = ({ mapRef, geojson, mapConfig }: TableMapProps) => {
       onClick={(e) => {
         e.originalEvent.stopPropagation();
         if (e.features?.length) {
+          setSelectedFeatures(e.features)
           setSelectedFeature(e.features[0]);
         } else {
           setSelectedFeature(null);
+          setSelectedFeatures(null)
         }
       }}
       // conditionally include props from mapConfig
@@ -143,6 +146,7 @@ export const TableMap = ({ mapRef, geojson, mapConfig }: TableMapProps) => {
           longitude={selectedFeature?.properties?.longitude}
           latitude={selectedFeature?.properties?.latitude}
           featureProperties={selectedFeature.properties}
+          selectedFeatures={selectedFeatures}
           PopupContent={PopupComponent}
           onClose={() => setSelectedFeature(null)}
         />

--- a/editor/components/TableMapPopupContent.tsx
+++ b/editor/components/TableMapPopupContent.tsx
@@ -10,7 +10,7 @@ export default function TableMapPopupContent({
   properties,
 }: TableMapPopupContentProps) {
   return (
-    <div className="h-100 m-1 px-1" style={{ minWidth: "125px" }}>
+    <div className="h-100 m-1 px-1">
       <div className="fw-bold fs-6 pb-2 border-bottom">
         {properties?.address_display}
       </div>


### PR DESCRIPTION
## Associated issues

https://github.com/cityofaustin/atd-data-tech/issues/26697

mapbox sends multiple features on click, i did not dig into how big of a radius the click encompasses. We choose the first feature in production now, this PR uses the entire array of features in the popups. 

## Testing

**URL to test:** <!-- VZ URL or Netlify -->
https://deploy-preview-2015--atd-vze-staging.netlify.app/editor/crashes


**Steps to test:**

Toggle map view, and select past 5 years as a filter (this helps get overlapping points). Zooming out also helps. 

Click an area with overlapping markers. Use the left and right arrow buttons to cycle through the popups. 
Find a marker without others nearby (you may need to zoom in). Check that the popup for one crash works as before. 

Repeat the tests on the ems listing map and the fatalities map. 

<img width="657" height="461" alt="Screenshot 2026-04-13 at 10 41 58 AM" src="https://github.com/user-attachments/assets/0498536d-d66e-4700-938e-ebdbb3bf1864" />

---

#### Ship list

- [ ] Check migrations for any conflicts with latest migrations in `main` branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved
