### PR TITLE
Add “Risk factors” to Crash UI

### DIFF
--- a/editor/app/fatalities/[record_locator]/page.tsx
+++ b/editor/app/fatalities/[record_locator]/page.tsx
@@ -141,6 +141,14 @@ export default function FatalCrashDetailsPage({
                   </tr>
                   <tr>
                     <td style={{ textWrap: "nowrap" }} className="fw-bold">
+                      Risk factors
+                    </td>
+                    <td>
+                      {crashesColumns.risk_factors.valueRenderer(crash)}
+                    </td>
+                  </tr>
+                  <tr>
+                    <td style={{ textWrap: "nowrap" }} className="fw-bold">
                       Roadway owner
                     </td>
                     <td>

--- a/editor/configs/crashDataCard.ts
+++ b/editor/configs/crashDataCard.ts
@@ -5,6 +5,7 @@ export const crashDataCards = {
     crashesColumns.case_id,
     crashesColumns.crash_timestamp,
     crashesColumns.collsn,
+    crashesColumns.risk_factors,
     crashesColumns.city,
     crashesColumns.agency,
   ],
@@ -27,6 +28,5 @@ export const crashDataCards = {
     crashesColumns.crash_speed_limit,
     crashesColumns.obj_struck,
     crashesColumns.law_enforcement_ytd_fatality_num,
-    crashesColumns.risk_factors,
   ],
 };

--- a/editor/configs/crashDataCard.ts
+++ b/editor/configs/crashDataCard.ts
@@ -27,5 +27,6 @@ export const crashDataCards = {
     crashesColumns.crash_speed_limit,
     crashesColumns.obj_struck,
     crashesColumns.law_enforcement_ytd_fatality_num,
+    crashesColumns.risk_factors,
   ],
 };

--- a/editor/configs/crashesColumns.tsx
+++ b/editor/configs/crashesColumns.tsx
@@ -371,4 +371,22 @@ export const crashesColumns = {
     editable: false,
     inputType: "yes_no",
   },
+  risk_factors: {
+    path: "crash_risk_factors_view.risk_factors",
+    label: "Risk factors",
+    editable: false,
+    valueRenderer: (record: Crash) => {
+      const factors = record.crash_risk_factors_view?.risk_factors;
+      if (!factors?.length) {
+        return null;
+      }
+      return (
+        <>
+          {factors.map((factor) => (
+            <div key={factor}>{factor}</div>
+          ))}
+        </>
+      );
+    },
+  },
 } satisfies Record<string, ColDataCardDef<Crash>>;

--- a/editor/configs/crashesColumns.tsx
+++ b/editor/configs/crashesColumns.tsx
@@ -340,7 +340,7 @@ export const crashesColumns = {
       foreignKey: "wthr_cond_id",
     },
   },
-    surf_cond: {
+  surf_cond: {
     path: "surf_cond.label",
     label: "Surface condition",
     editable: false,
@@ -378,7 +378,7 @@ export const crashesColumns = {
     valueRenderer: (record: Crash) => {
       const factors = record.crash_risk_factors_view?.risk_factors;
       if (!factors?.length) {
-        return null;
+        return "None identified";
       }
       return (
         <>

--- a/editor/queries/crash.ts
+++ b/editor/queries/crash.ts
@@ -108,6 +108,9 @@ export const GET_CRASH = gql`
       is_temp_record
       in_austin_full_purpose
       diagram_transform
+      crash_risk_factors_view {
+        risk_factors
+      }
       crash_injury_metrics_view {
         vz_fatality_count
         sus_serious_injry_count

--- a/editor/types/crashRiskFactors.ts
+++ b/editor/types/crashRiskFactors.ts
@@ -1,0 +1,8 @@
+/**
+ * Type which describes the crash_risk_factors_view database view
+ * which has an object relationship to crashes
+ */
+export type CrashRiskFactors = {
+  id?: number;
+  risk_factors?: string[] | null;
+};

--- a/editor/types/crashes.ts
+++ b/editor/types/crashes.ts
@@ -10,11 +10,13 @@ import { CrashNote } from "./crashNote";
 import { EMSPatientCareRecord } from "@/types/ems";
 import { CrashDiagramOrientation } from "./crashDiagramOrientation";
 import { UnitTypesInvolved } from "@/types/unitTypesInvolved";
+import { CrashRiskFactors } from "@/types/crashRiskFactors";
 
 export type Crash = {
   active_school_zone_fl: boolean | null;
   at_intrsct_fl: boolean | null;
   case_id: string | null;
+  crash_risk_factors_view: CrashRiskFactors | null;
   crash_injury_metrics_view: CrashInjuryMetric | null;
   crash_notes: CrashNote[];
   cr3_stored_fl: boolean | null;


### PR DESCRIPTION
## Associated issues
Closes https://github.com/cityofaustin/atd-data-tech/issues/29181

Built from the backend changes in this PR:
https://github.com/cityofaustin/vision-zero/pull/2086

## Testing

**URL to test:** <!-- VZ URL or Netlify -->
Local

**Steps to test:**
1. Spin up local instance with migration and metadata updates `hasura migrate apply && hasura metadata apply`
2. Start the /editor
3. Go to any crash page and note the new **Details** -> **Risk factors**. 
    - Here's an example with multiple lines: http://localhost:3002/editor/crashes/11155009
    - Here's one with null: http://localhost:3002/editor/crashes/11163904
    - 
<img width="613" height="401" alt="Screenshot 2026-07-16 at 11 32 58 PM" src="https://github.com/user-attachments/assets/a0e2494c-7a5a-427d-980f-94755bc4e8f3" />

---

#### Ship list

- [ ] Check migrations for any conflicts with latest migrations in `main` branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved
