### PR TITLE
Add COA roadway field to crash details flags card

### DIFF
--- a/editor/configs/crashDataCard.ts
+++ b/editor/configs/crashDataCard.ts
@@ -10,9 +10,10 @@ export const crashDataCards = {
   ],
   flags: [
     crashesColumns.private_dr_fl,
+    crashesColumns.is_coa_roadway,
+    crashesColumns.onsys_fl,
     crashesColumns.at_intrsct_fl,
     crashesColumns.active_school_zone_fl,
-    crashesColumns.onsys_fl,
     crashesColumns.rr_relat_fl,
     crashesColumns.schl_bus_fl,
     crashesColumns.toll_road_fl,

--- a/editor/configs/crashesColumns.tsx
+++ b/editor/configs/crashesColumns.tsx
@@ -339,4 +339,10 @@ export const crashesColumns = {
       foreignKey: "investigat_agency_id",
     },
   },
+  is_coa_roadway: {
+    path: "is_coa_roadway",
+    label: "COA roadway",
+    editable: true,
+    inputType: "yes_no",
+  },
 } satisfies Record<string, ColDataCardDef<Crash>>;

--- a/editor/configs/crashesColumns.tsx
+++ b/editor/configs/crashesColumns.tsx
@@ -342,7 +342,6 @@ export const crashesColumns = {
   is_coa_roadway: {
     path: "is_coa_roadway",
     label: "COA roadway",
-    editable: true,
-    inputType: "yes_no",
+    editable: false,
   },
 } satisfies Record<string, ColDataCardDef<Crash>>;

--- a/editor/configs/crashesColumns.tsx
+++ b/editor/configs/crashesColumns.tsx
@@ -343,5 +343,6 @@ export const crashesColumns = {
     path: "is_coa_roadway",
     label: "COA roadway",
     editable: false,
+    inputType: "yes_no",
   },
 } satisfies Record<string, ColDataCardDef<Crash>>;


### PR DESCRIPTION
## Associated issues

https://github.com/cityofaustin/atd-data-tech/issues/28782

## Testing

**URL to test:**

https://deploy-preview-2053--vze-staging.netlify.app/editor/crashes/20874690

**Steps to test:**

Go to any crash details page. 
Check the flags card, the top three flags are : Private drive, COA roadway, On TxDOT highway system
(make sure if you have hidden any of these fields before, that you unhide them)

Try clicking the field value to edit, you should not be able to edit this field. 



---

#### Ship list

- [ ] Check migrations for any conflicts with latest migrations in `main` branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved
