### PR TITLE
Fixes redundant data fetch in list views

### DIFF
--- a/editor/components/TableWrapper.tsx
+++ b/editor/components/TableWrapper.tsx
@@ -130,7 +130,12 @@ export default function TableWrapper<T extends Record<string, unknown>>({
 
   const { data, aggregateData, isLoading, error, refetch } = useQuery<T>({
     // don't fire first query until localstorage is loaded
-    query: (isQueryConfigLocalStorageLoaded && visibleColumns.length > 0) ? query : null,
+    query:
+      isQueryConfigLocalStorageLoaded &&
+      isColVisibilityLocalStorageLoaded &&
+      visibleColumns.length > 0
+        ? query
+        : null,
     typename: queryConfig.tableName,
     hasAggregates: true,
   });
@@ -272,6 +277,7 @@ export default function TableWrapper<T extends Record<string, unknown>>({
   useEffect(() => {
     refetch();
   }, [_refetch, refetch]);
+
   /**
    * wait until the localstorage hook resolves to render anything
    * to prevent filter UI elements from jumping


### PR DESCRIPTION
## Associated issues

* https://github.com/cityofaustin/atd-data-tech/issues/28226

I came across this small bug yesterday while testing other work. 

## Testing

**URL to test:** Netlify

**Steps to test:**

1. Open your browser console and keep an eye the network requests. I filter on the name `graphql` to isolate hasura requests.
2. Refresh the crashes list and observe the network requests to Hasura. There should be three query operations: `BuildQuery_crashes_list_view`, `UnitTypes`, `InsertUserEvent`. 
3. Use the column visibility picker to hide and unhide the **Est comp cost** column. This will fire a new `BuildQuery_crashes_list_view` network request whenever you hide or unhide it.
4. Make a few more changes to column visibility, then refresh your page and confirm that there are still just three queries fired when the page loads.
5. Feel free to compare to prod to see the bug this fixes 😇 

---

#### Ship list

- [ ] Check migrations for any conflicts with latest migrations in `main` branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved
