### PR TITLE
Bump graphql-engine to v2.50.0

### DIFF
--- a/docker-compose-github-actions.yml
+++ b/docker-compose-github-actions.yml
@@ -1,6 +1,6 @@
 services:
   graphql-engine:
-    image: hasura/graphql-engine:v2.49.5
+    image: hasura/graphql-engine:v2.50.0
     volumes:
       - ./viewer/graphql-engine-metadata:/metadata
     container_name: visionzero-graphql-engine

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   graphql-engine:
-    image: hasura/graphql-engine:v2.49.5
+    image: hasura/graphql-engine:v2.50.0
     volumes:
       - ./viewer/graphql-engine-metadata:/metadata
     ports:


### PR DESCRIPTION
## Associated issues

https://github.com/cityofaustin/atd-data-tech/issues/29496

## Note

I'm filling in for @roseeichelmann for a few of the launch party tasks, and she said she normally would check out the RC and push this version bump directly onto it. I'm making a PR that we can rebase onto the RC when it's ready so I can ask to double check the changes before they hit the RC.

## Testing

* You can spin up the local stack or simply look at the diff.

---

#### Ship list

- [ ] Check migrations for any conflicts with latest migrations in `main` branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved
