### PR TITLE
Add field visibility picker to crash details summary card

### DIFF
--- a/editor/app/crashes/[record_locator]/page.tsx
+++ b/editor/app/crashes/[record_locator]/page.tsx
@@ -132,6 +132,8 @@ export default function CrashDetailsPage({
             columns={crashDataCards.summary}
             mutation={UPDATE_CRASH}
             onSaveCallback={onSaveCallback}
+            shouldShowColumnVisibilityPicker={true}
+            localStorageKey="crashPageSummary"
           />
         </Col>
         <Col sm={12} md={6} lg={4} className="mb-3">


### PR DESCRIPTION
## Associated issues

https://github.com/cityofaustin/atd-data-tech/issues/27782

## Testing

**URL to test:** <!-- VZ URL or Netlify -->

https://deploy-preview-2023--atd-vze-staging.netlify.app/editor/crashes

**Steps to test:**

1. Go to a crash details page. 
2. see the visibility picker on the summary card. 
3. hide some of the fields. refresh. 

---

#### Ship list

- [ ] Check migrations for any conflicts with latest migrations in `main` branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved
