### PR TITLE
Add temp crash banner to fatality details page

### DIFF
--- a/editor/app/fatalities/[record_locator]/page.tsx
+++ b/editor/app/fatalities/[record_locator]/page.tsx
@@ -76,12 +76,6 @@ export default function FatalCrashDetailsPage({
 
   return (
     <>
-      {
-        // show alert if crash is a temp record, hide delete button on fatalities pages
-        crash.is_temp_record && (
-          <CrashIsTemporaryBanner crash={crash} allowDelete={false} />
-        )
-      }
       <Row>
         <div className="d-flex justify-content-between align-items-center mb-3">
           <span className="fs-3 fw-bold text-uppercase">
@@ -99,6 +93,12 @@ export default function FatalCrashDetailsPage({
           </span>
         </div>
       </Row>
+      {
+        // show alert if crash is a temp record, hide delete button on fatalities pages
+        crash.is_temp_record && (
+          <CrashIsTemporaryBanner crash={crash} allowDelete={false} />
+        )
+      }
       <Row>
         <Col className="mb-3" sm={12} md={6}>
           <Card className="h-100">

--- a/editor/app/fatalities/[record_locator]/page.tsx
+++ b/editor/app/fatalities/[record_locator]/page.tsx
@@ -20,6 +20,7 @@ import { crashesColumns } from "@/configs/crashesColumns";
 import CrashRecommendationCard from "@/components/CrashRecommendationCard";
 import NotesCard from "@/components/NotesCard";
 import { INSERT_CRASH_NOTE, UPDATE_CRASH_NOTE } from "@/queries/crashNotes";
+import CrashIsTemporaryBanner from "@/components/CrashIsTemporaryBanner";
 
 const otherCardColumns = [
   crashesColumns.case_id,
@@ -75,6 +76,12 @@ export default function FatalCrashDetailsPage({
 
   return (
     <>
+      {
+        // show alert if crash is a temp record, hide delete button on fatalities pages
+        crash.is_temp_record && (
+          <CrashIsTemporaryBanner crash={crash} allowDelete={false} />
+        )
+      }
       <Row>
         <div className="d-flex justify-content-between align-items-center mb-3">
           <span className="fs-3 fw-bold text-uppercase">

--- a/editor/components/CrashIsTemporaryBanner.tsx
+++ b/editor/components/CrashIsTemporaryBanner.tsx
@@ -32,9 +32,8 @@ export default function CrashIsTemporaryBanner({
         <span className="d-flex align-items-center">
           <FaTriangleExclamation className="me-2 d-none d-lg-inline" />
           <span className="me-3">
-            This crash record was created by the Vision Zero team and serves as a
-            placeholder until the CR3 report is received from TxDOT. It may be
-            deleted at any time.
+            This preliminary crash record was created by the Vision Zero team and serves as a
+            placeholder until the official crash report is received from TxDOT — it may be modifed or removed at any time.
           </span>
         </span>
         <PermissionsRequired allowedRoles={allowedDeleteCrashRecordEditRoles}>

--- a/editor/components/CrashIsTemporaryBanner.tsx
+++ b/editor/components/CrashIsTemporaryBanner.tsx
@@ -36,7 +36,7 @@ export default function CrashIsTemporaryBanner({
           <span className="me-3">
             This preliminary crash record was created by the Vision Zero team
             and serves as a placeholder until the official crash report is
-            received from TxDOT — it may be modifed or removed at any time.
+            received from TxDOT.
           </span>
         </span>
         {allowDelete && (

--- a/editor/components/CrashIsTemporaryBanner.tsx
+++ b/editor/components/CrashIsTemporaryBanner.tsx
@@ -11,6 +11,7 @@ const allowedDeleteCrashRecordEditRoles = ["vz-admin", "editor"];
 
 interface CrashIsTemporaryBannerProps {
   crash: Crash;
+  allowDelete?: boolean;
 }
 
 /**
@@ -20,6 +21,7 @@ interface CrashIsTemporaryBannerProps {
  */
 export default function CrashIsTemporaryBanner({
   crash,
+  allowDelete = true,
 }: CrashIsTemporaryBannerProps) {
   const [showDeleteModal, setShowDeleteModal] = useState(false);
 
@@ -32,23 +34,23 @@ export default function CrashIsTemporaryBanner({
         <span className="d-flex align-items-center">
           <FaTriangleExclamation className="me-2 d-none d-lg-inline" />
           <span className="me-3">
-            This preliminary crash record was created by the Vision Zero team and serves as a
-            placeholder until the official crash report is received from TxDOT — it may be modifed or removed at any time.
+            This preliminary crash record was created by the Vision Zero team
+            and serves as a placeholder until the official crash report is
+            received from TxDOT — it may be modifed or removed at any time.
           </span>
         </span>
-        <PermissionsRequired allowedRoles={allowedDeleteCrashRecordEditRoles}>
-          <span>
-            <Button
-              variant="danger"
-              onClick={() => setShowDeleteModal(true)}
-            >
-              <AlignedLabel>
-                <FaTrash className="me-2" />
-                <span>Delete</span>
-              </AlignedLabel>
-            </Button>
-          </span>
-        </PermissionsRequired>
+        {allowDelete && (
+          <PermissionsRequired allowedRoles={allowedDeleteCrashRecordEditRoles}>
+            <span>
+              <Button variant="danger" onClick={() => setShowDeleteModal(true)}>
+                <AlignedLabel>
+                  <FaTrash className="me-2" />
+                  <span>Delete</span>
+                </AlignedLabel>
+              </Button>
+            </span>
+          </PermissionsRequired>
+        )}
       </Alert>
       {showDeleteModal && (
         <DeleteTemporaryCrashModal


### PR DESCRIPTION
## Associated issues

https://github.com/cityofaustin/atd-data-tech/issues/27786

## Testing

**URL to test:** <!-- VZ URL or Netlify -->

https://deploy-preview-2018--atd-vze-staging.netlify.app/editor/fatalities/T1371165

**Steps to test:**

Visit a fatalities page for a temporary crash, there is now a banner alerting the user that the crash is temporary and may be modified or removed at any time.
Click the crash ID to navigate to that temporary crash's details page, the same banner is present except now also has a delete button. 

---

#### Ship list

- [ ] Check migrations for any conflicts with latest migrations in `main` branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved
