### PR TITLE
Add Risk Factors to Fatality details pages

### DIFF
--- a/editor/app/fatalities/[record_locator]/page.tsx
+++ b/editor/app/fatalities/[record_locator]/page.tsx
@@ -141,6 +141,14 @@ export default function FatalCrashDetailsPage({
                   </tr>
                   <tr>
                     <td style={{ textWrap: "nowrap" }} className="fw-bold">
+                      Risk factors
+                    </td>
+                    <td>
+                      {crashesColumns.risk_factors.valueRenderer(crash)}
+                    </td>
+                  </tr>
+                  <tr>
+                    <td style={{ textWrap: "nowrap" }} className="fw-bold">
                       Roadway owner
                     </td>
                     <td>


### PR DESCRIPTION
## Associated issues
Closes https://github.com/cityofaustin/atd-data-tech/issues/29490

## Testing

**URL to test:** <!-- VZ URL or Netlify -->
Local because of upstream migration

**Steps to test:**
1. Spin up a local instance with migration and metadata updates `hasura migrate apply && hasura metadata apply`
2. Start the /editor
3. Go to any fatality page and note the **Risk factors** in the first summary card

<img width="534" height="411" alt="Screenshot 2026-07-23 at 9 56 43 AM" src="https://github.com/user-attachments/assets/033084c8-550e-43ab-aa17-30aa2ba9440b" />


---

#### Ship list

- [ ] Check migrations for any conflicts with latest migrations in `main` branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved
