### PR TITLE
Update the comprehensive cost calculations in the Vision Zero database

### DIFF
--- a/database/migrations/default/1780000491675_update_comp_costs_2026/down.sql
+++ b/database/migrations/default/1780000491675_update_comp_costs_2026/down.sql
@@ -1,0 +1,7 @@
+ALTER TABLE people ALTER COLUMN est_comp_cost_crash_based SET EXPRESSION AS (CASE
+WHEN prsn_injry_sev_id = 1 THEN 3000000
+WHEN prsn_injry_sev_id = 2 THEN 250000
+WHEN prsn_injry_sev_id = 3 THEN 200000
+WHEN prsn_injry_sev_id = 4 THEN 3500000
+ELSE 20000
+END)

--- a/database/migrations/default/1780000491675_update_comp_costs_2026/up.sql
+++ b/database/migrations/default/1780000491675_update_comp_costs_2026/up.sql
@@ -1,0 +1,10 @@
+ALTER TABLE people ALTER COLUMN est_comp_cost_crash_based SET EXPRESSION AS (CASE
+WHEN prsn_injry_sev_id = 1 THEN 3700000 -- SUSPECTED SERIOUS INJURY
+WHEN prsn_injry_sev_id = 2 THEN 250000 -- NON-INCAPACITATING INJURY / SUSPECTED MINOR INJURY
+WHEN prsn_injry_sev_id = 3 THEN 200000 -- POSSIBLE INJURY
+WHEN prsn_injry_sev_id = 4 THEN 4500000 -- KILLED/FATAL
+ELSE 25000 -- NOT INJURED, UNKNOWN, AUTONOMOUS AND KILLED (NON-ATD)
+end) ;
+
+COMMENT ON COLUMN people.est_comp_cost_crash_based IS
+'Generated column of comprehensive costs based on injury severity. Last updated May 2026';


### PR DESCRIPTION
## Associated issues

https://github.com/cityofaustin/atd-data-tech/issues/28573

The amount for NON CR-3 has not changed, so I did not need to update the `atd_apd_blueform` table

## Testing

**URL to test:** <!-- VZ URL or Netlify -->

**Steps to test:**

Spin up your db locally with production data.
Look at the values in the Est Comp Cost column on the crashes list view.
Apply migrations. 
Now look at the values in the column. They have updated. 

---

#### Ship list

- [ ] Check migrations for any conflicts with latest migrations in `main` branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved
