### PR TITLE
Remove Access Management Crashes card from the dashboard page

### DIFF
--- a/editor/app/dashboard/page.tsx
+++ b/editor/app/dashboard/page.tsx
@@ -1,7 +1,11 @@
 "use client";
 import Row from "react-bootstrap/Row";
 import Col from "react-bootstrap/Col";
-import { FaMap, FaChartPie } from "react-icons/fa6";
+import {
+  LuMapPinned,
+  LuFileChartColumn,
+  LuPanelsTopLeft,
+} from "react-icons/lu";
 import DashboardLinkCard, {
   DashboardLinkCardProps,
 } from "@/components/DashboardLinkCard";
@@ -16,20 +20,20 @@ const dashboardLinks: DashboardLinkCardProps[] = [
     description:
       "Our public-facing dashboard with official Vision Zero statistics",
     href: "https://visionzero.austin.gov/viewer/",
-    icon: FaMap,
+    icon: LuPanelsTopLeft,
   },
   {
     title: "Crash Data by Location",
     description: "Based on Vision Zero location polygons",
     href: "https://experience.arcgis.com/experience/4d642c739efe472b8a86c11be5f1b1dc",
-    icon: FaMap,
+    icon: LuMapPinned,
   },
   {
     title: "Key Metrics",
     description:
       "Collection of internal dashboards enabling a wide range of crash analysis",
     href: "https://app.powerbigov.us/links/JznhTDu8kc?ctid=5c5e19f6-a6ab-4b45-b1d0-be4608a9a67f&pbi_source=linkShare",
-    icon: FaChartPie,
+    icon: LuFileChartColumn,
   },
 ];
 
@@ -54,7 +58,7 @@ export default function Dashboard() {
       <Row>
         <Col>
           <iframe
-            src={`${VZV_ENDPOINT}/measures`}
+            src={`https://visionzero.austin.gov/viewer/measures`}
             title="Vision Zero Viewer Stats"
             style={{
               width: "100%",
@@ -69,7 +73,7 @@ export default function Dashboard() {
       </Row>
       <Row>
         {dashboardLinks.map((item) => (
-          <Col md={6} key={item.href}>
+          <Col md={3} key={item.href} className="mb-2">
             <DashboardLinkCard {...item} />
           </Col>
         ))}

--- a/editor/app/dashboard/page.tsx
+++ b/editor/app/dashboard/page.tsx
@@ -31,12 +31,6 @@ const dashboardLinks: DashboardLinkCardProps[] = [
     href: "https://app.powerbigov.us/links/JznhTDu8kc?ctid=5c5e19f6-a6ab-4b45-b1d0-be4608a9a67f&pbi_source=linkShare",
     icon: FaChartPie,
   },
-  {
-    title: "Access Management Crashes",
-    description: "Summary of crashes for individual locations",
-    href: "https://austin.maps.arcgis.com/apps/instant/interactivelegend/index.html?appid=ea84226e6e5a4ecf998082b73b8c6cca",
-    icon: FaMap,
-  },
 ];
 
 export default function Dashboard() {

--- a/editor/app/dashboard/page.tsx
+++ b/editor/app/dashboard/page.tsx
@@ -58,7 +58,7 @@ export default function Dashboard() {
       <Row>
         <Col>
           <iframe
-            src={`https://visionzero.austin.gov/viewer/measures`}
+            src={`${VZV_ENDPOINT}/measures`}
             title="Vision Zero Viewer Stats"
             style={{
               width: "100%",

--- a/editor/components/DashboardLinkCard.tsx
+++ b/editor/components/DashboardLinkCard.tsx
@@ -20,10 +20,10 @@ export default function DashboardLinkCard({
   icon: Icon,
 }: DashboardLinkCardProps) {
   return (
-    <a href={href} style={{ textDecoration: "none" }}>
-      <Card className="my-2 dashboard-link-card">
-        <CardBody className="d-flex">
-          <div className="d-flex align-items-center me-4 py-3 px-3 bg-dark rounded fs-3 fw-bold text-white border">
+    <a href={href} className="d-block h-100" style={{ textDecoration: "none" }}>
+      <Card className="my-2 h-100 hover-shadow">
+        <CardBody className="d-flex align-items-center">
+          <div className="d-flex align-items-center me-4 py-3 px-3 bg-primary rounded fs-1 text-light fw-bold text-white border border-primary-subtle">
             <Icon />
           </div>
           <div className="d-flex flex-column">

--- a/editor/components/DashboardLinkCard.tsx
+++ b/editor/components/DashboardLinkCard.tsx
@@ -23,7 +23,7 @@ export default function DashboardLinkCard({
     <a href={href} className="d-block h-100" style={{ textDecoration: "none" }}>
       <Card className="my-2 h-100 hover-shadow">
         <CardBody className="d-flex align-items-center">
-          <div className="d-flex align-items-center me-4 py-3 px-3 bg-primary rounded fs-1 text-light fw-bold text-white border border-primary-subtle">
+          <div className="d-flex align-items-center me-4 py-3 px-3 bg-light-subtle rounded fs-1 fw-bold text-primary border border-primary-subtle">
             <Icon />
           </div>
           <div className="d-flex flex-column">

--- a/editor/styles/global.scss
+++ b/editor/styles/global.scss
@@ -294,7 +294,7 @@ h5.card-title {
   border: none !important;
 }
 
-.dashboard-link-card:hover {
+.hover-shadow:hover {
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
 }
 


### PR DESCRIPTION
## Associated issues

https://github.com/cityofaustin/atd-data-tech/issues/29242

## Testing

**URL to test:** <!-- VZ URL or Netlify -->

https://deploy-preview-2079--vze-staging.netlify.app/editor/dashboard

**Steps to test:**

Look at this dashboard. There once was 4 cards, but now there are only 3. 
<img width="814" height="300" alt="Screenshot 2026-07-08 at 1 15 12 PM" src="https://github.com/user-attachments/assets/cdf7e427-bb4c-4dfd-9e36-b22ebc7f0e54" />

---

#### Ship list

- [ ] Check migrations for any conflicts with latest migrations in `main` branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved
