### PR TITLE
Link to fatality details page from crash details page

### DIFF
--- a/editor/components/CrashHeader.tsx
+++ b/editor/components/CrashHeader.tsx
@@ -53,7 +53,10 @@ export default function CrashHeader({ crash, refetch }: CrashHeaderProps) {
       </Col>
       {crash.crash_injury_metrics_view && (
         <Col xs="auto">
-          <CrashInjuryIndicators injuries={crash.crash_injury_metrics_view} />
+          <CrashInjuryIndicators
+            injuries={crash.crash_injury_metrics_view}
+            recordLocator={crash.record_locator}
+          />
         </Col>
       )}
       <EditCrashAddressModal

--- a/editor/components/CrashInjuryIndicators.tsx
+++ b/editor/components/CrashInjuryIndicators.tsx
@@ -1,12 +1,14 @@
 import { CrashInjuryMetric } from "@/types/crashInjuryMetrics";
 import AlignedLabel from "@/components/AlignedLabel";
+import Link from "next/link";
+import { ReactNode } from "react";
 
 const InjuryBadge = ({
   label,
   value,
   className,
 }: {
-  label: string;
+  label: string | ReactNode;
   value: number | null;
   className?: string;
 }) => {
@@ -35,15 +37,23 @@ const InjuryBadge = ({
  */
 export default function CrashInjuryIndicators({
   injuries,
+  recordLocator,
 }: {
   injuries: CrashInjuryMetric;
+  recordLocator: string;
 }) {
   return (
     <div className="bg-light-use-theme fs-6 d-flex align-items-center align-self-center py-2 rounded-3 px-3 border">
       <span className="fw-bold me-3">Injuries</span>
       <InjuryBadge
         value={injuries.vz_fatality_count}
-        label="Fatal"
+        label={
+          injuries.vz_fatality_count && injuries.vz_fatality_count > 0 ? (
+            <Link href={`/fatalities/${recordLocator}`}>Fatal</Link>
+          ) : (
+            "Fatal"
+          )
+        }
         className="me-3"
       />
       <InjuryBadge

--- a/editor/testing.md
+++ b/editor/testing.md
@@ -83,7 +83,10 @@ The below features should be tested with each role. Features with role-based acc
 - Verify page `<title>` element is formatted as `<record-locator> - <crash-address>` (check how the title is rendered in your browser tab)
 - Crash address header looks correct. Use copy button to copy the crash address to the clipboard
 - [role: editor, admin] Click crash address to edit form inputs. Use **Swap addresses** button to swap primary and secondary address inputs. Confirm changes save correctly.
-- Crash injury widget reflects injuries from **People** card (test by editing person injuries)
+- Crash injury widget (top right of page) 
+  - Reflects injuries correftly from **People** card (test by editing person injuries)
+  - While looking at a crash with at least one fatality, confirm that the **Fatality** indicator is hyperlinked. Click on the hyperlink to navigate to the `/fatalities/[record_locator]` page for the corresponding crash.
+  - Confirm the **Fatality** indicator is not hyperlinked for crashes with no fatalities
 - Temporary record banner is visible for (temp crashes only)
 - [role: editor, admin] Delete tempoary crash record button inside temp record banner (temp crashes only)
 - Crash map: card header: displays hyperlinked **Location ID** (if crash is matched to a location)


### PR DESCRIPTION
## Associated issues
Closes https://github.com/cityofaustin/atd-data-tech/issues/28223

## Testing

**URL to test:** <!-- VZ URL or Netlify -->
[Netlify](https://deploy-preview-2056--vze-staging.netlify.app/editor/crashes)

**Steps to test:**
1. Open up some crash details pages, see that if there is 1 or more fatalities, the Fatal label in the crash injury indicator banner will be hyperlinked to that fatality details page.
2. Test editing the people cards to remove their fatalities and see that the data refetches & hyperlink is gone
---

#### Ship list

- [ ] Check migrations for any conflicts with latest migrations in `main` branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved
