### PR TITLE
VZV: Change order of demographic categories so that "other" is last

### DIFF
--- a/viewer/src/views/summary/PeopleByDemographics.js
+++ b/viewer/src/views/summary/PeopleByDemographics.js
@@ -41,8 +41,8 @@ const chartConfigs = {
       "Hispanic",
       "Black",
       "Asian",
-      "Other or unknown",
       "American Indian or Alaska Native",
+      "Other or unknown",
     ],
     exceptionCategory: "Other or unknown", // Category for missing or unknown data
     query: `SELECT date_extract_y(crash_timestamp_ct) as year, COUNT(*) as total, prsn_ethnicity_id, prsn_injry_sev_id


### PR DESCRIPTION
## Associated issues

https://github.com/cityofaustin/atd-data-tech/issues/27510

## Testing

**URL to test:** <!-- VZ URL or Netlify -->

https://deploy-preview-2038--atd-vzv-staging.netlify.app/

**Steps to test:**

Color order is maintained, but Other has been moved to the end and is the orange color. 

<img width="1167" height="621" alt="Screenshot 2026-05-11 at 1 39 34 PM" src="https://github.com/user-attachments/assets/2d21a922-5535-4131-93d0-0e66a4ec2db7" />



---

#### Ship list

- [ ] Check migrations for any conflicts with latest migrations in `main` branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved
