### PR TITLE
Adds process to link EMS and AFD incidents to VZ incidents

### DIFF
--- a/database/migrations/default/1781725446085_ems_to_vz_incident_links/down.sql
+++ b/database/migrations/default/1781725446085_ems_to_vz_incident_links/down.sql
@@ -1,0 +1,37 @@
+-- revert view changes
+CREATE OR REPLACE VIEW public.vz_incident_records_view AS
+    SELECT
+        c.vz_incident_id,
+        'crash'::text        AS record_type,
+        agency.label         AS record_responding_agency,
+        c.id                 AS record_id,
+        c.case_id            AS record_incident_number,
+        c.crash_timestamp    AS record_timestamp,
+        c.address_display    AS record_address,
+        c.position           AS geom
+    FROM crashes c
+        LEFT JOIN lookups.agency agency on agency.id = c.investigat_agency_id
+    WHERE c.vz_incident_id IS NOT NULL and c.is_deleted is false
+    UNION ALL
+    SELECT
+        ci.vz_incident_id,
+        'cad_incident'::text        AS record_type,
+        ci.agency_type_short        AS record_responding_agency,
+        ci.id                       AS record_id,
+        ci.master_incident_number   AS record_incident_number,
+        ci.response_date            AS record_timestamp,
+        ci.address                  AS record_address,
+        ci.geom                     AS geom
+    FROM cad_incidents ci
+    WHERE ci.vz_incident_id IS NOT NULL;
+
+COMMENT ON VIEW public.vz_incident_records_view IS 'Unified view of records (crashes, cad_incidents) belonging to a vz_incident, exposed under a common schema for cross-type queries and geo-temporal matching.';
+
+DROP TRIGGER IF EXISTS ems__incidents_vz_incident_match_insert_trigger ON public.ems__incidents;
+
+DROP FUNCTION if exists public.ems_match_vz_incident;
+
+ALTER TABLE ems__incidents
+    drop COLUMN vz_incident_id,
+    drop COLUMN vz_incident_match_status,
+    drop COLUMN vz_incident_matched_ids;

--- a/database/migrations/default/1781725446085_ems_to_vz_incident_links/down.sql
+++ b/database/migrations/default/1781725446085_ems_to_vz_incident_links/down.sql
@@ -27,7 +27,7 @@ CREATE OR REPLACE VIEW public.vz_incident_records_view AS
 
 COMMENT ON VIEW public.vz_incident_records_view IS 'Unified view of records (crashes, cad_incidents) belonging to a vz_incident, exposed under a common schema for cross-type queries and geo-temporal matching.';
 
-DROP TRIGGER IF EXISTS ems__incidents_vz_incident_match_insert_trigger ON public.ems__incidents;
+DROP TRIGGER IF EXISTS ems_incidents_trigger_vz_incident_match_insert ON public.ems__incidents;
 
 DROP FUNCTION if exists public.ems_match_vz_incident;
 

--- a/database/migrations/default/1781725446085_ems_to_vz_incident_links/up.sql
+++ b/database/migrations/default/1781725446085_ems_to_vz_incident_links/up.sql
@@ -1,0 +1,174 @@
+ALTER TABLE ems__incidents
+ADD COLUMN vz_incident_id bigint REFERENCES vz_incidents (id),
+ADD COLUMN vz_incident_match_status text NOT NULL DEFAULT 'unprocessed',
+ADD COLUMN vz_incident_matched_ids BIGINT[],
+ADD CONSTRAINT ems__incidents_vz_incident_match_status_check CHECK (
+    vz_incident_match_status IN (
+        'unprocessed',
+        'created_by_automation',
+        'matched_by_automation_case_id',
+        'matched_by_automation_geo_temporal',
+        'multiple_matches_by_automation',
+        'matched_by_manual_qa')
+);
+
+COMMENT ON COLUMN public.ems__incidents.vz_incident_id is 'The vz_incidents foreign key.';
+COMMENT ON COLUMN public.ems__incidents.vz_incident_match_status is 'Indicates the status of automated vz_incident matching.';
+COMMENT ON COLUMN public.ems__incidents.vz_incident_matched_ids is 'Array of vz_incident_id''s to which this ems__incidents was matched.';
+
+CREATE INDEX idx_ems__incidents_vz_incident_id ON ems__incidents(vz_incident_id);
+CREATE INDEX idx_ems__incidents_vz_incident_match_status ON ems__incidents(vz_incident_match_status);
+
+
+CREATE OR REPLACE VIEW public.vz_incident_records_view AS
+    SELECT
+        c.vz_incident_id,
+        'crash'::text        AS record_type,
+        agency.label         AS record_responding_agency,
+        c.id                 AS record_id,
+        c.case_id            AS record_incident_number,
+        c.crash_timestamp    AS record_timestamp,
+        c.address_display    AS record_address,
+        c.position           AS geom
+    FROM crashes c
+        LEFT JOIN lookups.agency agency on agency.id = c.investigat_agency_id
+    WHERE c.vz_incident_id IS NOT NULL and c.is_deleted is false
+    UNION ALL
+    SELECT
+        ci.vz_incident_id,
+        'cad_incident'::text        AS record_type,
+        ci.agency_type_short        AS record_responding_agency,
+        ci.id                       AS record_id,
+        ci.master_incident_number   AS record_incident_number,
+        ci.response_date            AS record_timestamp,
+        ci.address                  AS record_address,
+        ci.geom                     AS geom
+    FROM cad_incidents ci
+    WHERE ci.vz_incident_id IS NOT NULL
+    UNION ALL
+    SELECT
+        ems.vz_incident_id,
+        'ems__incidents'::text           AS record_type,
+        'ems'                            AS record_responding_agency,
+        ems.id                           AS record_id,
+        ems.incident_number              AS record_incident_number,
+        ems.incident_received_datetime   AS record_timestamp,
+        ems.incident_location_address    AS record_address,
+        ems.geometry                     AS geom
+    FROM ems__incidents ems
+    WHERE ems.vz_incident_id IS NOT NULL;
+
+COMMENT ON VIEW public.vz_incident_records_view IS 'Unified view of records (crashes, cad_incidents, ems__incidents) belonging to a vz_incident, exposed under a common schema for cross-type queries and geo-temporal matching.';
+
+
+CREATE OR REPLACE FUNCTION public.ems_match_vz_incident()
+RETURNS trigger
+LANGUAGE plpgsql AS
+$function$
+DECLARE
+    v_vz_incident_id bigint;
+    v_matched_ids bigint[];
+    v_match_count integer;
+    meters_threshold integer := 500;
+    time_threshold interval := '60 minutes';
+BEGIN
+    -- safety check: vz_incident_id should never be non-null
+    IF (NEW.vz_incident_id IS NOT NULL) THEN
+        RETURN NEW;
+    END IF;
+
+    
+    -- First try: exact match APD crashes on case_id
+    raise debug 'Attempting to match incident # %', NEW.incident_number;
+
+    SELECT vz_incident_id
+    INTO v_vz_incident_id
+    FROM cad_incidents
+    WHERE agency_type_short = 'ems'
+    AND master_incident_number = NEW.incident_number
+    LIMIT 1;
+
+    IF v_vz_incident_id IS NOT NULL THEN
+        NEW.vz_incident_id := v_vz_incident_id;
+        NEW.vz_incident_matched_ids := ARRAY[v_vz_incident_id];
+        NEW.vz_incident_match_status := 'matched_by_automation_case_id';
+
+        raise debug 'Matched to VZ incident ID % based on incident # %', v_vz_incident_id, NEW.incident_number;
+        -- no further processing needed
+        RETURN NEW;
+    raise debug 'Incident number match not found';
+    END IF;
+
+
+    -- TODO HAVENTUPDATED HER
+
+    -- Fallback: spatial + temporal proximity (only if we have the data to do it)
+    IF NEW.geometry IS NOT NULL AND NEW.incident_received_datetime IS NOT NULL THEN
+        -- A vz_incident matches if ANY of its member events (crash, cad_incident,
+        -- or ems__incident) is within the spatial + temporal threshold. Query the
+        -- unified vz_incident_records_view and group by vz_incident_id so each
+        -- distinct container is counted once, regardless of member type or count.
+        SELECT count(*), array_agg(v.vz_incident_id)
+        INTO v_match_count, v_matched_ids
+        FROM (
+            SELECT v.vz_incident_id
+            FROM vz_incident_records_view v
+            WHERE v.geom IS NOT NULL
+              AND v.vz_incident_id IS NOT NULL
+              AND v.record_timestamp >= (NEW.incident_received_datetime - time_threshold)
+              AND v.record_timestamp <= (NEW.incident_received_datetime + time_threshold)
+              AND ST_DWithin(v.geom::geography, NEW.geometry::geography, meters_threshold)
+            GROUP BY v.vz_incident_id
+        ) v;
+
+        IF v_match_count > 1 THEN
+            NEW.vz_incident_id := NULL;
+            NEW.vz_incident_matched_ids := v_matched_ids;
+            NEW.vz_incident_match_status := 'multiple_matches_by_automation';
+            raise debug 'Multiple incident matches found';
+
+        ELSIF v_match_count = 1 THEN
+            NEW.vz_incident_id := v_matched_ids[1];
+            NEW.vz_incident_matched_ids := v_matched_ids;
+            NEW.vz_incident_match_status := 'matched_by_automation_geo_temporal';
+            raise debug 'Matched to incident % based on geo/temporal', v_matched_ids[1];
+
+        -- no match found: create a new VZ incident
+        ELSE
+            INSERT INTO vz_incidents (id) VALUES (DEFAULT)
+            RETURNING id INTO v_vz_incident_id;
+            NEW.vz_incident_id := v_vz_incident_id;
+            NEW.vz_incident_matched_ids := NULL;
+            NEW.vz_incident_match_status := 'created_by_automation';
+            raise debug 'No matching incident found. Created incident %', v_vz_incident_id;
+        END IF;
+        -- Done processing
+        RETURN NEW;
+
+    -- Can't match (missing position/timestamp): create a new VZ incident
+    ELSE
+        INSERT INTO vz_incidents (id) VALUES (DEFAULT)
+        RETURNING id INTO v_vz_incident_id;
+        NEW.vz_incident_id := v_vz_incident_id;
+        NEW.vz_incident_matched_ids := NULL;
+        NEW.vz_incident_match_status := 'created_by_automation';
+        raise debug 'Not enough data to match incident. Created incident %', v_vz_incident_id;
+        RETURN NEW;
+    END IF;
+    RETURN NEW;
+END;
+$function$;
+
+comment on function ems_match_vz_incident is 'Function which matches ems__incidents to vz_incidents and creates new vz_incidents when no match can be found.';
+
+--todo: check trigger order
+--todo: check DAG processing order
+-- CREATE OR REPLACE TRIGGER ems__incidents_vz_incident_match_insert_trigger
+--     BEFORE INSERT ON public.ems__incidents
+--     FOR EACH ROW
+--     EXECUTE FUNCTION public.ems_match_vz_incident();
+
+CREATE OR REPLACE TRIGGER ems__incidents_vz_incident_match_insert_trigger
+    BEFORE INSERT OR UPDATE ON public.ems__incidents
+    FOR EACH ROW
+    EXECUTE FUNCTION public.ems_match_vz_incident();

--- a/database/migrations/default/1781725446085_ems_to_vz_incident_links/up.sql
+++ b/database/migrations/default/1781725446085_ems_to_vz_incident_links/up.sql
@@ -6,7 +6,7 @@ ADD CONSTRAINT ems__incidents_vz_incident_match_status_check CHECK (
     vz_incident_match_status IN (
         'unprocessed',
         'created_by_automation',
-        'matched_by_automation_case_id',
+        'matched_by_automation_incident_number',
         'matched_by_automation_geo_temporal',
         'multiple_matches_by_automation',
         'matched_by_manual_qa')
@@ -78,7 +78,7 @@ BEGIN
     END IF;
 
     
-    -- First try: exact match APD crashes on case_id
+    -- First try: exact match on incident number
     raise debug 'Attempting to match incident # %', NEW.incident_number;
 
     SELECT vz_incident_id
@@ -91,16 +91,13 @@ BEGIN
     IF v_vz_incident_id IS NOT NULL THEN
         NEW.vz_incident_id := v_vz_incident_id;
         NEW.vz_incident_matched_ids := ARRAY[v_vz_incident_id];
-        NEW.vz_incident_match_status := 'matched_by_automation_case_id';
+        NEW.vz_incident_match_status := 'matched_by_automation_incident_number';
 
         raise debug 'Matched to VZ incident ID % based on incident # %', v_vz_incident_id, NEW.incident_number;
         -- no further processing needed
         RETURN NEW;
     raise debug 'Incident number match not found';
     END IF;
-
-
-    -- TODO HAVENTUPDATED HER
 
     -- Fallback: spatial + temporal proximity (only if we have the data to do it)
     IF NEW.geometry IS NOT NULL AND NEW.incident_received_datetime IS NOT NULL THEN
@@ -132,7 +129,7 @@ BEGIN
             NEW.vz_incident_matched_ids := v_matched_ids;
             NEW.vz_incident_match_status := 'matched_by_automation_geo_temporal';
             raise debug 'Matched to incident % based on geo/temporal', v_matched_ids[1];
-
+ 
         -- no match found: create a new VZ incident
         ELSE
             INSERT INTO vz_incidents (id) VALUES (DEFAULT)

--- a/database/migrations/default/1781725446085_ems_to_vz_incident_links/up.sql
+++ b/database/migrations/default/1781725446085_ems_to_vz_incident_links/up.sql
@@ -158,14 +158,7 @@ $function$;
 
 comment on function ems_match_vz_incident is 'Function which matches ems__incidents to vz_incidents and creates new vz_incidents when no match can be found.';
 
---todo: check trigger order
---todo: check DAG processing order
--- CREATE OR REPLACE TRIGGER ems__incidents_vz_incident_match_insert_trigger
---     BEFORE INSERT ON public.ems__incidents
---     FOR EACH ROW
---     EXECUTE FUNCTION public.ems_match_vz_incident();
-
-CREATE OR REPLACE TRIGGER ems__incidents_vz_incident_match_insert_trigger
-    BEFORE INSERT OR UPDATE ON public.ems__incidents
+CREATE OR REPLACE TRIGGER ems_incidents_trigger_vz_incident_match_insert
+    BEFORE INSERT ON public.ems__incidents
     FOR EACH ROW
     EXECUTE FUNCTION public.ems_match_vz_incident();

--- a/database/migrations/default/1781725446086_afd_to_vz_incident_links/down.sql
+++ b/database/migrations/default/1781725446086_afd_to_vz_incident_links/down.sql
@@ -39,7 +39,7 @@ CREATE OR REPLACE VIEW public.vz_incident_records_view AS
 
 COMMENT ON VIEW public.vz_incident_records_view IS 'Unified view of records (crashes, cad_incidents, ems__incidents) belonging to a vz_incident, exposed under a common schema for cross-type queries and geo-temporal matching.';
 
-DROP TRIGGER IF EXISTS afd__incidents_vz_incident_match_insert_trigger ON public.afd__incidents;
+DROP TRIGGER IF EXISTS afd_incidents_trigger_vz_incident_match_insert ON public.afd__incidents;
 
 DROP FUNCTION if exists public.afd_match_vz_incident;
 

--- a/database/migrations/default/1781725446086_afd_to_vz_incident_links/down.sql
+++ b/database/migrations/default/1781725446086_afd_to_vz_incident_links/down.sql
@@ -1,0 +1,49 @@
+-- revert view changes
+CREATE OR REPLACE VIEW public.vz_incident_records_view AS
+    SELECT
+        c.vz_incident_id,
+        'crash'::text        AS record_type,
+        agency.label         AS record_responding_agency,
+        c.id                 AS record_id,
+        c.case_id            AS record_incident_number,
+        c.crash_timestamp    AS record_timestamp,
+        c.address_display    AS record_address,
+        c.position           AS geom
+    FROM crashes c
+        LEFT JOIN lookups.agency agency on agency.id = c.investigat_agency_id
+    WHERE c.vz_incident_id IS NOT NULL and c.is_deleted is false
+    UNION ALL
+    SELECT
+        ci.vz_incident_id,
+        'cad_incident'::text        AS record_type,
+        ci.agency_type_short        AS record_responding_agency,
+        ci.id                       AS record_id,
+        ci.master_incident_number   AS record_incident_number,
+        ci.response_date            AS record_timestamp,
+        ci.address                  AS record_address,
+        ci.geom                     AS geom
+    FROM cad_incidents ci
+    WHERE ci.vz_incident_id IS NOT NULL
+    UNION ALL
+    SELECT
+        ems.vz_incident_id,
+        'ems__incidents'::text           AS record_type,
+        'ems'                            AS record_responding_agency,
+        ems.id                           AS record_id,
+        ems.incident_number              AS record_incident_number,
+        ems.incident_received_datetime   AS record_timestamp,
+        ems.incident_location_address    AS record_address,
+        ems.geometry                     AS geom
+    FROM ems__incidents ems
+    WHERE ems.vz_incident_id IS NOT NULL;
+
+COMMENT ON VIEW public.vz_incident_records_view IS 'Unified view of records (crashes, cad_incidents, ems__incidents) belonging to a vz_incident, exposed under a common schema for cross-type queries and geo-temporal matching.';
+
+DROP TRIGGER IF EXISTS afd__incidents_vz_incident_match_insert_trigger ON public.afd__incidents;
+
+DROP FUNCTION if exists public.afd_match_vz_incident;
+
+ALTER TABLE afd__incidents
+    drop COLUMN vz_incident_id,
+    drop COLUMN vz_incident_match_status,
+    drop COLUMN vz_incident_matched_ids;

--- a/database/migrations/default/1781725446086_afd_to_vz_incident_links/up.sql
+++ b/database/migrations/default/1781725446086_afd_to_vz_incident_links/up.sql
@@ -1,0 +1,183 @@
+ALTER TABLE afd__incidents
+ADD COLUMN vz_incident_id bigint REFERENCES vz_incidents (id),
+ADD COLUMN vz_incident_match_status text NOT NULL DEFAULT 'unprocessed',
+ADD COLUMN vz_incident_matched_ids BIGINT[],
+ADD CONSTRAINT afd__incidents_vz_incident_match_status_check CHECK (
+    vz_incident_match_status IN (
+        'unprocessed',
+        'created_by_automation',
+        'matched_by_automation_incident_number',
+        'matched_by_automation_geo_temporal',
+        'multiple_matches_by_automation',
+        'matched_by_manual_qa')
+);
+
+COMMENT ON COLUMN public.afd__incidents.vz_incident_id is 'The vz_incidents foreign key.';
+COMMENT ON COLUMN public.afd__incidents.vz_incident_match_status is 'Indicates the status of automated vz_incident matching.';
+COMMENT ON COLUMN public.afd__incidents.vz_incident_matched_ids is 'Array of vz_incident_id''s to which this afd__incidents was matched.';
+
+CREATE INDEX idx_afd__incidents_vz_incident_id ON afd__incidents(vz_incident_id);
+CREATE INDEX idx_afd__incidents_vz_incident_match_status ON afd__incidents(vz_incident_match_status);
+
+
+CREATE OR REPLACE VIEW public.vz_incident_records_view AS
+    SELECT
+        c.vz_incident_id,
+        'crash'::text        AS record_type,
+        agency.label         AS record_responding_agency,
+        c.id                 AS record_id,
+        c.case_id            AS record_incident_number,
+        c.crash_timestamp    AS record_timestamp,
+        c.address_display    AS record_address,
+        c.position           AS geom
+    FROM crashes c
+        LEFT JOIN lookups.agency agency on agency.id = c.investigat_agency_id
+    WHERE c.vz_incident_id IS NOT NULL and c.is_deleted is false
+    UNION ALL
+    SELECT
+        ci.vz_incident_id,
+        'cad_incident'::text        AS record_type,
+        ci.agency_type_short        AS record_responding_agency,
+        ci.id                       AS record_id,
+        ci.master_incident_number   AS record_incident_number,
+        ci.response_date            AS record_timestamp,
+        ci.address                  AS record_address,
+        ci.geom                     AS geom
+    FROM cad_incidents ci
+    WHERE ci.vz_incident_id IS NOT NULL
+    UNION ALL
+    SELECT
+        ems.vz_incident_id,
+        'ems__incidents'::text           AS record_type,
+        'ems'                            AS record_responding_agency,
+        ems.id                           AS record_id,
+        ems.incident_number              AS record_incident_number,
+        ems.incident_received_datetime   AS record_timestamp,
+        ems.incident_location_address    AS record_address,
+        ems.geometry                     AS geom
+    FROM ems__incidents ems
+    WHERE ems.vz_incident_id IS NOT NULL
+    UNION ALL
+    SELECT
+        afd.vz_incident_id,
+        'afd__incidents'::text           AS record_type,
+        'afd'                            AS record_responding_agency,
+        afd.id                           AS record_id,
+        afd.incident_number::text        AS record_incident_number,
+        afd.call_datetime                AS record_timestamp,
+        afd.address                      AS record_address,
+        afd.geometry                     AS geom
+    FROM afd__incidents afd
+    WHERE afd.vz_incident_id IS NOT NULL;
+
+COMMENT ON VIEW public.vz_incident_records_view IS 'Unified view of records (crashes, cad_incidents, ems__incidents, afd__incidents) belonging to a vz_incident, exposed under a common schema for cross-type queries and geo-temporal matching.';
+
+
+CREATE OR REPLACE FUNCTION public.afd_match_vz_incident()
+RETURNS trigger
+LANGUAGE plpgsql AS
+$function$
+DECLARE
+    v_vz_incident_id bigint;
+    v_matched_ids bigint[];
+    v_match_count integer;
+    meters_threshold integer := 500;
+    time_threshold interval := '60 minutes';
+BEGIN
+    -- safety check: vz_incident_id should never be non-null
+    IF (NEW.vz_incident_id IS NOT NULL) THEN
+        RETURN NEW;
+    END IF;
+
+    
+    -- First try: exact match on matched_by_automation_incident_number
+    raise debug 'Attempting to match incident # %', NEW.incident_number;
+
+    SELECT vz_incident_id
+    INTO v_vz_incident_id
+    FROM cad_incidents
+    WHERE agency_type_short = 'ems'
+    AND master_incident_number = NEW.incident_number::text
+    LIMIT 1;
+
+    IF v_vz_incident_id IS NOT NULL THEN
+        NEW.vz_incident_id := v_vz_incident_id;
+        NEW.vz_incident_matched_ids := ARRAY[v_vz_incident_id];
+        NEW.vz_incident_match_status := 'matched_by_automation_incident_number';
+
+        raise debug 'Matched to VZ incident ID % based on incident # %', v_vz_incident_id, NEW.incident_number;
+        -- no further processing needed
+        RETURN NEW;
+    raise debug 'Incident number match not found';
+    END IF;
+
+    -- Fallback: spatial + temporal proximity (only if we have the data to do it)
+    IF NEW.geometry IS NOT NULL AND NEW.call_datetime IS NOT NULL THEN
+        -- A vz_incident matches if ANY of its member events (crash, cad_incident,
+        -- or ems__incident, afd__incident) is within the spatial + temporal threshold. Query the
+        -- unified vz_incident_records_view and group by vz_incident_id so each
+        -- distinct container is counted once, regardless of member type or count.
+        SELECT count(*), array_agg(v.vz_incident_id)
+        INTO v_match_count, v_matched_ids
+        FROM (
+            SELECT v.vz_incident_id
+            FROM vz_incident_records_view v
+            WHERE v.geom IS NOT NULL
+              AND v.vz_incident_id IS NOT NULL
+              AND v.record_timestamp >= (NEW.call_datetime - time_threshold)
+              AND v.record_timestamp <= (NEW.call_datetime + time_threshold)
+              AND ST_DWithin(v.geom::geography, NEW.geometry::geography, meters_threshold)
+            GROUP BY v.vz_incident_id
+        ) v;
+
+        IF v_match_count > 1 THEN
+            NEW.vz_incident_id := NULL;
+            NEW.vz_incident_matched_ids := v_matched_ids;
+            NEW.vz_incident_match_status := 'multiple_matches_by_automation';
+            raise debug 'Multiple incident matches found';
+
+        ELSIF v_match_count = 1 THEN
+            NEW.vz_incident_id := v_matched_ids[1];
+            NEW.vz_incident_matched_ids := v_matched_ids;
+            NEW.vz_incident_match_status := 'matched_by_automation_geo_temporal';
+            raise debug 'Matched to incident % based on geo/temporal', v_matched_ids[1];
+
+        -- no match found: create a new VZ incident
+        ELSE
+            INSERT INTO vz_incidents (id) VALUES (DEFAULT)
+            RETURNING id INTO v_vz_incident_id;
+            NEW.vz_incident_id := v_vz_incident_id;
+            NEW.vz_incident_matched_ids := NULL;
+            NEW.vz_incident_match_status := 'created_by_automation';
+            raise debug 'No matching incident found. Created incident %', v_vz_incident_id;
+        END IF;
+        -- Done processing
+        RETURN NEW;
+
+    -- Can't match (missing position/timestamp): create a new VZ incident
+    ELSE
+        INSERT INTO vz_incidents (id) VALUES (DEFAULT)
+        RETURNING id INTO v_vz_incident_id;
+        NEW.vz_incident_id := v_vz_incident_id;
+        NEW.vz_incident_matched_ids := NULL;
+        NEW.vz_incident_match_status := 'created_by_automation';
+        raise debug 'Not enough data to match incident. Created incident %', v_vz_incident_id;
+        RETURN NEW;
+    END IF;
+    RETURN NEW;
+END;
+$function$;
+
+comment on function afd_match_vz_incident is 'Function which matches afd__incidents to vz_incidents and creates new vz_incidents when no match can be found.';
+
+--todo: check trigger order
+--todo: check DAG processing order
+-- CREATE OR REPLACE TRIGGER afd__incidents_vz_incident_match_insert_trigger
+--     BEFORE INSERT ON public.afd__incidents
+--     FOR EACH ROW
+--     EXECUTE FUNCTION public.afd_match_vz_incident();
+
+CREATE OR REPLACE TRIGGER afd__incidents_vz_incident_match_insert_trigger
+    BEFORE INSERT OR UPDATE ON public.afd__incidents
+    FOR EACH ROW
+    EXECUTE FUNCTION public.afd_match_vz_incident();

--- a/database/migrations/default/1781725446086_afd_to_vz_incident_links/up.sql
+++ b/database/migrations/default/1781725446086_afd_to_vz_incident_links/up.sql
@@ -96,7 +96,7 @@ BEGIN
     SELECT vz_incident_id
     INTO v_vz_incident_id
     FROM cad_incidents
-    WHERE agency_type_short = 'ems'
+    WHERE agency_type_short = 'afd'
     AND master_incident_number = NEW.incident_number::text
     LIMIT 1;
 
@@ -170,14 +170,7 @@ $function$;
 
 comment on function afd_match_vz_incident is 'Function which matches afd__incidents to vz_incidents and creates new vz_incidents when no match can be found.';
 
---todo: check trigger order
---todo: check DAG processing order
--- CREATE OR REPLACE TRIGGER afd__incidents_vz_incident_match_insert_trigger
---     BEFORE INSERT ON public.afd__incidents
---     FOR EACH ROW
---     EXECUTE FUNCTION public.afd_match_vz_incident();
-
-CREATE OR REPLACE TRIGGER afd__incidents_vz_incident_match_insert_trigger
-    BEFORE INSERT OR UPDATE ON public.afd__incidents
+CREATE OR REPLACE TRIGGER afd_incidents_trigger_vz_incident_match_insert
+    BEFORE INSERT ON public.afd__incidents
     FOR EACH ROW
     EXECUTE FUNCTION public.afd_match_vz_incident();

--- a/database/views/vz_incident_records_view.sql
+++ b/database/views/vz_incident_records_view.sql
@@ -1,4 +1,4 @@
--- Most recent migration: database/migrations/default/1781725446085_ems_to_vz_incident_links/up.sql
+-- Most recent migration: database/migrations/default/1781725446086_afd_to_vz_incident_links/up.sql
 
 CREATE OR REPLACE VIEW vz_incident_records_view AS
 SELECT
@@ -36,4 +36,16 @@ SELECT
     ems.incident_location_address  AS record_address,
     ems.geometry                   AS geom
 FROM ems__incidents ems
-WHERE ems.vz_incident_id IS NOT NULL;
+WHERE ems.vz_incident_id IS NOT NULL
+UNION ALL
+SELECT
+    afd.vz_incident_id,
+    'afd__incidents'::text    AS record_type,
+    'afd'::text               AS record_responding_agency,
+    afd.id                    AS record_id,
+    afd.incident_number::text AS record_incident_number,
+    afd.call_datetime         AS record_timestamp,
+    afd.address               AS record_address,
+    afd.geometry              AS geom
+FROM afd__incidents afd
+WHERE afd.vz_incident_id IS NOT NULL;

--- a/database/views/vz_incident_records_view.sql
+++ b/database/views/vz_incident_records_view.sql
@@ -1,4 +1,4 @@
--- Most recent migration: database/migrations/default/1781537795232_crashes_incident_link/up.sql
+-- Most recent migration: database/migrations/default/1781725446085_ems_to_vz_incident_links/up.sql
 
 CREATE OR REPLACE VIEW vz_incident_records_view AS
 SELECT
@@ -24,4 +24,16 @@ SELECT
     ci.address                AS record_address,
     ci.geom
 FROM cad_incidents ci
-WHERE ci.vz_incident_id IS NOT NULL;
+WHERE ci.vz_incident_id IS NOT NULL
+UNION ALL
+SELECT
+    ems.vz_incident_id,
+    'ems__incidents'::text         AS record_type,
+    'ems'::text                    AS record_responding_agency,
+    ems.id                         AS record_id,
+    ems.incident_number            AS record_incident_number,
+    ems.incident_received_datetime AS record_timestamp,
+    ems.incident_location_address  AS record_address,
+    ems.geometry                   AS geom
+FROM ems__incidents ems
+WHERE ems.vz_incident_id IS NOT NULL;


### PR DESCRIPTION
## Associated issues

* https://github.com/cityofaustin/atd-data-tech/issues/28997


## Testing

**URL to test:** 🏚️ Local

1. Replicate your DB if you haven't done so since June 15th. This ensures you have existing VZ incidents in your DB
2. Apply migrations and metadata

4. Use your SQL client to enable debug logging, then execute the following tests cases to see how the trigger is working.

``` sql
-- enable debug logging
SET client_min_messages = 'DEBUG';
```


### EMS

1. Creates a new VZ incident - No matching record found

```sql
INSERT INTO
    ems__incidents (pcr_key, incident_number, incident_location_address, incident_received_datetime, latitude, longitude)
VALUES
    (999990, '0001', '123 Fake St', '2000-01-06T00:00:00', 0, 0);
```

> DEBUG:  No matching incident found. Created incident <number>

2. EMS incident matches to VZ incident based on incident number

```sql
INSERT INTO
    ems__incidents (pcr_key, incident_number, incident_location_address, incident_received_datetime, latitude, longitude)
VALUES
    (999991, '26163-0156', 'Ed Bluestein', '2000-01-06T00:00:00', 0, 0);
```

> DEBUG:  Matched to VZ incident ID 329115 based on incident # 26163-0156


3. EMS incident matched based on approximate time and location


```sql
INSERT INTO
    ems__incidents (pcr_key, incident_number, incident_location_address, incident_received_datetime, latitude, longitude)
VALUES
    (999992, '999992', '10300-10323 S Ih 35 Svrd Nb', '2026-06-11 04:43:49+00', 30.1505771, -97.791789);
```

> DEBUG:  Matched to incident 53958 based on geo/temporal


4. EMS incident which matches multiple existing incidents


```sql
INSERT INTO
    ems__incidents (pcr_key, incident_number, incident_location_address, incident_received_datetime, latitude, longitude)
VALUES
    (999994, '999994', '510 W 10TH ST TEST', '2026-06-05 19:35:34+00',  30.273252, -97.746581);
```

> DEBUG:  Multiple incident matches found


5. Query the `vz_incident_records_view` to see `vz_incidents` associated with an ems__incidents record. 

```sql
WITH
    start_ids AS ( SELECT vz_incident_id FROM ems__incidents WHERE vz_incident_id IS NOT NULL
    )
    SELECT * FROM start_ids ids INNER JOIN vz_incident_records_view v ON ids.vz_incident_id = v.vz_incident_id order by v.vz_incident_id desc;
```

### AFD incidents


1. Creates a new VZ incident - No matching record found

```sql
insert into afd__incidents (incident_number, address, call_datetime, latitude, longitude)
values (99999991, 'Fake', '2000-01-06T00:00:00', 50, 50);
```

> DEBUG:  No matching incident found. Created incident <number>

2. AFD incident matches to VZ incident based on incident number

```sql
insert into afd__incidents (incident_number, address, call_datetime, latitude, longitude)
values (16039721, 'Fake', '2000-01-06T00:00:00', 0, 0);
```

DEBUG:  Matched to VZ incident ID 379003 based on incident # 16039721


3. AFD incident matched based on approximate time and location


```sql
insert into afd__incidents (incident_number, address, call_datetime, latitude, longitude)
values (99999993, 'Fake #2', '2026-06-11 04:43:49+00',  30.1505771, -97.791789);
```

> DEBUG:  Matched to incident <number> based on geo/temporal


4. AFD incident which matches multiple existing incidents


```sql
-- set the time and location of incidents we created in earlier to be the same, which will 
-- cause their VZ incidents to have overlapping time/geometries
update afd__incidents set latitude = 0, longitude = 0, call_datetime = '2000-01-06T00:00:00' where incident_number >= 99999990;

-- insert a new incident that will match the previous incidents we created
insert into afd__incidents (incident_number, address, call_datetime, latitude, longitude)
values (99999994, 'Fake - again', '2000-01-06T00:00:00', 0, 0);
```

> DEBUG:  Multiple incident matches found


5. Query the `vz_incident_records_view` to see `vz_incidents` associated with an afd__incidents record. 

```sql
WITH
    start_ids AS ( SELECT vz_incident_id FROM afd__incidents WHERE vz_incident_id IS NOT NULL
    )
    SELECT * FROM start_ids ids INNER JOIN vz_incident_records_view v ON ids.vz_incident_id = v.vz_incident_id order by v.vz_incident_id desc;
```

### Wrap up

Run the down migrations


```
hasura migrate apply --down 2
```


## Before merge

- Update Airflow DAGs to ensure that CAD incidents are processed before EMS incidents

---

#### Ship list

- [ ] Check migrations for any conflicts with latest migrations in `main` branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved
