### PR TITLE
Add crashes list filter toggle for minor injuries

### DIFF
--- a/editor/configs/crashesListViewTable.ts
+++ b/editor/configs/crashesListViewTable.ts
@@ -279,7 +279,7 @@ const crashesListViewfilterCards: FilterGroup[] = [
 ];
 
 export const crashesListViewQueryConfig: QueryConfig = {
-  _version: 1,
+  _version: 2,
   exportable: true,
   exportFilename: "crashes",
   tableName: "crashes_list_view",

--- a/editor/configs/crashesListViewTable.ts
+++ b/editor/configs/crashesListViewTable.ts
@@ -66,6 +66,20 @@ const crashesListViewfilterCards: FilterGroup[] = [
           },
         ],
       },
+      {
+        id: "suspected_minor_injury_crashes",
+        label: "Suspected minor injuries",
+        groupOperator: "_and",
+        enabled: false,
+        filters: [
+          {
+            id: "suspected_minor_injury_crashes",
+            column: "nonincap_injry_count",
+            operator: "_gt",
+            value: 0,
+          },
+        ],
+      },
     ],
   },
   {


### PR DESCRIPTION
## Associated issues

https://github.com/cityofaustin/atd-data-tech/issues/29135

## Testing

**URL to test:** <!-- VZ URL or Netlify -->

https://deploy-preview-2080--vze-staging.netlify.app/editor/crashes

**Steps to test:**

If you are testing with the deploy preview:
1. go to the crash list table settings and toggle on the "minor injuries" column to visible
2. Switch the date range to 5Y or a date range that includes at the latest June of 2025
3. open the drop down filters menu and toggle "Suspected Minor Injuries"
4. See results that all include at least one minor injury
5. change the date range back to YTD or 1Y and you wont see any records. 

If you test locally you wont have to switch the date ranges, our staging data is roughly a year old.

---

#### Ship list

- [ ] Check migrations for any conflicts with latest migrations in `main` branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved
