### PR TITLE
Updates CAD import ETL column handling

### DIFF
--- a/etl/cad_incidents_import/incidents_import.py
+++ b/etl/cad_incidents_import/incidents_import.py
@@ -151,6 +151,8 @@ def main(args):
     )
 
     if not files_todo:
+        if args.no_files_pass:
+            return
         raise Exception(
             f"No CAD files found in {"local directory" if args.local_files else "S3 inbox"}"
         )
@@ -249,6 +251,11 @@ if __name__ == "__main__":
         "--local-files",
         action="store_true",
         help="If true, process files from local COACD_MOUNT_PATH directory instead of AWS S3",
+    )
+    parser.add_argument(
+        "--no-files-pass",
+        action="store_true",
+        help="Don't throw an error if there are no files to process",
     )
     args = parser.parse_args()
     main(args)

--- a/etl/cad_incidents_import/incidents_import.py
+++ b/etl/cad_incidents_import/incidents_import.py
@@ -109,31 +109,31 @@ def transform_lat_lon(data):
             row["latitude"] = float(lat) / 1000000
 
 
-def prune_and_validate_columns(data, allowed_columns):
+def prune_and_validate_columns(data, required_columns):
     """
     Removes unknown columns from each record and raises an error if any
     required columns are missing.
 
     Args:
         data (list): list of cad records
-        allowed_columns (list): list of column name strings
+        required_columns (list): list of column name strings
 
     Returns:
-        list: data with record dicts containing only allowed columns
+        list: data with record dicts containing only required columns
 
     Raises:
-        ValueError: if any record is missing one or more allowed columns
+        ValueError: if any record is missing one or more required columns
     """
-    allowed = set(allowed_columns)
+    required = set(required_columns)
     pruned = []
     for i, record in enumerate(data):
         record_keys = set(record.keys())
-        missing = allowed - record_keys
+        missing = required - record_keys
         if missing:
             raise ValueError(
                 f"Record at index {i} is missing required columns: {sorted(missing)}"
             )
-        pruned.append({key: val for key, val in record.items() if key in allowed})
+        pruned.append({key: val for key, val in record.items() if key in required})
     return pruned
 
 
@@ -180,7 +180,7 @@ def main(args):
         if columns_to_rename:
             rename_columns(data, columns_to_rename)
 
-        data = prune_and_validate_columns(data, COLUMNS["allowed_columns"][table_name])
+        data = prune_and_validate_columns(data, COLUMNS["required_columns"][table_name])
 
         set_empty_strings_to_none(data)
 

--- a/etl/cad_incidents_import/incidents_import.py
+++ b/etl/cad_incidents_import/incidents_import.py
@@ -109,6 +109,22 @@ def transform_lat_lon(data):
             row["latitude"] = float(lat) / 1000000
 
 
+def prune_columns(data, allowed_columns):
+    """_summary_
+
+    Args:
+        data (list): list of cad records
+        allowed_columns (list): list of column name strings
+
+    Returns:
+        list: data with record dicts containing only allowed columns
+    """
+    allowed = set(allowed_columns)
+    return [
+        {key: val for key, val in record.items() if key in allowed} for record in data
+    ]
+
+
 def main(args):
     logging.info(f"Running CAD incident import")
 
@@ -128,6 +144,8 @@ def main(args):
         )
 
     for file_obj_key_or_path in files_todo:
+        is_group_id_file = "GroupID" in file_obj_key_or_path
+        table_name = "cad_incidents" if not is_group_id_file else "cad_incident_groups"
 
         if args.local_files:
             logging.info(f"Loading local file: {file_obj_key_or_path}")
@@ -138,16 +156,21 @@ def main(args):
 
         reader = csv.DictReader(csv_content.splitlines())
         data = list(reader)
-        data = lower_case_keys(data)
 
         if not data:
             raise Exception("CAD file contains no records")
 
+        data = lower_case_keys(data)
+
+        columns_to_rename = COLUMNS["cols_to_rename"].get(table_name)
+        if columns_to_rename:
+            rename_columns(data, columns_to_rename)
+
+        data = prune_columns(data, COLUMNS["allowed_columns"][table_name])
+
         set_empty_strings_to_none(data)
 
-        is_group_id_file = "GroupID" in file_obj_key_or_path
         if not is_group_id_file:
-            rename_columns(data, COLUMNS["cols_to_rename"])
             transform_lat_lon(data)
             make_fields_timezone_aware(
                 data,
@@ -161,6 +184,7 @@ def main(args):
         if not is_group_id_file:
             # add update column names to the muation "on conflict" directive
             column_names_to_upsert = list(data[0].keys())
+            # remove master_incident_id because it is the unique record ID
             column_names_to_upsert.remove("master_incident_id")
             upsert_mutation = UPSERT_CAD_INCIDENTS_MUTATION.replace(
                 "$updateColumns", "\n".join(column_names_to_upsert)

--- a/etl/cad_incidents_import/incidents_import.py
+++ b/etl/cad_incidents_import/incidents_import.py
@@ -109,8 +109,10 @@ def transform_lat_lon(data):
             row["latitude"] = float(lat) / 1000000
 
 
-def prune_columns(data, allowed_columns):
-    """_summary_
+def prune_and_validate_columns(data, allowed_columns):
+    """
+    Removes unknown columns from each record and raises an error if any
+    required columns are missing.
 
     Args:
         data (list): list of cad records
@@ -118,11 +120,21 @@ def prune_columns(data, allowed_columns):
 
     Returns:
         list: data with record dicts containing only allowed columns
+
+    Raises:
+        ValueError: if any record is missing one or more allowed columns
     """
     allowed = set(allowed_columns)
-    return [
-        {key: val for key, val in record.items() if key in allowed} for record in data
-    ]
+    pruned = []
+    for i, record in enumerate(data):
+        record_keys = set(record.keys())
+        missing = allowed - record_keys
+        if missing:
+            raise ValueError(
+                f"Record at index {i} is missing required columns: {sorted(missing)}"
+            )
+        pruned.append({key: val for key, val in record.items() if key in allowed})
+    return pruned
 
 
 def main(args):
@@ -166,7 +178,7 @@ def main(args):
         if columns_to_rename:
             rename_columns(data, columns_to_rename)
 
-        data = prune_columns(data, COLUMNS["allowed_columns"][table_name])
+        data = prune_and_validate_columns(data, COLUMNS["allowed_columns"][table_name])
 
         set_empty_strings_to_none(data)
 

--- a/etl/cad_incidents_import/incidents_to_s3.py
+++ b/etl/cad_incidents_import/incidents_to_s3.py
@@ -23,10 +23,12 @@ def main(args):
 
     files_todo = get_local_files_to_process(dir_name=COACD_MOUNT_PATH)
 
-    if not files_todo:
-        raise Exception("No files found in COACD network directory")
-
     logger.info(f"Found {len(files_todo)} file(s) to process.")
+
+    if not files_todo:
+        if args.no_files_pass:
+            return
+        raise Exception("No files found in COACD network directory")
 
     for file_path in files_todo:
         filename = os.path.basename(file_path)
@@ -62,6 +64,11 @@ if __name__ == "__main__":
         "--remove",
         action="store_true",
         help="Delete the file(s) from the file system processing",
+    )
+    parser.add_argument(
+        "--no-files-pass",
+        action="store_true",
+        help="Don't throw an error if there are no files to process",
     )
     args = parser.parse_args()
 

--- a/etl/cad_incidents_import/utils/columns.py
+++ b/etl/cad_incidents_import/utils/columns.py
@@ -1,5 +1,27 @@
 COLUMNS = {
     "cols_to_rename": {
-        "time_callclosed": "time_call_closed",
+        "cad_incidents": {
+            "time_callclosed": "time_call_closed",
+        },
+    },
+    "allowed_columns": {
+        "cad_incidents": [
+            "address",
+            "agency_type",
+            "call_disposition",
+            "final_problem",
+            "incident_type",
+            "initial_problem",
+            "master_incident_id",
+            "master_incident_number",
+            "priority_description",
+            "priority_number",
+            "response_date",
+            "time_call_closed",
+            "time_first_unit_arrived",
+            "latitude",
+            "longitude",
+        ],
+        "cad_incident_groups": {"master_incident_id", "incident_group_id"},
     },
 }

--- a/etl/cad_incidents_import/utils/columns.py
+++ b/etl/cad_incidents_import/utils/columns.py
@@ -4,7 +4,7 @@ COLUMNS = {
             "time_callclosed": "time_call_closed",
         },
     },
-    "allowed_columns": {
+    "required_columns": {
         "cad_incidents": [
             "address",
             "agency_type",


### PR DESCRIPTION



## Associated issues

* https://github.com/cityofaustin/atd-data-tech/issues/29006

I made the following changes to the script:
- Unknown columns are removed from the data before import
- An error is thrown if any of the expected columns are missing
- The `--no-files-pass` CLI arg is available to `incidents_to_s3.py` and `incidents_import.py` to suppress errors when no files are found to process. This will allow us to more easily recover from a broken state once we [add this flag to the DAG params](https://github.com/cityofaustin/vision-zero/pull/2064).

## Testing

**URL to test:** Local

1. Start your local VZ stack and apply migrations + metadata
2. If you've never run this ETL, follow the CAD incident import ETL readme to get your env file set up.
3. Save each of these files to the `/etl/cad_incidents_import/test_data` directory of your repo

- [TPWCADTrafficSafetyDailyMissingCols_20260617.CSV](https://github.com/user-attachments/files/29213134/TPWCADTrafficSafetyDailyMissingCols_20260617.CSV)
- [TPWCADTrafficSafetyWithGroupIDDailyMissingCols_20260617.CSV](https://github.com/user-attachments/files/29213135/TPWCADTrafficSafetyWithGroupIDDailyMissingCols_20260617.CSV)
- [TPWCADTrafficSafetyWithGroupIDDailyExtraCols_20260617.CSV](https://github.com/user-attachments/files/29213137/TPWCADTrafficSafetyWithGroupIDDailyExtraCols_20260617.CSV)
- [TPWCADTrafficSafetyDailyExtraCols_20260617.CSV](https://github.com/user-attachments/files/29213138/TPWCADTrafficSafetyDailyExtraCols_20260617.CSV)

4. From the `/etl/cad_incidents_import` directory, run `incidents_to_s3.py` as a dry run and confirm that four files would be processed:

```shell
docker compose -f docker-compose.yml -f docker-compose.local.yml run import incidents_to_s3.py --dry-run
```

5. Now attempt a dry run of the incident import with local files. You should hit a **ValueError** due to the import file missing columns.

```shell
docker compose -f docker-compose.yml -f docker-compose.local.yml run import incidents_import.py --dry-run --local-files

# ValueError: Record at index 0 is missing required columns: ['agency_type']%
```

6. Delete `TPWCADTrafficSafetyDailyMissingCols_20260617.CSV` from your `test_data` directory and attempt the ETL again. Confirm that you hit another error due to Group ID file also missing a column:


```shell
docker compose -f docker-compose.yml -f docker-compose.local.yml run import incidents_import.py --dry-run --local-files

# ValueError: Record at index 0 is missing required columns: ['master_incident_id']
```

7. Delete `TPWCADTrafficSafetyWithGroupIDDailyMissingCols_20260617.CSV` from your `test_data` directory and repeat without the dry-run flag. Everything should process without error.

```shell
docker compose -f docker-compose.yml -f docker-compose.local.yml run import incidents_import.py --local-files
```

8. Nice! Now delete all of the CSV files from your `test_data` directory, then run the `incidents_to_s3` script. It should log that zero files were found to process.

```shell
 docker compose -f docker-compose.yml -f docker-compose.local.yml run import incidents_to_s3.py --no-files-pass

# 2026-06-22 15:48:25,786 INFO Found 0 file(s) to process.
```

9. Repeat with `incidents_import.py.

```shell
docker compose -f docker-compose.yml -f docker-compose.local.yml run import incidents_import.py --no-files-pass --local-files

# INFO:root:0 local files to process
```

✅ 👍 
---

#### Ship list

- [ ] Check migrations for any conflicts with latest migrations in `main` branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved
