### PR TITLE
Optimize fatality details page for slide deck / screencap

### DIFF
--- a/editor/app/crashes/[record_locator]/page.tsx
+++ b/editor/app/crashes/[record_locator]/page.tsx
@@ -103,7 +103,7 @@ export default function CrashDetailsPage({
       {
         // show alert if crash is a temp record
         crash.is_temp_record && (
-          <CrashIsTemporaryBanner crash={crash} allowDelete={true} />
+          <CrashIsTemporaryBanner crash={crash} allowDelete />
         )
       }
       <Row>

--- a/editor/app/crashes/[record_locator]/page.tsx
+++ b/editor/app/crashes/[record_locator]/page.tsx
@@ -102,7 +102,9 @@ export default function CrashDetailsPage({
       }
       {
         // show alert if crash is a temp record
-        crash.is_temp_record && <CrashIsTemporaryBanner crash={crash} />
+        crash.is_temp_record && (
+          <CrashIsTemporaryBanner crash={crash} allowDelete={true} />
+        )
       }
       <Row>
         <Col sm={12} md={6} lg={4} className="mb-3">

--- a/editor/app/fatalities/[record_locator]/page.tsx
+++ b/editor/app/fatalities/[record_locator]/page.tsx
@@ -189,7 +189,7 @@ export default function FatalCrashDetailsPage({
           </Row>
         </Col>
       </Row>
-      <Row>
+      <Row style={{ fontSize: "18px" }}>
         <Col className="mb-3" sm={12} md={12} lg={6}>
           <CrashRecommendationCard
             crash_pk={crash.id}

--- a/editor/app/fatalities/[record_locator]/page.tsx
+++ b/editor/app/fatalities/[record_locator]/page.tsx
@@ -100,8 +100,8 @@ export default function FatalCrashDetailsPage({
           <CrashIsTemporaryBanner crash={crash} allowDelete={false} />
         )
       }
-      <Row>
-        <Col className="mb-3" sm={12} md={6}>
+      <Row style={{ fontSize: "18px" }}>
+        <Col className="mb-3" sm={12} md={5}>
           <Card className="h-100">
             <Card.Body>
               <Table>
@@ -156,31 +156,37 @@ export default function FatalCrashDetailsPage({
             </Card.Body>
           </Card>
         </Col>
-        <Col className="mb-3" sm={12} md={6}>
+        <Col className="mb-3" sm={12} md={7}>
           <FatalityUnitsCards crash={crash} onSaveCallback={onSaveCallback} />
         </Col>
       </Row>
-      <Row>
-        <Col className="mb-3" sm={12} md={6} lg={4}>
+      <Row style={{ fontSize: "18px" }}>
+        <Col className="mb-3" sm={12} md={6} style={{ minHeight: "625px" }}>
           <CrashDiagramCard crash={crash} crashRefetch={refetch} />
         </Col>
-        <Col className="mb-3" sm={12} md={6} lg={4}>
-          <CrashNarrativeEditableCard
-            crash={crash}
-            onSaveCallback={onSaveCallback}
-          />
-        </Col>
-        <Col className="mb-3">
-          <DataCard<Crash>
-            record={crash}
-            isValidating={false}
-            title="Details"
-            columns={otherCardColumns}
-            mutation={UPDATE_CRASH}
-            onSaveCallback={onSaveCallback}
-            shouldShowColumnVisibilityPicker={true}
-            localStorageKey="crashPageOther"
-          />
+        <Col className="mb-3" sm={12} md={6}>
+          <Row>
+            <Col className="mb-3">
+              <CrashNarrativeEditableCard
+                crash={crash}
+                onSaveCallback={onSaveCallback}
+              />
+            </Col>
+          </Row>
+          <Row>
+            <Col>
+              <DataCard<Crash>
+                record={crash}
+                isValidating={false}
+                title="Details"
+                columns={otherCardColumns}
+                mutation={UPDATE_CRASH}
+                onSaveCallback={onSaveCallback}
+                shouldShowColumnVisibilityPicker={true}
+                localStorageKey="crashPageOther"
+              />
+            </Col>
+          </Row>
         </Col>
       </Row>
       <Row>

--- a/editor/app/fatalities/[record_locator]/page.tsx
+++ b/editor/app/fatalities/[record_locator]/page.tsx
@@ -100,7 +100,7 @@ export default function FatalCrashDetailsPage({
           <CrashIsTemporaryBanner crash={crash} allowDelete={false} />
         )
       }
-      <Row style={{ fontSize: "16px" }}>
+      <Row className="fatality-details-row">
         <Col className="mb-3" sm={12} md={5}>
           <Card className="h-100">
             <Card.Body>
@@ -160,7 +160,7 @@ export default function FatalCrashDetailsPage({
           <FatalityUnitsCards crash={crash} onSaveCallback={onSaveCallback} />
         </Col>
       </Row>
-      <Row style={{ fontSize: "16px" }}>
+      <Row className="fatality-details-row">
         <Col className="mb-3" sm={12} md={6} style={{ minHeight: "625px" }}>
           <CrashDiagramCard crash={crash} crashRefetch={refetch} />
         </Col>
@@ -189,7 +189,7 @@ export default function FatalCrashDetailsPage({
           </Row>
         </Col>
       </Row>
-      <Row style={{ fontSize: "16px" }}>
+      <Row className="fatality-details-row">
         <Col className="mb-3" sm={12} md={12} lg={6}>
           <CrashRecommendationCard
             crash_pk={crash.id}

--- a/editor/app/fatalities/[record_locator]/page.tsx
+++ b/editor/app/fatalities/[record_locator]/page.tsx
@@ -99,7 +99,6 @@ export default function FatalCrashDetailsPage({
         crash.is_temp_record && (
           <CrashIsTemporaryBanner
             crash={crash}
-            allowDelete={false}
             dismissible
           />
         )

--- a/editor/app/fatalities/[record_locator]/page.tsx
+++ b/editor/app/fatalities/[record_locator]/page.tsx
@@ -79,12 +79,12 @@ export default function FatalCrashDetailsPage({
     <UserEventsLogger eventName="fatality_details_view">
       <Row>
         <div className="d-flex justify-content-between align-items-center mb-3">
-          <span className="fs-3 fw-bold text-uppercase">
+          <span className="fs-2 fw-bold text-uppercase">
             {data[0].address_display}
           </span>
           <span className="text-nowrap bg-light-use-theme py-2 rounded-3 px-3 border">
-            <span className="fs-5 fw-bold me-1">Year</span>
-            <span className="fs-5 me-3">
+            <span className="fs-4 fw-bold me-1">Year</span>
+            <span className="fs-4 me-3">
               {formatYear(data[0].crash_timestamp)}
             </span>
             <span className="fs-5 fw-bold me-1">Fatal Crash</span>

--- a/editor/app/fatalities/[record_locator]/page.tsx
+++ b/editor/app/fatalities/[record_locator]/page.tsx
@@ -87,8 +87,8 @@ export default function FatalCrashDetailsPage({
             <span className="fs-4 me-3">
               {formatYear(data[0].crash_timestamp)}
             </span>
-            <span className="fs-5 fw-bold me-1">Fatal Crash</span>
-            <span className="fs-5">
+            <span className="fs-4 fw-bold me-1">Fatal Crash</span>
+            <span className="fs-4">
               #{data[0].law_enforcement_ytd_fatality_num}
             </span>
           </span>

--- a/editor/app/fatalities/[record_locator]/page.tsx
+++ b/editor/app/fatalities/[record_locator]/page.tsx
@@ -100,7 +100,7 @@ export default function FatalCrashDetailsPage({
           <CrashIsTemporaryBanner crash={crash} allowDelete={false} />
         )
       }
-      <Row style={{ fontSize: "18px" }}>
+      <Row style={{ fontSize: "16px" }}>
         <Col className="mb-3" sm={12} md={5}>
           <Card className="h-100">
             <Card.Body>
@@ -160,12 +160,12 @@ export default function FatalCrashDetailsPage({
           <FatalityUnitsCards crash={crash} onSaveCallback={onSaveCallback} />
         </Col>
       </Row>
-      <Row style={{ fontSize: "18px" }}>
+      <Row style={{ fontSize: "16px" }}>
         <Col className="mb-3" sm={12} md={6} style={{ minHeight: "625px" }}>
           <CrashDiagramCard crash={crash} crashRefetch={refetch} />
         </Col>
-        <Col className="mb-3" sm={12} md={6}>
-          <Row>
+        <Col className="mb-3 d-flex flex-column" sm={12} md={6}>
+          <Row className="flex-grow-1">
             <Col className="mb-3">
               <CrashNarrativeEditableCard
                 crash={crash}
@@ -174,7 +174,7 @@ export default function FatalCrashDetailsPage({
             </Col>
           </Row>
           <Row>
-            <Col>
+            <Col >
               <DataCard<Crash>
                 record={crash}
                 isValidating={false}
@@ -189,7 +189,7 @@ export default function FatalCrashDetailsPage({
           </Row>
         </Col>
       </Row>
-      <Row style={{ fontSize: "18px" }}>
+      <Row style={{ fontSize: "16px" }}>
         <Col className="mb-3" sm={12} md={12} lg={6}>
           <CrashRecommendationCard
             crash_pk={crash.id}

--- a/editor/app/fatalities/[record_locator]/page.tsx
+++ b/editor/app/fatalities/[record_locator]/page.tsx
@@ -97,7 +97,11 @@ export default function FatalCrashDetailsPage({
       {
         // show alert if crash is a temp record, hide delete button on fatalities pages
         crash.is_temp_record && (
-          <CrashIsTemporaryBanner crash={crash} allowDelete={false} />
+          <CrashIsTemporaryBanner
+            crash={crash}
+            allowDelete={false}
+            dismissible
+          />
         )
       }
       <Row className="fatality-details-row">
@@ -174,7 +178,7 @@ export default function FatalCrashDetailsPage({
             </Col>
           </Row>
           <Row>
-            <Col >
+            <Col>
               <DataCard<Crash>
                 record={crash}
                 isValidating={false}

--- a/editor/components/CrashIsTemporaryBanner.tsx
+++ b/editor/components/CrashIsTemporaryBanner.tsx
@@ -12,6 +12,7 @@ const allowedDeleteCrashRecordEditRoles = ["vz-admin", "editor"];
 interface CrashIsTemporaryBannerProps {
   crash: Crash;
   allowDelete?: boolean;
+  dismissible?: boolean;
 }
 
 /**
@@ -21,16 +22,17 @@ interface CrashIsTemporaryBannerProps {
  */
 export default function CrashIsTemporaryBanner({
   crash,
-  allowDelete = true,
+  allowDelete,
+  dismissible,
 }: CrashIsTemporaryBannerProps) {
   const [showDeleteModal, setShowDeleteModal] = useState(false);
 
   return (
     <>
       <Alert
-        dismissible
         variant="warning"
         className="d-flex justify-content-between align-items-center"
+        dismissible={dismissible}
       >
         <span className="d-flex align-items-center">
           <FaTriangleExclamation className="me-2 d-none d-lg-inline" />

--- a/editor/components/CrashIsTemporaryBanner.tsx
+++ b/editor/components/CrashIsTemporaryBanner.tsx
@@ -28,6 +28,7 @@ export default function CrashIsTemporaryBanner({
   return (
     <>
       <Alert
+        dismissible
         variant="warning"
         className="d-flex justify-content-between align-items-center"
       >

--- a/editor/components/CrashNarrativeCard.tsx
+++ b/editor/components/CrashNarrativeCard.tsx
@@ -61,7 +61,7 @@ export default function CrashNarrativeCard({ crash }: { crash: Crash }) {
           </AlignedLabel>
         </Button>
       </Card.Header>
-      <Card.Body className="crash-header-card-body">
+      <Card.Body>
         <Card.Text>{crash.investigator_narrative || ""}</Card.Text>
       </Card.Body>
     </Card>

--- a/editor/components/CrashNarrativeEditableCard.tsx
+++ b/editor/components/CrashNarrativeEditableCard.tsx
@@ -92,7 +92,7 @@ export default function CrashNarrativeEditableCard({
             </AlignedLabel>
           </Button>
         </Card.Header>
-        <Card.Body className="crash-header-card-body">
+        <Card.Body>
           <Tab.Content>
             <Tab.Pane eventKey="narrative">
               <div style={{ whiteSpace: "pre-wrap" }}>

--- a/editor/components/FatalityUnitsCards.tsx
+++ b/editor/components/FatalityUnitsCards.tsx
@@ -95,7 +95,7 @@ export default function FatalityUnitsCards({
       <Card className="h-100">
         <Card.Header>
           <div className="d-flex flex-row justify-content-between">
-            <div className="fs-5 fw-bold">
+            <div className="fw-bold">
               {showAllUnits && !isSingleUnitCrash
                 ? "Units involved"
                 : "Victims"}

--- a/editor/configs/crashesColumns.tsx
+++ b/editor/configs/crashesColumns.tsx
@@ -79,7 +79,7 @@ export const crashesColumns = {
   },
   law_enforcement_ytd_fatality_num: {
     path: "law_enforcement_ytd_fatality_num",
-    label: "Law Enf. YTD Fatal Crash",
+    label: "Law Enforcement YTD Fatal Crash",
     editable: true,
     inputType: "text",
   },

--- a/editor/configs/crashesColumns.tsx
+++ b/editor/configs/crashesColumns.tsx
@@ -79,7 +79,7 @@ export const crashesColumns = {
   },
   law_enforcement_ytd_fatality_num: {
     path: "law_enforcement_ytd_fatality_num",
-    label: "Law Enforcement YTD Fatal Crash",
+    label: "Law Enf. YTD Fatal Crash",
     editable: true,
     inputType: "text",
   },

--- a/editor/styles/global.scss
+++ b/editor/styles/global.scss
@@ -395,6 +395,10 @@ to make sure it renders on top is a common fix */
   opacity: 1;
 }
 
+.row.fatality-details-row {
+  font-size: 16px !important;
+}
+
 /* Used in fatal victim PersonImages*/
 .editable-image {
   cursor: pointer;

--- a/editor/utils/images.ts
+++ b/editor/utils/images.ts
@@ -76,7 +76,11 @@ export function useImage({
         setImageUrl(data.url);
         setIsLoading(false);
       } catch (err) {
-        console.error(`Error fetching ${recordType} image:`, err);
+        if (`${err}`.includes("404")) {
+          console.warn(err);
+        } else {
+          console.error(`Error fetching ${recordType} image:`, err);
+        }
         setError(err instanceof Error ? err : new Error("Unknown error"));
         setImageUrl(null);
         setIsLoading(false);


### PR DESCRIPTION
## Associated issues

* https://github.com/cityofaustin/atd-data-tech/issues/28459

<img width="3066" height="3662" alt="frb-layout-1" src="https://github.com/user-attachments/assets/ef3e68bd-ee3a-4b31-9208-ad08e6144c60" />


## Testing

**URL to test:** [Netlify](https://deploy-preview-2055--vze-staging.netlify.app/)

1. From the fatalities list, view the details for a temporary crash.

2. Confirm that you are now able to dismiss the temp crash banner.

3. Observe the changes. It will be helpful to look at prod side-by-side.

* Increased font size
* Updated the top row (map + units cards) column ratio to 5:7
* Update middle row (diagram + narrative + details cards) column ratio to 6:6 with narrative + details now stacked
Increase font size

4. I left the [dark mode theme refactor](https://austininnovation.slack.com/archives/CM9MK950S/p1781015424624429) out of scope

---

#### Ship list

- [ ] Check migrations for any conflicts with latest migrations in `main` branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved
