### PR TITLE
Add person transport fields to people table on crash details page

### DIFF
--- a/editor/configs/peopleColumns.tsx
+++ b/editor/configs/peopleColumns.tsx
@@ -91,6 +91,8 @@ export const ALL_PEOPLE_COLUMNS = {
     path: "prsn_taken_to",
     label: "Transported to",
     sortable: true,
+    defaultHidden: true,
+    editable: false,
   },
   gndr: {
     path: "gndr.label",

--- a/editor/configs/peopleColumns.tsx
+++ b/editor/configs/peopleColumns.tsx
@@ -94,6 +94,12 @@ export const ALL_PEOPLE_COLUMNS = {
     defaultHidden: true,
     editable: false,
   },
+  prsn_taken_by: {
+    path: "prsn_taken_by",
+    label: "Transported by",
+    defaultHidden: true,
+    editable: false
+  },
   gndr: {
     path: "gndr.label",
     label: "Sex",

--- a/editor/configs/peopleColumns.tsx
+++ b/editor/configs/peopleColumns.tsx
@@ -91,7 +91,6 @@ export const ALL_PEOPLE_COLUMNS = {
     path: "prsn_taken_to",
     label: "Transported to",
     sortable: true,
-    defaultHidden: true,
     editable: false,
   },
   prsn_taken_by: {

--- a/editor/configs/peopleRelatedRecordTable.ts
+++ b/editor/configs/peopleRelatedRecordTable.ts
@@ -6,6 +6,7 @@ export const peopleRelatedRecordCols = [
   ALL_PEOPLE_COLUMNS.injry_sev,
   ALL_PEOPLE_COLUMNS.prsn_type,
   ALL_PEOPLE_COLUMNS.occpnt_pos,
+  ALL_PEOPLE_COLUMNS.prsn_taken_by,
   ALL_PEOPLE_COLUMNS.prsn_taken_to,
   ALL_PEOPLE_COLUMNS.prsn_age,
   ALL_PEOPLE_COLUMNS.gndr,

--- a/editor/configs/peopleRelatedRecordTable.ts
+++ b/editor/configs/peopleRelatedRecordTable.ts
@@ -6,6 +6,7 @@ export const peopleRelatedRecordCols = [
   ALL_PEOPLE_COLUMNS.injry_sev,
   ALL_PEOPLE_COLUMNS.prsn_type,
   ALL_PEOPLE_COLUMNS.occpnt_pos,
+  ALL_PEOPLE_COLUMNS.prsn_taken_to,
   ALL_PEOPLE_COLUMNS.prsn_age,
   ALL_PEOPLE_COLUMNS.gndr,
   ALL_PEOPLE_COLUMNS.drvr_ethncty,

--- a/editor/queries/crash.ts
+++ b/editor/queries/crash.ts
@@ -210,6 +210,8 @@ export const GET_CRASH = gql`
         prsn_last_name
         prsn_injry_sev_id
         prsn_rest_id
+        prsn_taken_to
+        prsn_taken_by
         rest {
           id
           label

--- a/editor/types/peopleList.ts
+++ b/editor/types/peopleList.ts
@@ -23,6 +23,7 @@ export type PeopleListRow = {
   prsn_mid_name: string | null;
   prsn_nbr?: number | null;
   prsn_taken_to?: string | null;
+  prsn_taken_by?: string | null;
   prsn_type?: LookupTableOption;
   prsn_type_id: number | null;
   unit_nbr: number;


### PR DESCRIPTION
## Associated issues

https://github.com/cityofaustin/atd-data-tech/issues/29087

## Testing

**URL to test:**

you *could* use the deploy preview (https://deploy-preview-2069--vze-staging.netlify.app/editor/crashes) to see the columns, but if you want to see infomation in them, you'll have more luck running locally. 

**Steps to test:**

Here is a crash record with information in the Transported By and Transported To columns http://localhost:3002/editor/crashes/21386826 (shift + p to get right to the people table)

Transported By is hidden by default, use the column visibility menu to unhide. 

Confirm that you cannot edit either column. 

---

#### Ship list

- [ ] Check migrations for any conflicts with latest migrations in `main` branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved
