### PR TITLE
Ensure the EMS popup shows all fields regardless of column visibility settings

### DIFF
--- a/editor/configs/crashesListViewColumns.tsx
+++ b/editor/configs/crashesListViewColumns.tsx
@@ -8,6 +8,7 @@ export const crashesListViewColumns: ColDataCardDef<CrashesListRow>[] = [
     path: "record_locator",
     label: "Crash ID",
     sortable: true,
+    fetchAlways: true,
     valueRenderer: (record: CrashesListRow) => (
       <Link href={`/crashes/${record.record_locator}`} prefetch={false}>
         {record.record_locator}

--- a/editor/configs/emsColumns.tsx
+++ b/editor/configs/emsColumns.tsx
@@ -154,6 +154,7 @@ export const ALL_EMS_COLUMNS = {
   cris_crash_id: {
     path: "crash.cris_crash_id",
     label: "Crash ID",
+    fetchAlways: true,
     relationship: {
       tableSchema: "public",
       tableName: "crashes",
@@ -181,6 +182,7 @@ export const ALL_EMS_COLUMNS = {
     path: "incident_location_address",
     label: "Incident address",
     sortable: true,
+    fetchAlways: true,
   },
   incident_number: {
     path: "incident_number",
@@ -204,6 +206,7 @@ export const ALL_EMS_COLUMNS = {
     style: { whiteSpace: "nowrap" },
     valueFormatter: formatIsoDateTime,
     sortable: true,
+    fetchAlways: true,
   },
   incident_received_datetime: {
     path: "incident_received_datetime",
@@ -238,11 +241,15 @@ export const ALL_EMS_COLUMNS = {
   },
   latitude: {
     path: "latitude",
-    label: "Latitude"
+    label: "Latitude",
+    fetchAlways: true,
+    exportOnly: true,
   },
   longitude: {
     path: "longitude",
-    label: "Longitude"
+    label: "Longitude",
+    fetchAlways: true,
+    exportOnly: true,
   },
   mvc_form_position_in_vehicle: {
     path: "mvc_form_position_in_vehicle",

--- a/editor/configs/emsColumns.tsx
+++ b/editor/configs/emsColumns.tsx
@@ -154,7 +154,6 @@ export const ALL_EMS_COLUMNS = {
   cris_crash_id: {
     path: "crash.cris_crash_id",
     label: "Crash ID",
-    fetchAlways: true,
     relationship: {
       tableSchema: "public",
       tableName: "crashes",
@@ -188,6 +187,7 @@ export const ALL_EMS_COLUMNS = {
     path: "incident_number",
     label: "Incident",
     sortable: true,
+    fetchAlways: true,
     valueRenderer: (record: EMSPatientCareRecord) => (
       <Link href={`/ems/${record.incident_number}`} prefetch={false}>
         <span style={{ whiteSpace: "nowrap" }}>{record.incident_number}</span>

--- a/editor/configs/emsColumns.tsx
+++ b/editor/configs/emsColumns.tsx
@@ -206,7 +206,6 @@ export const ALL_EMS_COLUMNS = {
     style: { whiteSpace: "nowrap" },
     valueFormatter: formatIsoDateTime,
     sortable: true,
-    fetchAlways: true,
   },
   incident_received_datetime: {
     path: "incident_received_datetime",
@@ -214,6 +213,7 @@ export const ALL_EMS_COLUMNS = {
     style: { whiteSpace: "nowrap" },
     valueFormatter: formatDate,
     sortable: true,
+    fetchAlways: true,
   },
   person_id: {
     path: "person_id",

--- a/editor/configs/emsListViewTable.ts
+++ b/editor/configs/emsListViewTable.ts
@@ -1,6 +1,5 @@
 import { getYearsAgoDate, makeDateFilters } from "@/utils/dates";
 import { QueryConfig, FilterGroup } from "@/types/queryBuilder";
-import { DEFAULT_QUERY_LIMIT } from "@/utils/constants";
 
 const emsListViewFilterCards: FilterGroup[] = [
   {

--- a/editor/configs/emsListViewTable.ts
+++ b/editor/configs/emsListViewTable.ts
@@ -440,7 +440,7 @@ export const emsListViewQueryConfig: QueryConfig = {
   exportable: true,
   exportFilename: "ems_patient_care_records",
   tableName: "ems__incidents",
-  limit: DEFAULT_QUERY_LIMIT,
+  limit: 1000,
   offset: 0,
   sortColName: "id",
   sortAsc: false,

--- a/editor/configs/fatalitiesListViewColumns.tsx
+++ b/editor/configs/fatalitiesListViewColumns.tsx
@@ -13,6 +13,7 @@ export const fatalitiesListViewColumns: ColDataCardDef<fatalitiesListRow>[] = [
     path: "record_locator",
     label: "Crash ID",
     sortable: true,
+    fetchAlways: true,
     valueRenderer: (record: fatalitiesListRow) => (
       <Link href={`/fatalities/${record.record_locator}`} prefetch={false}>
         {record.record_locator}
@@ -28,6 +29,7 @@ export const fatalitiesListViewColumns: ColDataCardDef<fatalitiesListRow>[] = [
     path: "ytd_fatal_crash",
     label: "YTD Fatal Crash",
     sortable: true,
+    fetchAlways: true,
   },
   {
     path: "ytd_fatality",
@@ -43,6 +45,7 @@ export const fatalitiesListViewColumns: ColDataCardDef<fatalitiesListRow>[] = [
     path: "crash_date_ct",
     label: "Crash Date",
     sortable: true,
+    fetchAlways: true,
     valueFormatter: formatDate,
     style: { whiteSpace: "nowrap" },
   },

--- a/editor/configs/fatalitiesListViewTable.ts
+++ b/editor/configs/fatalitiesListViewTable.ts
@@ -1,6 +1,5 @@
 import { getYearsAgoDate, makeDateFilters } from "@/utils/dates";
 import { QueryConfig, FilterGroup } from "@/types/queryBuilder";
-import { DEFAULT_QUERY_LIMIT } from "@/utils/constants";
 
 const fatalitiesListViewFilterCards: FilterGroup[] = [
   {
@@ -264,7 +263,7 @@ export const fatalitiesListViewQueryConfig: QueryConfig = {
   exportable: true,
   exportFilename: "fatalities",
   tableName: "fatalities_view",
-  limit: DEFAULT_QUERY_LIMIT,
+  limit: 1000,
   offset: 0,
   sortColName: "cris_crash_id",
   sortAsc: false,

--- a/editor/configs/locationCrashesColumns.tsx
+++ b/editor/configs/locationCrashesColumns.tsx
@@ -8,11 +8,13 @@ export const locationCrashesColumns: ColDataCardDef<LocationCrashRow>[] = [
     path: "type",
     label: "Type",
     sortable: true,
+    fetchAlways: true,
   },
   {
     path: "record_locator",
     label: "Crash ID",
     sortable: true,
+    fetchAlways: true,
     valueRenderer: (record: LocationCrashRow) =>
       record.record_locator ? (
         <Link href={`/crashes/${record.record_locator}`}>
@@ -26,17 +28,20 @@ export const locationCrashesColumns: ColDataCardDef<LocationCrashRow>[] = [
     path: "case_id",
     label: "Case ID",
     sortable: true,
+    fetchAlways: true,
   },
   {
     path: "crash_timestamp",
     label: "Date",
     sortable: true,
     valueFormatter: formatDate,
+    fetchAlways: true,
   },
   {
     path: "address_display",
     label: "Address",
     sortable: true,
+    fetchAlways: true,
   },
   {
     path: "sus_serious_injry_count",

--- a/editor/configs/locationCrashesTable.ts
+++ b/editor/configs/locationCrashesTable.ts
@@ -1,5 +1,4 @@
 import { QueryConfig, FilterGroup } from "@/types/queryBuilder";
-import { DEFAULT_QUERY_LIMIT } from "@/utils/constants";
 import { getYearsAgoDate, makeDateFilters } from "@/utils/dates";
 
 const locationCrashesFiltercards: FilterGroup[] = [
@@ -185,7 +184,7 @@ export const locationCrashesQueryConfig: QueryConfig = {
   exportable: true,
   exportFilename: "location-crashes",
   tableName: "location_crashes_view",
-  limit: DEFAULT_QUERY_LIMIT,
+  limit: 1000,
   offset: 0,
   sortColName: "crash_timestamp",
   sortAsc: false,


### PR DESCRIPTION
## Associated issues

* https://github.com/cityofaustin/atd-data-tech/issues/27881

## Testing

**URL to test:** [Netlify](https://deploy-preview-2020--atd-vze-staging.netlify.app/)

1. Go to the EMS list. Confirm that the table is set to display 1,000 rows per page by default.
2. Use the column visibility settings menu (cog icon to the right of the table pagination controls) to hide the **Date**, **Incident address**, and **Incident number** columns.
3. Switch the map view and click on a circle marker — confirm that the incident address, date, and crash ID are all rendered correctly. Repeat steps 2 and 3 in prod and you will see the bug 🐛 
4. Repeat these steps (confirm 1k row limit and hide visible columns) on these pages as well:

* [Fatalities list](https://deploy-preview-2020--atd-vze-staging.netlify.app/editor/fatalities) (columns: Crash ID, YTD Fatal Crash, Crash Date)
* [Location details crashes list](https://deploy-preview-2020--atd-vze-staging.netlify.app/editor/locations/153D618A97) (columns: Type, Crash ID, Case ID, Date, Address)
* Crashes (columns: **Crash ID**)


---

#### Ship list

- [ ] Check migrations for any conflicts with latest migrations in `main` branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved
