### PR TITLE
Standardize the way dates are displayed across the VZE

### DIFF
--- a/editor/app/fatalities/[record_locator]/page.tsx
+++ b/editor/app/fatalities/[record_locator]/page.tsx
@@ -11,7 +11,7 @@ import CrashNarrativeEditableCard from "@/components/CrashNarrativeEditableCard"
 import { GET_CRASH } from "@/queries/crash";
 import { Crash } from "@/types/crashes";
 import { useDocumentTitle } from "@/utils/documentTitle";
-import { formatUSDateTimeWithDay, formatYear } from "@/utils/formatters";
+import { formatUsDateTimeWithDay, formatYear } from "@/utils/formatters";
 import { useQuery } from "@/utils/graphql";
 import { UPDATE_CRASH } from "@/queries/crash";
 import CrashDiagramCard from "@/components/CrashDiagramCard";
@@ -118,7 +118,7 @@ export default function FatalCrashDetailsPage({
                     <td style={{ textWrap: "nowrap" }} className="fw-bold">
                       Date
                     </td>
-                    <td>{formatUSDateTimeWithDay(crash.crash_timestamp)}</td>
+                    <td>{formatUsDateTimeWithDay(crash.crash_timestamp)}</td>
                   </tr>
                   <tr>
                     <td style={{ textWrap: "nowrap" }} className="fw-bold">

--- a/editor/app/fatalities/[record_locator]/page.tsx
+++ b/editor/app/fatalities/[record_locator]/page.tsx
@@ -11,7 +11,7 @@ import CrashNarrativeEditableCard from "@/components/CrashNarrativeEditableCard"
 import { GET_CRASH } from "@/queries/crash";
 import { Crash } from "@/types/crashes";
 import { useDocumentTitle } from "@/utils/documentTitle";
-import { formatIsoDateTimeWithDay, formatYear } from "@/utils/formatters";
+import { formatUSDateTimeWithDay, formatYear } from "@/utils/formatters";
 import { useQuery } from "@/utils/graphql";
 import { UPDATE_CRASH } from "@/queries/crash";
 import CrashDiagramCard from "@/components/CrashDiagramCard";
@@ -118,7 +118,7 @@ export default function FatalCrashDetailsPage({
                     <td style={{ textWrap: "nowrap" }} className="fw-bold">
                       Date
                     </td>
-                    <td>{formatIsoDateTimeWithDay(crash.crash_timestamp)}</td>
+                    <td>{formatUSDateTimeWithDay(crash.crash_timestamp)}</td>
                   </tr>
                   <tr>
                     <td style={{ textWrap: "nowrap" }} className="fw-bold">

--- a/editor/app/fatalities/[record_locator]/page.tsx
+++ b/editor/app/fatalities/[record_locator]/page.tsx
@@ -11,7 +11,7 @@ import CrashNarrativeEditableCard from "@/components/CrashNarrativeEditableCard"
 import { GET_CRASH } from "@/queries/crash";
 import { Crash } from "@/types/crashes";
 import { useDocumentTitle } from "@/utils/documentTitle";
-import { formatUsDateTimeWithDay, formatYear } from "@/utils/formatters";
+import { formatIsoDateTimeWithDay, formatYear } from "@/utils/formatters";
 import { useQuery } from "@/utils/graphql";
 import { UPDATE_CRASH } from "@/queries/crash";
 import CrashDiagramCard from "@/components/CrashDiagramCard";
@@ -118,7 +118,7 @@ export default function FatalCrashDetailsPage({
                     <td style={{ textWrap: "nowrap" }} className="fw-bold">
                       Date
                     </td>
-                    <td>{formatUsDateTimeWithDay(crash.crash_timestamp)}</td>
+                    <td>{formatIsoDateTimeWithDay(crash.crash_timestamp)}</td>
                   </tr>
                   <tr>
                     <td style={{ textWrap: "nowrap" }} className="fw-bold">

--- a/editor/app/users/[user_id]/page.tsx
+++ b/editor/app/users/[user_id]/page.tsx
@@ -14,7 +14,7 @@ import PermissionsRequired from "@/components/PermissionsRequired";
 import { formatRoleName, useGetToken } from "@/utils/auth";
 import { useUser } from "@/utils/users";
 import { User } from "@/types/users";
-import { formatDateTimeWithDay } from "@/utils/formatters";
+import { formatIsoDateTimeWithDay } from "@/utils/formatters";
 
 const allowedUserEditRoles = ["vz-admin"];
 
@@ -37,17 +37,17 @@ const COLUMNS: UserColumn[] = [
   {
     name: "created_at",
     label: "Created at",
-    renderer: (user) => formatDateTimeWithDay(user.created_at),
+    renderer: (user) => formatIsoDateTimeWithDay(user.created_at),
   },
   {
     name: "last_login",
     label: "Last login",
-    renderer: (user) => formatDateTimeWithDay(user.last_login),
+    renderer: (user) => formatIsoDateTimeWithDay(user.last_login),
   },
   {
     name: "updated_at",
     label: "Updated at",
-    renderer: (user) => formatDateTimeWithDay(user.updated_at),
+    renderer: (user) => formatIsoDateTimeWithDay(user.updated_at),
   },
 ];
 

--- a/editor/app/users/[user_id]/page.tsx
+++ b/editor/app/users/[user_id]/page.tsx
@@ -14,7 +14,7 @@ import PermissionsRequired from "@/components/PermissionsRequired";
 import { formatRoleName, useGetToken } from "@/utils/auth";
 import { useUser } from "@/utils/users";
 import { User } from "@/types/users";
-import { formatIsoDateTimeWithDay } from "@/utils/formatters";
+import { formatIsoDateTime } from "@/utils/formatters";
 
 const allowedUserEditRoles = ["vz-admin"];
 
@@ -37,17 +37,17 @@ const COLUMNS: UserColumn[] = [
   {
     name: "created_at",
     label: "Created at",
-    renderer: (user) => formatIsoDateTimeWithDay(user.created_at),
+    renderer: (user) => formatIsoDateTime(user.created_at),
   },
   {
     name: "last_login",
     label: "Last login",
-    renderer: (user) => formatIsoDateTimeWithDay(user.last_login),
+    renderer: (user) => formatIsoDateTime(user.last_login),
   },
   {
     name: "updated_at",
     label: "Updated at",
-    renderer: (user) => formatIsoDateTimeWithDay(user.updated_at),
+    renderer: (user) => formatIsoDateTime(user.updated_at),
   },
 ];
 

--- a/editor/app/users/page.tsx
+++ b/editor/app/users/page.tsx
@@ -13,6 +13,7 @@ import { User } from "@/types/users";
 import { formatRoleName } from "@/utils/auth";
 import { useDocumentTitle } from "@/utils/documentTitle";
 import { LuCheck, LuCopy, LuUserPlus } from "react-icons/lu";
+import { formatIsoDateTime } from "@/utils/formatters";
 
 const allowedCreateUserRoles = ["vz-admin"];
 
@@ -147,14 +148,16 @@ export default function Users() {
                   >
                     <td>{user.name}</td>
                     <td>{user.email}</td>
-                    <td>{new Date(user.created_at).toLocaleDateString()}</td>
+                    <td>{formatIsoDateTime(user.created_at)}</td>
                     <td>
                       {user.last_login
-                        ? new Date(user.last_login).toLocaleDateString()
+                        ? formatIsoDateTime(user.last_login)
                         : ""}
                     </td>
                     <td>{user.logins_count || "0"}</td>
-                    <td>{formatRoleName(user.app_metadata?.roles?.[0] || "")}</td>
+                    <td>
+                      {formatRoleName(user.app_metadata?.roles?.[0] || "")}
+                    </td>
                   </tr>
                 );
               })}

--- a/editor/components/ChangeDetailHeader.tsx
+++ b/editor/components/ChangeDetailHeader.tsx
@@ -1,5 +1,5 @@
 import { ChangeLogEntryEnriched } from "@/types/changeLog";
-import { formatDateTimeWithDay } from "@/utils/formatters";
+import { formatIsoDateTimeWithDay } from "@/utils/formatters";
 
 /**
  * Header component of the change details table
@@ -15,7 +15,7 @@ export default function ChangeDetailHeader({
       <span>{selectedChange.operation_type}</span>
       {" | "} <span>{selectedChange.created_by}</span>
       {" | "}
-      {formatDateTimeWithDay(selectedChange.created_at)}
+      {formatIsoDateTimeWithDay(selectedChange.created_at)}
     </div>
   );
 }

--- a/editor/components/ChangeLog.tsx
+++ b/editor/components/ChangeLog.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from "react";
 import Table from "react-bootstrap/Table";
 import Accordion from "react-bootstrap/Accordion";
-import { formatIsoDateTimeWithDay, formatUSDateTimeWithDay } from "@/utils/formatters";
+import { formatIsoDateTime } from "@/utils/formatters";
 import ChangeLogDetails from "@/components/ChangeLogDetails";
 import {
   ChangeLogEntry,
@@ -137,7 +137,7 @@ export default function ChangeLog({ logs }: { logs: ChangeLogEntry[] }) {
                       : change.affected_fields.join(", ")}
                   </td>
                   <td>{change.created_by}</td>
-                  <td>{formatUSDateTimeWithDay(change.created_at)}</td>
+                  <td>{formatIsoDateTime(change.created_at)}</td>
                 </tr>
               ))}
             </tbody>

--- a/editor/components/ChangeLog.tsx
+++ b/editor/components/ChangeLog.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from "react";
 import Table from "react-bootstrap/Table";
 import Accordion from "react-bootstrap/Accordion";
-import { formatDateTimeWithDay } from "@/utils/formatters";
+import { formatIsoDateTimeWithDay, formatUSDateTimeWithDay } from "@/utils/formatters";
 import ChangeLogDetails from "@/components/ChangeLogDetails";
 import {
   ChangeLogEntry,
@@ -137,7 +137,7 @@ export default function ChangeLog({ logs }: { logs: ChangeLogEntry[] }) {
                       : change.affected_fields.join(", ")}
                   </td>
                   <td>{change.created_by}</td>
-                  <td>{formatDateTimeWithDay(change.created_at)}</td>
+                  <td>{formatUSDateTimeWithDay(change.created_at)}</td>
                 </tr>
               ))}
             </tbody>

--- a/editor/components/EMSMapPopupContent.tsx
+++ b/editor/components/EMSMapPopupContent.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { formatDate } from "@/utils/formatters";
+import { formatIsoDate } from "@/utils/formatters";
 import { GeoJsonProperties } from "geojson";
 
 export interface EMSMapPopupContentProps {
@@ -23,7 +23,7 @@ export default function EMSMapPopupContent({
       <div className="d-flex justify-content-between">
         <span className="fw-bold">Date</span>
         <span className="text-muted">
-          {formatDate(properties?.incident_received_datetime)}
+          {formatIsoDate(properties?.incident_received_datetime)}
         </span>
       </div>
     </div>

--- a/editor/components/FatalitiesMapPopupContent.tsx
+++ b/editor/components/FatalitiesMapPopupContent.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { formatDate } from "@/utils/formatters";
+import { formatIsoDate } from "@/utils/formatters";
 import { GeoJsonProperties } from "geojson";
 
 export interface FatalitiesMapPopupContentProps {
@@ -26,7 +26,7 @@ export default function FatalitiesMapPopupContent({
       <div className="d-flex justify-content-between">
         <span className="fw-bold">Date</span>
         <span className="text-muted">
-          {formatDate(properties?.crash_timestamp)}
+          {formatIsoDate(properties?.crash_timestamp)}
         </span>
       </div>
       <div className="d-flex justify-content-between">

--- a/editor/components/LocationsTableMapPopupContent.tsx
+++ b/editor/components/LocationsTableMapPopupContent.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { formatDate } from "@/utils/formatters";
+import { formatIsoDate } from "@/utils/formatters";
 import { TableMapPopupContentProps } from "./TableMapPopupContent";
 
 export default function LocationTableMapPopupContent({
@@ -33,7 +33,7 @@ export default function LocationTableMapPopupContent({
       <div className="d-flex justify-content-between">
         <span className="fw-bold">Date</span>
         <span className="text-muted">
-          {formatDate(properties?.crash_timestamp)}
+          {formatIsoDate(properties?.crash_timestamp)}
         </span>
       </div>
     </div>

--- a/editor/components/NotesCard.tsx
+++ b/editor/components/NotesCard.tsx
@@ -8,7 +8,7 @@ import AlignedLabel from "@/components/AlignedLabel";
 import DeleteNoteButton from "@/components/DeleteNoteButton";
 import PermissionsRequired from "@/components/PermissionsRequired";
 import { CrashNote } from "@/types/crashNote";
-import { formatDate, formatUserNameFromEmail } from "@/utils/formatters";
+import { formatIsoDate, formatUserNameFromEmail } from "@/utils/formatters";
 import { LuSquarePen } from "react-icons/lu";
 import { LocationNote } from "@/types/locationNote";
 
@@ -78,7 +78,7 @@ export default function NotesCard<T extends CrashNote | LocationNote>({
                       </span>
                       <span>{` on `}</span>
                       <span className="text-nowrap">
-                        {formatDate(note.updated_at)}
+                        {formatIsoDate(note.updated_at)}
                       </span>
                     </small>
                   </div>

--- a/editor/components/TableMapPopupContent.tsx
+++ b/editor/components/TableMapPopupContent.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { formatDate } from "@/utils/formatters";
+import { formatIsoDate } from "@/utils/formatters";
 import { GeoJsonProperties } from "geojson";
 
 export interface TableMapPopupContentProps {
@@ -23,7 +23,7 @@ export default function TableMapPopupContent({
       <div className="d-flex justify-content-between">
         <span className="fw-bold">Date</span>
         <span className="text-muted">
-          {formatDate(properties?.crash_timestamp)}
+          {formatIsoDate(properties?.crash_timestamp)}
         </span>
       </div>
     </div>

--- a/editor/configs/crashesColumns.tsx
+++ b/editor/configs/crashesColumns.tsx
@@ -1,6 +1,6 @@
 import { ColDataCardDef } from "@/types/types";
 import { Crash } from "@/types/crashes";
-import { formatIsoDateTimeWithDay, formatUSDateTimeWithDay } from "@/utils/formatters";
+import { formatIsoDateTimeWithDay } from "@/utils/formatters";
 import { commonValidations } from "@/utils/formHelpers";
 import Link from "next/link";
 
@@ -52,7 +52,7 @@ export const crashesColumns = {
   crash_timestamp: {
     path: "crash_timestamp",
     label: "Crash date",
-    valueFormatter: formatUSDateTimeWithDay,
+    valueFormatter: formatIsoDateTimeWithDay,
   },
   collsn: {
     path: "collsn.label",

--- a/editor/configs/crashesColumns.tsx
+++ b/editor/configs/crashesColumns.tsx
@@ -1,6 +1,6 @@
 import { ColDataCardDef } from "@/types/types";
 import { Crash } from "@/types/crashes";
-import { formatDateTimeWithDay } from "@/utils/formatters";
+import { formatIsoDateTimeWithDay, formatUSDateTimeWithDay } from "@/utils/formatters";
 import { commonValidations } from "@/utils/formHelpers";
 import Link from "next/link";
 
@@ -52,7 +52,7 @@ export const crashesColumns = {
   crash_timestamp: {
     path: "crash_timestamp",
     label: "Crash date",
-    valueFormatter: formatDateTimeWithDay,
+    valueFormatter: formatUSDateTimeWithDay,
   },
   collsn: {
     path: "collsn.label",

--- a/editor/configs/crashesListViewColumns.tsx
+++ b/editor/configs/crashesListViewColumns.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { formatDate, formatDollars, formatTime } from "@/utils/formatters";
+import { formatIsoDate, formatDollars, formatTime } from "@/utils/formatters";
 import { ColDataCardDef } from "@/types/types";
 import { CrashesListRow } from "@/types/crashesList";
 
@@ -25,7 +25,7 @@ export const crashesListViewColumns: ColDataCardDef<CrashesListRow>[] = [
     label: "Date",
     sortable: true,
     style: { minWidth: "8rem" },
-    valueFormatter: formatDate,
+    valueFormatter: formatIsoDate,
     fetchAlways: true,
   },
   {

--- a/editor/configs/emsColumns.tsx
+++ b/editor/configs/emsColumns.tsx
@@ -223,7 +223,7 @@ export const ALL_EMS_COLUMNS = {
     path: "incident_received_datetime",
     label: "Time",
     sortable: false,
-    defaultHidden: true,
+    defaultHidden: false,
     valueFormatter: formatTime,
     style: { minWidth: "6rem" },
   },

--- a/editor/configs/emsColumns.tsx
+++ b/editor/configs/emsColumns.tsx
@@ -1,7 +1,7 @@
 import { getInjuryColorClass } from "@/utils/people";
 import { ColDataCardDef } from "@/types/types";
 import { EMSPatientCareRecord } from "@/types/ems";
-import { formatDate, formatIsoDateTime } from "@/utils/formatters";
+import { formatIsoDate, formatIsoDateTimeWithDay } from "@/utils/formatters";
 import Link from "next/link";
 import { ClientError } from "graphql-request";
 import {
@@ -204,14 +204,14 @@ export const ALL_EMS_COLUMNS = {
     path: "incident_received_datetime",
     label: "Date",
     style: { whiteSpace: "nowrap" },
-    valueFormatter: formatIsoDateTime,
+    valueFormatter: formatIsoDateTimeWithDay,
     sortable: true,
   },
   incident_received_datetime: {
     path: "incident_received_datetime",
     label: "Date",
     style: { whiteSpace: "nowrap" },
-    valueFormatter: formatDate,
+    valueFormatter: formatIsoDate,
     sortable: true,
     fetchAlways: true,
   },

--- a/editor/configs/emsColumns.tsx
+++ b/editor/configs/emsColumns.tsx
@@ -1,7 +1,11 @@
 import { getInjuryColorClass } from "@/utils/people";
 import { ColDataCardDef } from "@/types/types";
 import { EMSPatientCareRecord } from "@/types/ems";
-import { formatIsoDate, formatIsoDateTimeWithDay } from "@/utils/formatters";
+import {
+  formatIsoDate,
+  formatIsoDateTimeWithDay,
+  formatTime,
+} from "@/utils/formatters";
 import Link from "next/link";
 import { ClientError } from "graphql-request";
 import {
@@ -215,6 +219,14 @@ export const ALL_EMS_COLUMNS = {
     sortable: true,
     fetchAlways: true,
   },
+  incident_received_time: {
+    path: "incident_received_datetime",
+    label: "Time",
+    sortable: false,
+    defaultHidden: true,
+    valueFormatter: formatTime,
+    style: { minWidth: "6rem" },
+  },
   person_id: {
     path: "person_id",
     label: "Person ID",
@@ -294,6 +306,7 @@ export const emsListViewColumns: ColDataCardDef<EMSPatientCareRecord>[] = [
   ALL_EMS_COLUMNS.id,
   ALL_EMS_COLUMNS.incident_number,
   ALL_EMS_COLUMNS.incident_received_datetime,
+  ALL_EMS_COLUMNS.incident_received_time,
   ALL_EMS_COLUMNS.incident_location_address,
   ALL_EMS_COLUMNS.travel_mode,
   ALL_EMS_COLUMNS.incident_problem,

--- a/editor/configs/fatalitiesListViewColumns.tsx
+++ b/editor/configs/fatalitiesListViewColumns.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { formatDate } from "@/utils/formatters";
+import { formatIsoDate } from "@/utils/formatters";
 import { ColDataCardDef } from "@/types/types";
 import { fatalitiesListRow } from "@/types/fatalitiesList";
 
@@ -46,7 +46,7 @@ export const fatalitiesListViewColumns: ColDataCardDef<fatalitiesListRow>[] = [
     label: "Crash Date",
     sortable: true,
     fetchAlways: true,
-    valueFormatter: formatDate,
+    valueFormatter: formatIsoDate,
     style: { whiteSpace: "nowrap" },
   },
   {

--- a/editor/configs/locationCrashesColumns.tsx
+++ b/editor/configs/locationCrashesColumns.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link";
 import { ColDataCardDef } from "@/types/types";
 import { LocationCrashRow } from "@/types/locationCrashes";
-import { formatDate, formatDollars } from "@/utils/formatters";
+import { formatIsoDate, formatDollars } from "@/utils/formatters";
 
 export const locationCrashesColumns: ColDataCardDef<LocationCrashRow>[] = [
   {
@@ -34,7 +34,7 @@ export const locationCrashesColumns: ColDataCardDef<LocationCrashRow>[] = [
     path: "crash_timestamp",
     label: "Date",
     sortable: true,
-    valueFormatter: formatDate,
+    valueFormatter: formatIsoDate,
     fetchAlways: true,
   },
   {

--- a/editor/utils/formatters.ts
+++ b/editor/utils/formatters.ts
@@ -17,7 +17,6 @@ export const formatIsoDateTimeWithDay = (value: unknown): string => {
   if (!value || typeof value !== "string") {
     return "";
   }
-//   E d MMM yyyy h:mm a
   return format(parseISO(value), "yyyy-MM-dd h:mm a · E") || "";
 };
 

--- a/editor/utils/formatters.ts
+++ b/editor/utils/formatters.ts
@@ -31,16 +31,6 @@ export const formatIsoDateTime = (value: unknown): string => {
 };
 
 /**
- * Format date as: 08/24/2025 8:57 PM — Sun
- */
-export const formatUsDateTimeWithDay = (value: unknown): string => {
-  if (!value || typeof value !== "string") {
-    return "";
-  }
-  return format(parseISO(value), "MM/dd/yyyy h:mm a — E") || "";
-};
-
-/**
  * Format date as: 2024-01-01
  */
 export const formatIsoDate = (value: unknown): string => {
@@ -139,4 +129,3 @@ export const formatYesNoString = (value: unknown): string => {
   if (value === null || value === undefined) return "";
   return value ? "Yes" : "No";
 };
-

--- a/editor/utils/formatters.ts
+++ b/editor/utils/formatters.ts
@@ -13,11 +13,11 @@ export const formatDollars = (cost: unknown | null): string => {
 /**
  * Format date as: Tue 5 Nov 2024 9:18 AM
  */
-export const formatDateTimeWithDay = (value: unknown): string => {
+export const formatIsoDateTimeWithDay = (value: unknown): string => {
   if (!value || typeof value !== "string") {
     return "";
   }
-  return format(parseISO(value), "E d MMM yyyy h:mm a") || "";
+  return format(parseISO(value), "yyyy-MM-dd h:mm a — E") || "";
 };
 
 /**
@@ -33,7 +33,7 @@ export const formatIsoDateTime = (value: unknown): string => {
 /**
  * Format date as: 08/24/2025 8:57 PM — Sun
  */
-export const formatIsoDateTimeWithDay = (value: unknown): string => {
+export const formatUSDateTimeWithDay = (value: unknown): string => {
   if (!value || typeof value !== "string") {
     return "";
   }

--- a/editor/utils/formatters.ts
+++ b/editor/utils/formatters.ts
@@ -11,13 +11,14 @@ export const formatDollars = (cost: unknown | null): string => {
 };
 
 /**
- * Format date as: Tue 5 Nov 2024 9:18 AM
+ * Format date as: 2025-06-22 10:33 AM · Sun
  */
 export const formatIsoDateTimeWithDay = (value: unknown): string => {
   if (!value || typeof value !== "string") {
     return "";
   }
-  return format(parseISO(value), "E yyyy-MM-dd h:mm a") || "";
+//   E d MMM yyyy h:mm a
+  return format(parseISO(value), "yyyy-MM-dd h:mm a · E") || "";
 };
 
 /**

--- a/editor/utils/formatters.ts
+++ b/editor/utils/formatters.ts
@@ -17,7 +17,7 @@ export const formatIsoDateTimeWithDay = (value: unknown): string => {
   if (!value || typeof value !== "string") {
     return "";
   }
-  return format(parseISO(value), "yyyy-MM-dd h:mm a — E") || "";
+  return format(parseISO(value), "E yyyy-MM-dd h:mm a") || "";
 };
 
 /**
@@ -33,7 +33,7 @@ export const formatIsoDateTime = (value: unknown): string => {
 /**
  * Format date as: 08/24/2025 8:57 PM — Sun
  */
-export const formatUSDateTimeWithDay = (value: unknown): string => {
+export const formatUsDateTimeWithDay = (value: unknown): string => {
   if (!value || typeof value !== "string") {
     return "";
   }
@@ -43,7 +43,7 @@ export const formatUSDateTimeWithDay = (value: unknown): string => {
 /**
  * Format date as: 2024-01-01
  */
-export const formatDate = (value: unknown): string => {
+export const formatIsoDate = (value: unknown): string => {
   if (!value || typeof value !== "string") {
     return "";
   }


### PR DESCRIPTION
## Associated issues

* https://github.com/cityofaustin/atd-data-tech/issues/26735
* https://github.com/cityofaustin/atd-data-tech/issues/28430

## Testing

**URL to test:** Netlify

Thing to verify:

- All dates now use one of four flavors:
  -  Date: `2025-06-22`
  - Time: `12:57 AM`
  - Date + time: `2025-06-22 10:33 AM`
  - Date + time + day of week:  `2025-06-22 10:33 AM · Sun`
- The new **Time** column appears in EMS list view 

Here is what should be a comprehensive list of places where we render a date:

- **EMS list map popups** showing incident_received_datetime
- **Crashes list map popups** showing crash_timestamp
- **Fatality list map popups** showing crash_timestamp
- **Location details -> crashes list map popups** showing crash_timestamp
- **Fatality details** "Date" field remains the same as prod
- **Crashes list view** - Date column
- **Crash details** - Crash date column
- **Crash details** - change log list and change log details
- **Fatalities list view** - Crash Date column
- **Location crashes list** - Date column
- **EMS list view** - Date column and new Time column
- **Users table** - Created at and Last login columns
- **User details page** - Created at and Last login columns
- **Crash details** and **location details** notes timestamps

---

#### Ship list

- [ ] Check migrations for any conflicts with latest migrations in `main` branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved
