### PR TITLE
Changes fatality details basemap default to aerial imagery

### DIFF
--- a/editor/app/fatalities/[record_locator]/page.tsx
+++ b/editor/app/fatalities/[record_locator]/page.tsx
@@ -150,7 +150,7 @@ export default function FatalCrashDetailsPage({
                   savedLatitude={crash.latitude}
                   savedLongitude={crash.longitude}
                   mapRef={mapRef}
-                  initialBasemapType="streets"
+                  initialBasemapType="aerial"
                 />
               </Row>
             </Card.Body>


### PR DESCRIPTION
## Associated issues

* https://github.com/cityofaustin/atd-data-tech/issues/28404

## Testing

**URL to test:** [Netlify](https://deploy-preview-2041--atd-vze-staging.netlify.app/)

Navigate to the [fatality details page](https://deploy-preview-2041--atd-vze-staging.netlify.app/editor/fatalities/20870944) and confirm the basemap defaults to aerial imagery, not streets.

---

#### Ship list

- [ ] Check migrations for any conflicts with latest migrations in `main` branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved
