### PR TITLE
Adds duplicate row handling to CAD incident import

### DIFF
--- a/database/migrations/default/1783347751352_cad_record_insert_timestamp/down.sql
+++ b/database/migrations/default/1783347751352_cad_record_insert_timestamp/down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE cad_incidents
+DROP COLUMN upstream_record_update_timestamp;

--- a/database/migrations/default/1783347751352_cad_record_insert_timestamp/up.sql
+++ b/database/migrations/default/1783347751352_cad_record_insert_timestamp/up.sql
@@ -1,0 +1,9 @@
+ALTER TABLE cad_incidents
+ADD COLUMN upstream_record_update_timestamp timestamptz;
+
+COMMENT ON COLUMN public.cad_incidents.upstream_record_update_timestamp is 
+    'The timestamp at which this record was last updated in the upstream data warehouse'
+    ' from which CAD incidents are sourced. This field is known as the `Record_Insert_Timestamp`'
+    ' in the ATS public safety data warehouse and is used to distinguish between the presence'
+    ' of multiple versions of the same record in daily extract files.'
+    ' See https://github.com/cityofaustin/atd-data-tech/issues/29125.';

--- a/etl/cad_incidents_import/incidents_import.py
+++ b/etl/cad_incidents_import/incidents_import.py
@@ -62,7 +62,7 @@ def make_fields_timezone_aware(
     data, date_field_names, date_format="%Y-%m-%d %H:%M:%S", tz="America/Chicago"
 ):
     """Update a field to be timezone aware by replacing the input value with a ISO string with a
-    tz offset
+    tz offset. The CAD data we receive are in America/Chicago time.
 
     Args:
         data (list): list of incident dicts

--- a/etl/cad_incidents_import/incidents_import.py
+++ b/etl/cad_incidents_import/incidents_import.py
@@ -137,9 +137,6 @@ def prune_and_validate_columns(data, required_columns):
     return pruned
 
 
-from datetime import datetime
-
-
 def dedupe_records_by_timestamp(
     data,
     key_field="master_incident_id",

--- a/etl/cad_incidents_import/incidents_import.py
+++ b/etl/cad_incidents_import/incidents_import.py
@@ -137,6 +137,51 @@ def prune_and_validate_columns(data, required_columns):
     return pruned
 
 
+from datetime import datetime
+
+
+def dedupe_records_by_timestamp(
+    data,
+    key_field="master_incident_id",
+    timestamp_field="upstream_record_update_timestamp",
+):
+    """Dedupe incident records with the same `master_incident_id` value.
+
+    It occasionally happens that CAD records are duplicated in our daily extract due to a bug
+    in the upstream data warehouse. This function identifies dupes based on `master_incident_id`
+    and selects the most recent record version based on the `upstream_record_update_timestamp`.
+
+    If dupe records have an identical timestamp, the first record encountered in the list is
+    preserved.
+
+    See https://github.com/cityofaustin/atd-data-tech/issues/29125.
+
+    Args:
+        data (list): List of CAD incident records
+        key_field (str, optional): The record key used to identify dupes. Defaults to
+            "master_incident_id".
+        timestamp_field (str, optional): The timestamp field to select the correct record version.
+            Defaults to "upstream_record_update_timestamp".
+
+    Returns:
+        list(dict): The de-duped list of CAD incident records.
+    """
+    latest = {}
+    for row in data:
+        key = row[key_field]
+        if key not in latest:
+            latest[key] = row
+        else:
+            # Dupe found - compare timestamps and replace with latest if needed
+            logging.info(f"Deduping record with master incident ID: {key}")
+            current_ts = datetime.fromisoformat(row[timestamp_field])
+            existing_ts = datetime.fromisoformat(latest[key][timestamp_field])
+            if current_ts > existing_ts:
+                latest[key] = row
+
+    return list(latest.values())
+
+
 def main(args):
     logging.info(f"Running CAD incident import")
 
@@ -192,8 +237,10 @@ def main(args):
                     "response_date",
                     "time_call_closed",
                     "time_first_unit_arrived",
+                    "upstream_record_update_timestamp",
                 ],
             )
+            data = dedupe_records_by_timestamp(data)
 
         if not is_group_id_file:
             # add update column names to the muation "on conflict" directive

--- a/etl/cad_incidents_import/utils/columns.py
+++ b/etl/cad_incidents_import/utils/columns.py
@@ -2,6 +2,7 @@ COLUMNS = {
     "cols_to_rename": {
         "cad_incidents": {
             "time_callclosed": "time_call_closed",
+            "record_insert_timestamp": "upstream_record_update_timestamp"
         },
     },
     "required_columns": {
@@ -12,6 +13,8 @@ COLUMNS = {
             "final_problem",
             "incident_type",
             "initial_problem",
+            "latitude",
+            "longitude",
             "master_incident_id",
             "master_incident_number",
             "priority_description",
@@ -19,8 +22,7 @@ COLUMNS = {
             "response_date",
             "time_call_closed",
             "time_first_unit_arrived",
-            "latitude",
-            "longitude",
+            "upstream_record_update_timestamp"
         ],
         "cad_incident_groups": {"master_incident_id", "incident_group_id"},
     },


### PR DESCRIPTION
## Associated issues

* https://github.com/cityofaustin/atd-data-tech/issues/29125

## Testing

**URL to test:** Local

1. Start your VZ stack and apply migrations and metadata from the `./database` directory.
2. Navigate to the `./etl/cad_incidents_import` directory. If you've never run this ETL before, follow the README to set up your env and build the image.
3. Run the incident import ETL, which will pick up a crufty test file we have in the `dev` S3 inbox.

```shell
docker compose -f docker-compose.yml -f docker-compose.local.yml run import incidents_import.py
```

The import should run without error, and the logs should print a message about deduping incident ID `42517033`:


```
INFO:root:Running CAD incident import
INFO:root:Getting list of files in S3 inbox
INFO:root:2 S3 files to process
INFO:root:Downloading: dev/cad_incidents/inbox/TPWCADTrafficSafetyDaily_20260702.CSV
INFO:root:Deduping record with master incident ID: 42517033
INFO:root:699 total records to upsert
INFO:root:Upserting 699 rows...
INFO:root:Downloading: dev/cad_incidents/inbox/TPWCADTrafficSafetyWithGroupIDDaily_20260702.CSV
INFO:root:555 total records to upsert
INFO:root:Upserting 555 rows...
```

4. Use your SQL client to verify that 699 records have the new `upstream_record_update` column populated

```sql
SELECT
    master_incident_id,
    upstream_record_update_timestamp
FROM
    cad_incidents
WHERE
    upstream_record_update_timestamp IS NOT NULL;
``` 

5. From the `./database` directory, run the down migration

```shell
hasura migrate apply --down 1
```

---

#### Ship list

- [ ] Check migrations for any conflicts with latest migrations in `main` branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved
