### PR TITLE
Crash-Project matching: Flat end caps for buffers

### DIFF
--- a/etl/moped_projects/env_template
+++ b/etl/moped_projects/env_template
@@ -1,7 +1,7 @@
 # Moped Hasura
-MOPED_HASURA_ADMIN_SECRET=
-MOPED_HASURA_ENDPOINT=
+MOPED_HASURA_ADMIN_SECRET=<Moped Hasura Admin Key - Staging>
+MOPED_HASURA_ENDPOINT=<Moped Hasura Admin Key - Staging>
 
 # Vision Zero Hasura
-VZ_HASURA_ADMIN_SECRET=hasurapassword
-VZ_HASURA_ENDPOINT=http://host.docker.internal:8084/v1/graphql
+VZ_HASURA_ADMIN_SECRET=<VZD - Staging - Hasura Admin key>
+VZ_HASURA_ENDPOINT=<VZD - Staging - Hasura Admin key>

--- a/etl/moped_projects/env_template
+++ b/etl/moped_projects/env_template
@@ -1,7 +1,7 @@
 # Moped Hasura
-MOPED_HASURA_ADMIN_SECRET=<Moped Hasura Admin Key - Staging>
-MOPED_HASURA_ENDPOINT=<Moped Hasura Admin Key - Staging>
+MOPED_HASURA_ADMIN_SECRET=<Moped Hasura Admin> (Admin Secret)
+MOPED_HASURA_ENDPOINT=<Moped Hasura Admin> (Endpoint)
 
 # Vision Zero Hasura
-VZ_HASURA_ADMIN_SECRET=<VZD - Staging - Hasura Admin key>
-VZ_HASURA_ENDPOINT=<VZD - Staging - Hasura Admin key>
+VZ_HASURA_ADMIN_SECRET=<Vision Zero ETLs> (Admin Secret)
+VZ_HASURA_ENDPOINT=<Vision Zero ETLs> (Endpoint)

--- a/etl/moped_projects/moped_project_components_spatial_join.py
+++ b/etl/moped_projects/moped_project_components_spatial_join.py
@@ -67,7 +67,14 @@ def buffer_geometries(row):
     if row.geometry.geom_type == "Point" or row.geometry.geom_type == "MultiPoint":
         return row.geometry.buffer(BUFFER_DISTANCE_POINTS)
     else:
-        return row.geometry.buffer(BUFFER_DISTANCE_LINES)
+        # Moped line geometry is always stored in a MultiLineString, even if it just has one Line feature.
+        # If we have one of these, use the flat caps for buffering
+        # see https://github.com/cityofaustin/atd-data-tech/issues/28126
+        if row.geometry.geom_type == "MultiLineString" and len(row.geometry.geoms) == 1:
+            return row.geometry.geoms[0].buffer(BUFFER_DISTANCE_LINES, cap_style="flat")
+        if row.geometry.geom_type in ("MultiLineString"):
+            return row.geometry.buffer(BUFFER_DISTANCE_LINES, cap_style="round")
+    raise ValueError(f"Unexpected geometry type: {row.geometry.geom_type}")
 
 
 def main():

--- a/etl/moped_projects/moped_project_components_spatial_join.py
+++ b/etl/moped_projects/moped_project_components_spatial_join.py
@@ -64,11 +64,16 @@ def chunk_list(lst, n):
 
 def buffer_geometries(row):
     """Applied to each moped component. Points are buffered to a distance of BUFFER_DISTANCE_POINTS and Lines to
-    BUFFER_DISTANCE_LINES"""
+    BUFFER_DISTANCE_LINES
+
+    Note that Moped stores linear projects as MultiLineStrings. Some of these lines are continuous and others are not.
+    To buffer correctly, we first line_merge which will combine all continuous lines.
+    Then, buffer each line separately and combine all polygon areas.
+    See Also: https://github.com/cityofaustin/atd-data-tech/issues/28126
+    """
     if row.geometry.geom_type == "Point" or row.geometry.geom_type == "MultiPoint":
         return row.geometry.buffer(BUFFER_DISTANCE_POINTS)
     elif row.geometry.geom_type == "MultiLineString":
-        # see https://github.com/cityofaustin/atd-data-tech/issues/28126
         merged = shapely.line_merge(row.geometry)
         if merged.geom_type == "LineString":
             line_parts = [merged]

--- a/etl/moped_projects/moped_project_components_spatial_join.py
+++ b/etl/moped_projects/moped_project_components_spatial_join.py
@@ -4,6 +4,7 @@ import os
 import logging
 
 from shapely.geometry import shape
+import shapely
 import geopandas as gpd
 
 from queries import query_vz, query_moped, truncate_query, publishing_query
@@ -66,14 +67,22 @@ def buffer_geometries(row):
     BUFFER_DISTANCE_LINES"""
     if row.geometry.geom_type == "Point" or row.geometry.geom_type == "MultiPoint":
         return row.geometry.buffer(BUFFER_DISTANCE_POINTS)
-    else:
-        # Moped line geometry is always stored in a MultiLineString, even if it just has one Line feature.
-        # If we have one of these, use the flat caps for buffering
+    elif row.geometry.geom_type == "MultiLineString":
         # see https://github.com/cityofaustin/atd-data-tech/issues/28126
-        if row.geometry.geom_type == "MultiLineString" and len(row.geometry.geoms) == 1:
-            return row.geometry.geoms[0].buffer(BUFFER_DISTANCE_LINES, cap_style="flat")
-        if row.geometry.geom_type in ("MultiLineString"):
-            return row.geometry.buffer(BUFFER_DISTANCE_LINES, cap_style="round")
+        merged = shapely.line_merge(row.geometry)
+        if merged.geom_type == "LineString":
+            line_parts = [merged]
+        elif merged.geom_type == "MultiLineString":
+            line_parts = list(merged.geoms)
+        else:
+            raise ValueError(f"Unexpected geometry type after line_merge: {merged.geom_type}")
+
+        buffered_parts = [
+        part.buffer(BUFFER_DISTANCE_LINES, cap_style="flat")
+            for part in line_parts
+        ]
+        return shapely.union_all(buffered_parts)
+
     raise ValueError(f"Unexpected geometry type: {row.geometry.geom_type}")
 
 

--- a/etl/moped_projects/moped_project_components_spatial_join.py
+++ b/etl/moped_projects/moped_project_components_spatial_join.py
@@ -126,7 +126,7 @@ def main():
     # Exporting results
     crashes_near_projects.reset_index(inplace=True)
     crashes_near_projects.rename(
-        columns={"id": "crash_pk", "index_right": "mopd_proj_component_id"},
+        columns={"id": "crash_pk", "project_component_id": "mopd_proj_component_id"},
         inplace=True,
     )
     crashes_near_projects = crashes_near_projects[

--- a/etl/moped_projects/requirements.txt
+++ b/etl/moped_projects/requirements.txt
@@ -1,4 +1,4 @@
 pandas==2.1.*
-geopandas==0.14.*
-shapely==2.0.*
 requests==2.31.*
+geopandas
+shapely

--- a/etl/moped_projects/requirements.txt
+++ b/etl/moped_projects/requirements.txt
@@ -1,4 +1,4 @@
-pandas==2.1.*
+pandas==3.0.*
 requests==2.31.*
-geopandas
+geopandas==1.1.*
 shapely


### PR DESCRIPTION
Changing the buffer for line geometry from a "round" end to a "flat" end. [See geopandas docs](https://geopandas.org/en/stable/docs/reference/api/geopandas.GeoSeries.buffer.html).

## Associated issues
[#28126](https://github.com/cityofaustin/atd-data-tech/issues/28126) - Adjust Moped crash intersection buffer to square off line ends

## Testing

**URL to test:** <!-- VZ URL or Netlify -->

**Steps to test:**

### Checking the results:
I have the results of one component's spatial join. Available [here](https://geojson.io/?data=gz:H4sIAAAAAAAAE-1dy44cx7H9l_aWEuL94NbAXd-9IAgEObTHIjnEaARbV-C_X5zuqewcGioyB17YZWpFNYNVlScj450Rv58efvt4c3p5-p-bVw-_3t_8-e7du5vXD7d3H04vTm8vv_1yevnD75_RnV6c_nJz9_7m4f6308vxl_979-63v5z_6eu7u_s3tx9ePZz_9Q8_fNf5fVp6lGm3kusLpe8ltL0Ev4ay_Phi0LmzlHtIbnQpJqFBnDrRGZloZPRGVu4cSaEzlZgZVVnGRtZpYl1qNdNRKnlx1oXMiIo8vcSmb6NiEtaMskcysXJxYu9BFSXC4lRR2ytJorGm-VnCEt1aVf5IFiUa3cVNdqXTaBNv4nh8p1q3u4tX1CCrjgrR9LYLbN6eTuUc1de3tnG4hns7P5IlS5xBIr0-rtWa1cj5cbe8K4uMHJBfybxdu0nkERDvxh64UKlfX1vUYq0UoRsmqS2tJS4TGYuSUkbSdRuCJKQ5rwCXqLmalj5uvSm1eFt7-HUNmUCSVYQfOclMLdKYrGceiZCsJjLiRzpmSrNqZY-JzsMi1CR1-7rq4qJm5plMkoxNaJCB9dlcaX6rclg3XTmzylysvVTn87B_bn788dOL08f7u4839w-3OHG_n24_vLn5x-nlh1_fvXtxen_38c1PH-_v_vbT67v3H-8-3Hx4-On2zfa3r-9f_fLXnz7-PKhf3f98c__d67t3d_ef_fbL7f_dbD_heTevHz57JLNzvTi9vX337vTy9Ke3b7u7T5cfvrv7-Or17cNvp5f0vb04_fJwf_fzzYWKiOi0_fTd32_fPPz19JI_fXrxtYLn9sPDP4mdje-SYtt8bTX-Q7Qko1X-GK_HxV0BMxKi_Byy05-wnLdvT5_hdnp_8-b21_enP8LugusFuuufr6hdfttgm_9vQwy__UtAi7bw7WRRhu1jViuYsfEhMSvijiGNstywJJJd6GyF3RR6wA4IXUK9xxmuTfy6WtY-dLYEnXHVAaFrCXYrz65N53tAR2cG5T6AvgBgOxTyAfFTqotZMmymbik1k31FYbmAHrdTHxM-PttmtaEXrOat8gU1aysqg0Va5IjoWQSHk2-Wc7FWl1Boxy5-riv4ETXTEfGTJiNlq9jYjySyPClb9wFcEX7s8COOCKAKcxpr-gaguniW1z58ESvwVUnoEeEzS1JyiuFIp5UbC9G-8RJr2iPSDin_VDWVTcSu7Gdumdq0z4BJSwIQ-vyQAEohVCE69O85eqLc_AX8Vqxn7lThA-IXzWFbcIDDuBCv6PJ97NaEXyof0d-NbN-gIzWVC3T7Pkf2itPWkXVEtfusUEGtSDwT0TpiqKDIdETzEE7fx4zXMEs9JmbPYbclDy2N2Y8JXbgNfssvaIZaEW9IupxVyQFBW-e3XjmqoWLHRC6KR65CYj8I0CvB49Q8ogX3PF5bcf6V2Y5phCTrNS_2BVZbMnk99ZDB9qLsayoxyC-8tu9p9ZKr72n5zQbZoFuyQTzDv4m4M3RJtBQfqZRDJhafB92KWuW2C9bHg07UYkDX8ejf70O3kpboND-iEReFupCWEJdRIuZOHkBgT88m8ZLEK-JD5sWedWxlxYHQ1ktw4GjQJenmQIjvxeKSZMkKDuQmDwhYVOow6kSp-yt4TVd4jTXpkNmHZx1TXfEkrLyPqVzZO4RpaAgrqbIK2QswPfLRQtUJ8xHP7LMYb6lgB2VVB2W8deR8Jaop5G1H1KzRxBzq4aNEPB0JRFSY7-IXK4cWFcV1RG2RzZ1tplsRu1mHRrA77xbr4DrHCoBeSUdkwFZnI1Wo0MdSRU5WtUaubx_ApbwEmx6SA9v48bqIt1fyJXzH-8JvrdBEqY7o0rZSpsJWHnViYlko2t6vVEzKJVPZEU45IIDZyOZsci_SvgDakpFM7IesMHmWsbKUghUyP6Sd14Lba-NGAH8hbrcUaDeyyCOWc4LfLC88duU624-i9BK_qbMckd-KrnV02riCe1atu1KOl6LFonapmj0edIrY5VZiwrHrTDAtXXsiaT-iKYe6nLxmJzLynJ3ofehWpJxKHzQTy1k0TBGx3I04Ma8cUqiGOmYdmF0z_5XyFUFiXsrl4Cr_QbPXyzUTedGRX3-jmFmPyXTr9u8lIfjVQs5CDhkreR50S_aISdMxrWAh8it0u5f_k2VJyiXnIS_SPeMGe7KuSDkpDT6oKbd-VHXNyy-VQ7oOLGhY8mjKMfm-VrW1UKbHYRku2K6-w779a0vxS2KSI8o3HFKfgyL9NQ7-WrbaEGc-KHbLAm6pu4mUJx8Uuq-_fpPsKyl-aYtDtjR5li3iS2acOccxw5jPOKqxZMYFWgB-g-4RuhWPSwnq9YDQZZtEomeO2EgRCoucuxfuph84lvqYKGpWvvn7j9gt9UAwMtNv0G3QLSWomeqQlw9b0Ph0q4gI7f3UzdJtdC6LOqK0Q88SrRah0bPkMfOa2fuxplorpFM9pH2HbnWNupscrEe4y9ntuZ8AqzWn4tw194j4ORqvgd-2tmshIoH6f9pnwKWLw0Iuh2yKALFnIdKl1xNsWkbo6LwHoCzdrZO0ikOmYJ-hcoWXEv8WnEfkvedBt3TTybP5iNbK86BbCako2px-O7AbdCs5CuPM-M-NHO8PfsD0AtXC_bpRP1xo_F9UrNNkAnG05iSviardm4uniQNmxZ7Mfm37WRhCoGVT7_82tBtr3Fvc5hygbWBQs02TBNqarArlzdu34cJBZVqYTWMOmEiczWuQcZoSJkTM0xBgNlG48iBTomLH2IRpCIPbOYQe0psRkmYiJIZFT3QOFyNNr8Ma8GZiyZzJEn2McaFskGUYuBbDLiY6TCFIx4X_jQ5V8U6UzvNMBz3DbLbVyxdLaqGOOadVBJFLpGRsjyuF3S1C7DrTuVq4iA-Ty7lUjdCueqbLpjSn2pZRyW1IfWb7TFdcVpYbo1QLlylmZNhMFpyBkRXbMppxq90ZRsxMx02kObootooYRZhL_GdMuihB029XmVJbUsWpGkjhT3Qm2SRWI51jBdTVimcyT_RxLhuliVFdqWrVT57Wjns916_DVkio9HSyS4wrLJ23wgKjFjgkxRHzWjE5QzGKZRSoFQ5at_hEJoWd9OtgB4gEkQwLyYmOsYJ24w1hi3AjpY5pI4QyVF2zxs2kMjJc3MoJObR64Ay9Ps2JDMdWS2e6rEBHTtZtsc4eaC55Lia-0gV-ZiYZz5Nz_TEaCMx0pmRK7LVh7AjjNVNk1RN-EmHLGNUb7ogptsu8FUxop62lQ6F5sKKijb2mZVCReUqXxKCDiNGqmdc9W8JREr5RpYYw_jlNW0aYJoOucmMiimdUEWNEy_R1uGPnaCc5Pi6LwxlC68oo2VXqBPaQQQeBLS7a0-ScDhf09WsZmKRlGUTUNK8FmscS1DbIcKuCI7gnMiG02vcca8VIolY0srhSFe56VKiO1DxG9Qif7xxNU10qmyF3o8a3mVM0OvP7RBZnrvOIwSaq4qRuNh3sLASRM8pHV06U_WdmePJMBzJFHmJwsROaQZnSNDmnWILhE8f1ijJ4JMncphk2RdgtkrERhuPqXhHzHJ5GiCLVY0S4XUOKwr2mxf5XzOs5zpwrmFOVSoZOLlvXiTrbT5E0P-0crkIYeHSniGToooj5cZwhgulZ2_EXDL8Cm9Ck7KLbWsFnY_slS7FgjcnciU4uvUys2uiKKWGwVM3Ps3L4fW0TXTEnWrnMzxOXiOwYbCxFHmRooT4_j0ScGQ1Kx_clVAwO0DQlLGHKnS-HDTJhNPsmm2zPKIdKaaIhKSScKTxlYs-ASGeHXhnoeSDOCjaTiY4TkRrrUQaO_jTtbk_Gk0V2QRtXDZNCFP-dz8pEVoye3ZZD3kHWuRD6qU5kEYR1-RgsJISgkYtNcgfmFHqCy1CeDJTOR2ear5Z2Fv48VDHkUiWR87wPqYRQH4TMRne21kwzfAI4BY3IKyO28w-NaKpF-WQNsETgK9RoGs2KnQ7kOGY6Q9tn5PC2M9bKDVsrn7yXwV-wPjeEKaXxNVQ57wS7RQWbDvmECS9QtNEx0zWDZWU0gSGVhAENFTKv11nTYtxzOsvcUqA_fx72mr15409tpColIL5nOlOokKItf6mdQUWawk-21tNKjSepWB7e_nQR0ZVmbZsdo22SfhYf80uhiQke0iCTbE3xmFVPFKnAhuZN9GhDrreFTgbKv_PEvmrYNpChOg350SBlodkYg1VUiFTQoIPPBiaejCJocXyQMo0bgsLB6D0akxMISV9YCY_75uQt5DF7Ck1IXHOXDifLmt2rFNWJE52TZsPyHnRZEZo9H9kmCG0PmNUbWaSisT3Pjiw1iTquhG1rgAXoWIjN0wkZ8y0gBIbPZtYNi3pWKOdBhwIL9boIaPBSbZ2f5lEpRZvJ7g2qs-rhJ48rorNdHTHoEi6qhOrkUcJXhskmeX1eFpSR6aTaWyQcXGE9vTfPB7Ongwi_E4PbmqZVYKQCccT8WsgxcBX5FRTTLqWoma4xcuzsBlxBhoFemHkxTYpkbUjoMB57Ft4M9TRxCnRH48TLeFwmZj3g-ExkzgbBTeMCK5jHPaV4OoutAfeByUbwwcnQpYqpZhbQElz2TxrpChcypgb_TOBBHDUa2QuP05OM2JLmJHjaKBofQz7OhTshPFQ6o2cMyeax-Ys43BpZWbAG56iXFFmwjTEi3kqiWmkyx7POYSBD9HGLZ8F6hMJ8Stbw3HyzPXB0kKfmgsR_SldNunWB9Q5XkfNdJ3vyVvhpvRUae0MtpKH3xJO37kX4_n0nVHa_fn2Or77dm1A5orBPg6T86dOPn_4fGK19A0R3AAA).

The blue polygon represents the old rounded ends buffer. The red polygon (appears purple) is the new flat-ended buffer. The blue points are the crashes that are **no longer** included with the changes included in this PR.

Check that:
1. The buffer looks how you should expect it to compare it to the component geometry in [moped](https://mobility.austin.gov/moped/projects/307?tab=map&project_component_id=11518).
2. There are no points inside of the red polygon

If you would like me to test another component let me know.

### Running the code:
1. `docker build . -t atddocker/vz-moped-join:local`
4. While this is building fill out the `env_template` (I used staging, I don't think it matters which?)
5. `docker run -it --rm --env-file env_file atddocker/vz-moped-join python moped_project_components_spatial_join.py`
6. Check that it completes.

---

#### Ship list

- [ ] Check migrations for any conflicts with latest migrations in `main` branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved
