### PR TITLE
Add dry run flag to incident linker

### DIFF
--- a/etl/cad_incidents_import/incident_linker.py
+++ b/etl/cad_incidents_import/incident_linker.py
@@ -85,6 +85,7 @@ def main(args):
     logging.info(f"  Found {len(incidents):,} unprocessed incidents\n")
 
     if args.dry_run:
+        logging.info(f"Dry run: aborting further processing")
         return
 
     processed_ids = set()

--- a/etl/cad_incidents_import/incident_linker.py
+++ b/etl/cad_incidents_import/incident_linker.py
@@ -15,7 +15,7 @@ from utils.queries import (
 MIN_RECORD_AGE_HOURS = 24
 DISTANCE_THRESHOLD_M = 500
 TIME_THRESHOLD_MINUTES = 60
-MAX_RECORD_TO_PROCESS = 1000
+MAX_RECORD_TO_PROCESS = 5000
 
 
 def point_geojson(lon, lat):
@@ -84,6 +84,9 @@ def main(args):
     incidents = data["cad_incidents"]
     logging.info(f"  Found {len(incidents):,} unprocessed incidents\n")
 
+    if args.dry_run:
+        return
+
     processed_ids = set()
     counts = {
         "cad_incidents_processed": 0,
@@ -141,6 +144,11 @@ if __name__ == "__main__":
         type=int,
         default=MAX_RECORD_TO_PROCESS,
         help="The maximum number of records to process",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Log if there are incidents to link without actually doing it",
     )
     args = parser.parse_args()
     main(args)


### PR DESCRIPTION
## Associated issues

* https://github.com/cityofaustin/atd-data-tech/issues/27761

## Testing

**URL to test:** Locally

1. If you haven't tested any of the CAD ETLs before, follow the `./etl/cad_incidents` readme to get set up for local dev. 
 
2. Apply migrations and metadata.

3. Run the ETL using the `--dry-run` flag.

```
docker compose -f docker-compose.yml -f docker-compose.local.yml run import incident_linker.py --dry-run
```

Your script output should look like this:

```
INFO:root:Fetching unprocessed incidents that occurred before 2026-06-09 16:11:20.836905+00:00...
INFO:root:  Found 5,000 unprocessed incidents
```

Note that default limit of 5k records to process is taking effect, and that no records are actually processed ✅ 

---

#### Ship list

- [ ] Check migrations for any conflicts with latest migrations in `main` branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved
