### PR TITLE
Add weather and road surface condition fields to crash details and fatality details pages

### DIFF
--- a/database/metadata/databases/default/tables/lookups_surf_cond.yaml
+++ b/database/metadata/databases/default/tables/lookups_surf_cond.yaml
@@ -16,3 +16,28 @@ array_relationships:
         table:
           name: crashes
           schema: public
+select_permissions:
+  - role: editor
+    permission:
+      columns:
+        - id
+        - label
+        - source
+      filter: {}
+    comment: ""
+  - role: readonly
+    permission:
+      columns:
+        - id
+        - label
+        - source
+      filter: {}
+    comment: ""
+  - role: vz-admin
+    permission:
+      columns:
+        - id
+        - label
+        - source
+      filter: {}
+    comment: ""

--- a/database/metadata/databases/default/tables/public_crashes.yaml
+++ b/database/metadata/databases/default/tables/public_crashes.yaml
@@ -60,6 +60,9 @@ object_relationships:
   - name: rwy_sys_sec
     using:
       foreign_key_constraint_on: rpt_sec_rdwy_sys_id
+  - name: surf_cond
+    using:
+      foreign_key_constraint_on: surf_cond_id
   - name: traffic_cntl
     using:
       foreign_key_constraint_on: traffic_cntl_id

--- a/editor/app/fatalities/[record_locator]/page.tsx
+++ b/editor/app/fatalities/[record_locator]/page.tsx
@@ -28,6 +28,7 @@ const otherCardColumns = [
   crashesColumns.law_enforcement_ytd_fatality_num,
   crashesColumns.light_cond,
   crashesColumns.wthr_cond,
+  crashesColumns.surf_cond,
   crashesColumns.crash_speed_limit,
   crashesColumns.obj_struck,
 ];

--- a/editor/app/fatalities/[record_locator]/page.tsx
+++ b/editor/app/fatalities/[record_locator]/page.tsx
@@ -27,6 +27,7 @@ const otherCardColumns = [
   crashesColumns.case_id,
   crashesColumns.law_enforcement_ytd_fatality_num,
   crashesColumns.light_cond,
+  crashesColumns.wthr_cond,
   crashesColumns.crash_speed_limit,
   crashesColumns.obj_struck,
 ];

--- a/editor/configs/crashDataCard.ts
+++ b/editor/configs/crashDataCard.ts
@@ -23,6 +23,7 @@ export const crashDataCards = {
   other: [
     crashesColumns.light_cond,
     crashesColumns.wthr_cond,
+    crashesColumns.surf_cond,
     crashesColumns.crash_speed_limit,
     crashesColumns.obj_struck,
     crashesColumns.law_enforcement_ytd_fatality_num,

--- a/editor/configs/crashDataCard.ts
+++ b/editor/configs/crashDataCard.ts
@@ -22,6 +22,7 @@ export const crashDataCards = {
   ],
   other: [
     crashesColumns.light_cond,
+    crashesColumns.wthr_cond,
     crashesColumns.crash_speed_limit,
     crashesColumns.obj_struck,
     crashesColumns.law_enforcement_ytd_fatality_num,

--- a/editor/configs/crashesColumns.tsx
+++ b/editor/configs/crashesColumns.tsx
@@ -340,6 +340,19 @@ export const crashesColumns = {
       foreignKey: "wthr_cond_id",
     },
   },
+    surf_cond: {
+    path: "surf_cond.label",
+    label: "Surface condition",
+    editable: false,
+    inputType: "select",
+    relationship: {
+      tableSchema: "lookups",
+      tableName: "surf_cond",
+      idColumnName: "id",
+      labelColumnName: "label",
+      foreignKey: "surf_cond_id",
+    },
+  },
   agency: {
     path: "agency.label",
     label: "Investigating agency",

--- a/editor/configs/crashesColumns.tsx
+++ b/editor/configs/crashesColumns.tsx
@@ -327,6 +327,19 @@ export const crashesColumns = {
     editable: true,
     inputType: "number",
   },
+  wthr_cond: {
+    path: "wthr_cond.label",
+    label: "Weather condition",
+    editable: false,
+    inputType: "select",
+    relationship: {
+      tableSchema: "lookups",
+      tableName: "wthr_cond",
+      idColumnName: "id",
+      labelColumnName: "label",
+      foreignKey: "wthr_cond_id",
+    },
+  },
   agency: {
     path: "agency.label",
     label: "Investigating agency",

--- a/editor/queries/crash.ts
+++ b/editor/queries/crash.ts
@@ -34,6 +34,10 @@ export const GET_CRASH = gql`
         label
       }
       wthr_cond_id
+      wthr_cond {
+        id
+        label
+      }
       obj_struck {
         id
         label

--- a/editor/queries/crash.ts
+++ b/editor/queries/crash.ts
@@ -38,6 +38,11 @@ export const GET_CRASH = gql`
         id
         label
       }
+      surf_cond_id
+      surf_cond {
+        id
+        label
+      }
       obj_struck {
         id
         label

--- a/editor/types/crashes.ts
+++ b/editor/types/crashes.ts
@@ -76,6 +76,7 @@ export type Crash = {
   updated_at: string | null;
   updated_by: string | null;
   wthr_cond_id: number | null;
+  wthr_cond: LookupTableOption | null;
   change_logs: ChangeLogEntry[] | null;
   units: Unit[] | null;
   charges_cris: Charge[] | null;

--- a/editor/types/crashes.ts
+++ b/editor/types/crashes.ts
@@ -71,6 +71,8 @@ export type Crash = {
   rpt_hwy_sfx: string | null;
   rr_relat_fl: boolean | null;
   schl_bus_fl: boolean | null;
+  surf_cond_id: number | null;
+  surf_cond: LookupTableOption | null;
   toll_road_fl: boolean | null;
   traffic_cntl_id: number | null;
   updated_at: string | null;


### PR DESCRIPTION
## Associated issues

https://github.com/cityofaustin/atd-data-tech/issues/29247

## Testing

**URL to test:** 

locally

**Steps to test:**

spin up stack locally. Apply metadata

Visit a crash details page. On the details card see the two new fields, Weather condition and Surface condition. Confirm you can't edit. 

Now visit a fatality details page. See the same fields on that details card. Confirm you can't edit. 

---

#### Ship list

- [ ] Check migrations for any conflicts with latest migrations in `main` branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved
